### PR TITLE
Add note for deprecated storage accessor logic

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientException.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientException.java
@@ -1,5 +1,12 @@
 package co.rsk.federate.btcreleaseclient;
 
+@Deprecated
+/***
+ * Due to FIT regression compatibility tests, this legacy code cannot be removed even when it is no longer needed.
+ * In case we remove it, when running FIT before fingerroot is activated, the federate node won’t be able to sign any peg-out,
+ * because the peg-out creation index won't be enabled at that time either, so, it won't be possible for the powpeg node to
+ * validate any peg-out.
+ */
 public class BtcReleaseClientException extends Exception {
 
     public BtcReleaseClientException(String message, Exception e) {

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageAccessor.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageAccessor.java
@@ -18,6 +18,13 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated()
+/***
+ * Due to FIT regression compatibility tests, this legacy code cannot be removed even when it is no longer needed.
+ * In case we remove it, when running FIT before fingerroot is activated, the federate node won’t be able to sign any peg-out,
+ * because the peg-out creation index won't be enabled at that time either, so, it won't be possible for the powpeg node to
+ * validate any peg-out.
+ */
 public class BtcReleaseClientStorageAccessor {
     private static final Logger logger = LoggerFactory.getLogger(BtcReleaseClientStorageAccessor.class);
 

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizer.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizer.java
@@ -20,6 +20,13 @@ import org.ethereum.vm.LogInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated
+/***
+ * Due to FIT regression compatibility tests, this legacy code cannot be removed even when it is no longer needed.
+ * In case we remove it, when running FIT before fingerroot is activated, the federate node won’t be able to sign any peg-out,
+ * because the peg-out creation index won't be enabled at that time either, so, it won't be possible for the powpeg node to
+ * validate any peg-out.
+ */
 public class BtcReleaseClientStorageSynchronizer {
     private static final Logger logger = LoggerFactory.getLogger(BtcReleaseClientStorageSynchronizer.class);
 

--- a/src/main/java/co/rsk/federate/btcreleaseclient/InvalidStorageFileException.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/InvalidStorageFileException.java
@@ -1,5 +1,12 @@
 package co.rsk.federate.btcreleaseclient;
 
+@Deprecated
+/***
+ * Due to FIT regression compatibility tests, this legacy code cannot be removed even when it is no longer needed.
+ * In case we remove it, when running FIT before fingerroot is activated, the federate node won’t be able to sign any peg-out,
+ * because the peg-out creation index won't be enabled at that time either, so, it won't be possible for the powpeg node to
+ * validate any peg-out.
+ */
 public class InvalidStorageFileException extends BtcReleaseClientException {
 
     public InvalidStorageFileException(String message, Exception e) {


### PR DESCRIPTION
Add useful note on storage accessor legacy classes explaining why this legacy code cannot be removed at this moment. **