### PR TITLE
Get rid of BtcReleaseClient.removeSignaturesFromTransaction local method

### DIFF
--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -54,6 +54,7 @@ import co.rsk.federate.signing.hsm.requirements.ReleaseRequirementsEnforcer;
 import co.rsk.federate.signing.hsm.requirements.ReleaseRequirementsEnforcerException;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.net.NodeBlockProcessor;
+import co.rsk.peg.BridgeUtils;
 import co.rsk.peg.ErpFederation;
 import co.rsk.peg.Federation;
 import co.rsk.peg.FederationMember;
@@ -762,7 +763,7 @@ public class BtcReleaseClientTest {
         Sha256Hash signedTxHash = releaseTx.getHash();
 
         // Act
-        client.removeSignaturesFromTransaction(releaseTx, federation);
+        BridgeUtils.removeSignaturesFromTransaction(releaseTx, federation);
         Sha256Hash removedSignaturesTxHash = releaseTx.getHash();
 
         // Assert


### PR DESCRIPTION
Get rid of BtcReleaseClient.removeSignaturesFromTransaction local method, to use instead the one at BridgeUtils class from the rskj project