### PR TITLE
Used 'compressed' header encoding for hsm messages' payload

### DIFF
--- a/src/main/java/co/rsk/federate/signing/hsm/message/ParsedHeader.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ParsedHeader.java
@@ -27,7 +27,7 @@ public class ParsedHeader {
     }
 
     private String serializeBlockHeader(BlockHeader blockHeader) {
-        return Hex.toHexString(blockHeader.getFullEncoded());
+        return Hex.toHexString(blockHeader.getEncoded(true, true, true));
     }
 
     private String[] serializeBrothers(List<BlockHeader> brothers) {

--- a/src/main/java/co/rsk/federate/signing/hsm/message/UpdateAncestorBlockMessage.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/UpdateAncestorBlockMessage.java
@@ -17,7 +17,7 @@ public class UpdateAncestorBlockMessage {
     }
 
     private String parseBlockHeader(BlockHeader blockHeader) {
-        return Hex.toHexString(blockHeader.getEncoded(true, false));
+        return Hex.toHexString(blockHeader.getEncoded(true, false, true));
     }
 
     public List<String> getData() {

--- a/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/HsmBookkeepingClientImplTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/HsmBookkeepingClientImplTest.java
@@ -293,14 +293,14 @@ class HsmBookkeepingClientImplTest {
 
             for (int j = 0; j < blocksInRequest.size() - 1; j++) {
                 assertEquals(
-                    Hex.toHexString(Objects.requireNonNull(blockHeadersInOriginalOrder.poll()).getFullEncoded()),
+                    Hex.toHexString(Objects.requireNonNull(blockHeadersInOriginalOrder.poll()).getEncoded(true, false, true)),
                     blocksInRequest.get(j).asText()
                 );
             }
 
             // The last element asserted should not be removed from the queue since it will be the first element in the next chunk
             assertEquals(
-                Hex.toHexString(Objects.requireNonNull(blockHeadersInOriginalOrder.peek()).getFullEncoded()),
+                Hex.toHexString(Objects.requireNonNull(blockHeadersInOriginalOrder.peek()).getEncoded(true, false, true)),
                 blocksInRequest.get(blocksInRequest.size() - 1).asText()
             );
         }
@@ -411,7 +411,7 @@ class HsmBookkeepingClientImplTest {
             // Headers should have been parsed in the reverse order
             for (int j = 0; j < blocksInRequest.size(); j++) {
                 assertEquals(
-                    Hex.toHexString(blockHeadersInverted.pop().getFullEncoded()),
+                    Hex.toHexString(blockHeadersInverted.pop().getEncoded(true, true, true)),
                     blocksInRequest.get(j).asText()
                 );
             }
@@ -437,7 +437,7 @@ class HsmBookkeepingClientImplTest {
 
             for (BlockHeader brother : blockBrothers) {
                 byte[] brotherFromPayload = Hex.decode(brothersPayload.next().asText());
-                assertArrayEquals(brother.getFullEncoded(), brotherFromPayload);
+                assertArrayEquals(brother.getEncoded(true, true, true), brotherFromPayload);
             }
             assertFalse(brothersPayload.hasNext()); // No more brothers
         }

--- a/src/test/java/co/rsk/federate/signing/hsm/message/AdvanceBlockchainMessageTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/AdvanceBlockchainMessageTest.java
@@ -48,7 +48,7 @@ class AdvanceBlockchainMessageTest {
             // Headers should have been parsed in the reverse order
             int blockIndex = blocks.size() - 1 - i;
             assertEquals(
-                Hex.toHexString(blocks.get(blockIndex).getHeader().getFullEncoded()),
+                Hex.toHexString(blocks.get(blockIndex).getHeader().getEncoded(true, true, true)),
                 parsedBlockHeaders.get(i)
             );
         }
@@ -63,7 +63,7 @@ class AdvanceBlockchainMessageTest {
             // Headers should have been parsed in the reverse order
             int blockIndex = blocks.size() - 1 - i;
             assertEquals(
-                Hex.toHexString(blocks.get(blockIndex).getHeader().getFullEncoded()),
+                Hex.toHexString(blocks.get(blockIndex).getHeader().getEncoded(true, true, true)),
                 parsedBlockHeaders.get(i)
             );
 
@@ -76,7 +76,7 @@ class AdvanceBlockchainMessageTest {
 
             for (int j = 0; j < parsedBrothers.length; j++) {
                 assertEquals(
-                    Hex.toHexString(expectedBrothers.get(j).getFullEncoded()),
+                    Hex.toHexString(expectedBrothers.get(j).getEncoded(true, true, true)),
                     parsedBrothers[j]
                 );
             }
@@ -90,7 +90,7 @@ class AdvanceBlockchainMessageTest {
 
         assertThrows(
             HSMBlockchainBookkeepingRelatedException.class,
-            () -> message.getParsedBrothers(Hex.toHexString(invalidBlockHeader.getFullEncoded()))
+            () -> message.getParsedBrothers(Hex.toHexString(invalidBlockHeader.getEncoded(true, true, true)))
         );
     }
 
@@ -107,7 +107,7 @@ class AdvanceBlockchainMessageTest {
             // Headers should have been parsed in the reverse order
             int blockIndex = blocksWithMultipleBrothers.size() - 1 - i;
             assertEquals(
-                Hex.toHexString(blocksWithMultipleBrothers.get(blockIndex).getHeader().getFullEncoded()),
+                Hex.toHexString(blocksWithMultipleBrothers.get(blockIndex).getHeader().getEncoded(true, true, true)),
                 parsedBlockHeaders.get(i)
             );
 
@@ -119,7 +119,7 @@ class AdvanceBlockchainMessageTest {
 
             for (int j = 0; j < parsedBrothers.length; j++) {
                 assertEquals(
-                    Hex.toHexString(expectedBrothers.get(j).getFullEncoded()),
+                    Hex.toHexString(expectedBrothers.get(j).getEncoded(true, true, true)),
                     parsedBrothers[j]
                 );
             }

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ParsedHeaderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ParsedHeaderTest.java
@@ -39,7 +39,7 @@ class ParsedHeaderTest {
 
     @Test
     void getBlockHeader() {
-        String serializedHeader = Hex.toHexString(blockHeader.getFullEncoded());
+        String serializedHeader = Hex.toHexString(blockHeader.getEncoded(true, true, true));
         assertEquals(serializedHeader, parsedHeader.getBlockHeader());
     }
 
@@ -50,7 +50,7 @@ class ParsedHeaderTest {
 
         brothers.sort(Comparator.comparing(BlockHeader::getHash));
         for (int i = 0; i < actualBrothers.length; i++) {
-            assertEquals(Hex.toHexString(brothers.get(i).getFullEncoded()), actualBrothers[i]);
+            assertEquals(Hex.toHexString(brothers.get(i).getEncoded(true, true, true)), actualBrothers[i]);
         }
     }
 

--- a/src/test/java/co/rsk/federate/signing/hsm/requirements/AncestorBlockUpdaterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/requirements/AncestorBlockUpdaterTest.java
@@ -59,7 +59,7 @@ class AncestorBlockUpdaterTest {
         Block targetBlock = mock(Block.class);
         when(targetBlock.getHash()).thenReturn(targetBlockHash);
         BlockHeader blockHeader = mock(BlockHeader.class);
-        when(blockHeader.getEncoded(true, false)).thenReturn(TestUtils.createHash(2).getBytes());
+        when(blockHeader.getEncoded(true, false, true)).thenReturn(TestUtils.createHash(2).getBytes());
         when(targetBlock.getHeader()).thenReturn(blockHeader);
 
         Keccak256 initialAncestorBlockHash = TestUtils.createHash(1);
@@ -69,7 +69,7 @@ class AncestorBlockUpdaterTest {
         // Ancestor is just one block ahead of the target block
         when(initialAncestorBlock.getParentHash()).thenReturn(targetBlockHash);
         when(initialAncestorBlock.getHeader()).thenReturn(initialAncestorBlockHeader);
-        when(initialAncestorBlockHeader.getEncoded(true, false)).thenReturn(initialAncestorBlockHash.getBytes());
+        when(initialAncestorBlockHeader.getEncoded(true, false, true)).thenReturn(initialAncestorBlockHash.getBytes());
 
         PowHSMState initialState = new PowHSMState(initialAncestorBlockHash.toHexString(), initialAncestorBlockHash.toHexString(), false);
         PowHSMState secondState = new PowHSMState(targetBlockHash.toHexString(), targetBlockHash.toHexString(), false);

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -65,7 +65,6 @@ public final class TestUtils {
         when(block.getUncleList()).thenReturn(Collections.emptyList());
         BlockHeader blockHeader = mock(BlockHeader.class);
         when(blockHeader.getHash()).thenReturn(hash);
-        when(blockHeader.getFullEncoded()).thenReturn(hash.getBytes());
         when(block.getHeader()).thenReturn(blockHeader);
 
         return block;
@@ -77,8 +76,7 @@ public final class TestUtils {
         when(block.getNumber()).thenReturn(number);
         when(block.getParentHash()).thenReturn(parentHash);
         BlockHeader blockHeader = mock(BlockHeader.class);
-        when(blockHeader.getEncoded(true, false)).thenReturn(hash.getBytes());
-        when(blockHeader.getFullEncoded()).thenReturn(hash.getBytes());
+        when(blockHeader.getEncoded(true, false, true)).thenReturn(hash.getBytes());
         when(block.getHeader()).thenReturn(blockHeader);
 
         return block;
@@ -89,7 +87,6 @@ public final class TestUtils {
         when(block.getHash()).thenReturn(hash);
         when(block.getNumber()).thenReturn(number);
         BlockHeader blockHeader = mock(BlockHeader.class);
-        when(blockHeader.getFullEncoded()).thenReturn(hash.getBytes());
         when(blockHeader.getHash()).thenReturn(hash);
         when(block.getHeader()).thenReturn(blockHeader);
         when(block.getDifficulty()).thenReturn(new BlockDifficulty(BigInteger.valueOf(difficultyValue)));


### PR DESCRIPTION
This PR changes the way on how block headers are being encoded when included in payloads of HSM messages. With the change they are now being "compressed".

`rskj:rskip351+rskip144`