### PR TITLE
Fix issue with BtcReleaseClientStorageSynchronizer

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -255,8 +255,10 @@ public class BtcReleaseClient {
             // TODO: Sorting and then looping again is not efficient but we are making a compromise on performance here as we don't have that many release txs
             // Sort descending
             releasesReadyToSign.sort((a, b) -> (int) (b.getBlock().getNumber() - a.getBlock().getNumber()));
-            // Sign
-            releasesReadyToSign.forEach(release -> signRelease(version, release));
+            // Sign only the first element
+            if (releasesReadyToSign.size() > 0) {
+                signRelease(version, releasesReadyToSign.get(0));
+            }
         } catch (Exception e) {
             logger.error("[processReleases] There was an error trying to process releases", e);
         }

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageAccessor.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageAccessor.java
@@ -37,6 +37,9 @@ public class BtcReleaseClientStorageAccessor {
         this(
             systemProperties,
             Executors.newSingleThreadScheduledExecutor(),
+            new BtcReleaseClientFileStorageImpl(
+                new BtcReleaseClientFileStorageInfo(systemProperties)
+            ),
             DEFAULT_DELAY_IN_MS,
             DEFAULT_MAX_DELAYS
         );
@@ -45,14 +48,12 @@ public class BtcReleaseClientStorageAccessor {
     public BtcReleaseClientStorageAccessor(
         FedNodeSystemProperties systemProperties,
         ScheduledExecutorService executorService,
+        BtcReleaseClientFileStorage btcReleaseClientFileStorage,
         int delaysInMs,
         int maxDelays
     ) throws InvalidStorageFileException {
 
-        this.btcReleaseClientFileStorage =
-            new BtcReleaseClientFileStorageImpl(
-                new BtcReleaseClientFileStorageInfo(systemProperties)
-            );
+        this.btcReleaseClientFileStorage = btcReleaseClientFileStorage;
         this.delayInMs = delaysInMs;
         this.maxDelays = maxDelays;
 

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizer.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizer.java
@@ -143,7 +143,6 @@ public class BtcReleaseClientStorageSynchronizer {
                 logger.trace("[sync] going to fetch block {}({})", blockToSearch.getNumber(), blockToSearch.getHash());
                 List<TransactionReceipt> receipts = new ArrayList<>();
                 for(Transaction transaction: blockToSearch.getTransactionsList()) {
-                    logger.trace("[sync] fetching tx {}", transaction.getHash());
                     TransactionReceipt receipt = receiptStore
                         .getInMainChain(transaction.getHash().getBytes(), blockStore)
                         .orElseThrow(NullPointerException::new)
@@ -173,8 +172,7 @@ public class BtcReleaseClientStorageSynchronizer {
                 .stream()
                 .filter(info -> RELEASE_REQUESTED_TOPIC.equals(info.getTopics().get(0)))
                 .collect(Collectors.toList());
-            if (matches.size() == 1) {
-                LogInfo match = matches.get(0);
+            for (LogInfo match: matches) {
                 Keccak256 rskTxHash = receipt.getTransaction().getHash();
                 co.rsk.bitcoinj.core.Sha256Hash btcTxHash = co.rsk.bitcoinj.core.Sha256Hash.wrap(match.getTopics().get(2).getData());
                 logger.debug(

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizer.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizer.java
@@ -143,7 +143,11 @@ public class BtcReleaseClientStorageSynchronizer {
                 logger.trace("[sync] going to fetch block {}({})", blockToSearch.getNumber(), blockToSearch.getHash());
                 List<TransactionReceipt> receipts = new ArrayList<>();
                 for(Transaction transaction: blockToSearch.getTransactionsList()) {
-                    TransactionReceipt receipt = receiptStore.getInMainChain(transaction.getHash().getBytes(), blockStore).orElseThrow(NullPointerException::new).getReceipt();
+                    logger.trace("[sync] fetching tx {}", transaction.getHash());
+                    TransactionReceipt receipt = receiptStore
+                        .getInMainChain(transaction.getHash().getBytes(), blockStore)
+                        .orElseThrow(NullPointerException::new)
+                        .getReceipt();
                     receipt.setTransaction(transaction);
                     receipts.add(receipt);
                 }

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -261,7 +261,7 @@ public class BtcReleaseClientTest {
     }
 
     @Test
-    public void onBestBlock_catch_exception_add_signature() throws Exception {
+    public void having_two_pegouts_signs_only_one() throws Exception {
         // Arrange
         Federation federation = TestUtils.createFederation(params, 1);
         BtcTransaction tx1 = TestUtils.createBtcTransaction(params, federation);
@@ -361,7 +361,7 @@ public class BtcReleaseClientTest {
         ethereumListener.get().onBestBlock(null, Collections.emptyList());
 
         // Assert
-        Mockito.verify(federatorSupport, Mockito.times(2)).addSignature(ArgumentMatchers.anyListOf(byte[].class), ArgumentMatchers
+        Mockito.verify(federatorSupport, Mockito.times(1)).addSignature(ArgumentMatchers.anyListOf(byte[].class), ArgumentMatchers
             .any(byte[].class));
     }
 


### PR DESCRIPTION
- The Syncronizer should accept as many release_requested events from a single rsk tx hash as possible.
- Improve btcReleaseClient performance
- Add fix and test to cover issue