### PR TITLE
Adapt to federation args creation

### DIFF
--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -158,18 +158,19 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
         ActivationConfig.ForBlock activations = federatorSupport.getConfigForBestBlock();
 
-        ErpFederationArgs erpFederationArgs =
-            new ErpFederationArgs(members, creationTime, creationBlockNumber, btcParams, erpPubKeys, activationDelay);
+        FederationArgs federationArgs =
+            new FederationArgs(members, creationTime, creationBlockNumber, btcParams);
 
         // If addresses match build a Non-Standard ERP federation
-        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        ErpFederation nonStandardErpFederation =
+            FederationFactory.buildNonStandardErpFederation(federationArgs, erpPubKeys, activationDelay, activations);
 
         if (nonStandardErpFederation.getAddress().equals(expectedFederationAddress)) {
             return nonStandardErpFederation;
         }
 
         // Finally, try building a P2SH ERP federation
-        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
+        return FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
 
         // TODO: what if no federation built matches the expected address?
         //  It could mean that there is a different type of federation in the Bridge that we are not considering here

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -185,8 +185,7 @@ class FederationProviderFromFederatorSupportTest {
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
         Federation expectedFederation = createP2shErpFederation(
-            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
-            configMock
+            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000)
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
@@ -338,8 +337,7 @@ class FederationProviderFromFederatorSupportTest {
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
         Federation expectedFederation = createP2shErpFederation(
-            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
-            configMock
+            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000)
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
@@ -466,8 +464,7 @@ class FederationProviderFromFederatorSupportTest {
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
         Federation expectedActiveFederation = createP2shErpFederation(
-            getFederationMembersFromPks(1,1000, 2000, 3000, 4000),
-            configMock
+            getFederationMembersFromPks(1,1000, 2000, 3000, 4000)
         );
         Address expectedActiveFederationAddress = expectedActiveFederation.getAddress();
 
@@ -706,8 +703,7 @@ class FederationProviderFromFederatorSupportTest {
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
         Federation expectedActiveFederation = createP2shErpFederation(
-            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
-            configMock
+            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000)
         );
         Address expectedActiveFederationAddress = expectedActiveFederation.getAddress();
 
@@ -760,14 +756,12 @@ class FederationProviderFromFederatorSupportTest {
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
         Federation expectedActiveFederation = createP2shErpFederation(
-            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
-            configMock
+            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000)
         );
         Address expectedActiveFederationAddress = expectedActiveFederation.getAddress();
 
         Federation expectedRetiringFederation = createP2shErpFederation(
-            getFederationMembersFromPks(1,2000, 4000, 6000, 8000, 10000),
-            configMock
+            getFederationMembersFromPks(1,2000, 4000, 6000, 8000, 10000)
         );
         Address expectedRetiringFederationAddress = expectedRetiringFederation.getAddress();
 
@@ -816,19 +810,19 @@ class FederationProviderFromFederatorSupportTest {
     private ErpFederation createNonStandardErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs =
-            new ErpFederationArgs(members, creationTime, 0L, testnetParams, erpPubKeys, activationDelay);
+        FederationArgs federationArgs =
+            new FederationArgs(members, creationTime, 0L, testnetParams);
 
-        return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
+        return FederationFactory.buildNonStandardErpFederation(federationArgs, erpPubKeys, activationDelay, activations);
     }
 
-    private ErpFederation createP2shErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
+    private ErpFederation createP2shErpFederation(List<FederationMember> members) {
         List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
         long activationDelay = bridgeConstants.getErpFedActivationDelay();
-        ErpFederationArgs erpFederationArgs =
-            new ErpFederationArgs(members, creationTime, 0L, testnetParams, erpPubKeys, activationDelay);
+        FederationArgs federationArgs =
+            new FederationArgs(members, creationTime, 0L, testnetParams);
         
-        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
+        return FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
     }
 
     private List<FederationMember> getFederationMembersFromPks(int offset, Integer... pks) {

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -121,7 +121,7 @@ class FederationProviderFromFederatorSupportTest {
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
-        Federation expectedFederation = createErpFederation(
+        Federation expectedFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
             configMock
         );
@@ -152,7 +152,7 @@ class FederationProviderFromFederatorSupportTest {
         when(configMock.isActive(RSKIP123)).thenReturn(true);
         when(configMock.isActive(RSKIP284)).thenReturn(false);
 
-        Federation expectedFederation = createErpFederation(
+        Federation expectedFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
             configMock
         );
@@ -304,7 +304,7 @@ class FederationProviderFromFederatorSupportTest {
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
-        Federation expectedFederation = createErpFederation(
+        Federation expectedFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
             configMock
         );
@@ -432,7 +432,7 @@ class FederationProviderFromFederatorSupportTest {
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
-        Federation expectedActiveFederation = createErpFederation(
+        Federation expectedActiveFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1,1000, 2000, 3000, 4000),
             configMock
         );
@@ -598,13 +598,13 @@ class FederationProviderFromFederatorSupportTest {
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
-        Federation expectedActiveFederation = createErpFederation(
+        Federation expectedActiveFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
             configMock
         );
         Address expectedActiveFederationAddress = expectedActiveFederation.getAddress();
 
-        Federation expectedRetiringFederation = createErpFederation(
+        Federation expectedRetiringFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1,2000, 4000, 6000, 8000, 10000),
             configMock
         );
@@ -652,7 +652,7 @@ class FederationProviderFromFederatorSupportTest {
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP123)).thenReturn(true);
 
-        Federation expectedActiveFederation = createErpFederation(
+        Federation expectedActiveFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
             configMock
         );
@@ -711,7 +711,7 @@ class FederationProviderFromFederatorSupportTest {
         );
         Address expectedActiveFederationAddress = expectedActiveFederation.getAddress();
 
-        Federation expectedRetiringFederation = createErpFederation(
+        Federation expectedRetiringFederation = createNonStandardErpFederation(
             getFederationMembersFromPks(1,2000, 4000, 6000, 8000, 10000),
             configMock
         );
@@ -809,35 +809,26 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     private Federation createFederation(List<FederationMember> members) {
-        return FederationFactory.buildStandardMultiSigFederation(
-            members,
-            creationTime,
-            0L,
-            testnetParams
-        );
+        FederationArgs federationArgs = new FederationArgs(members, creationTime, 0L, testnetParams);
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
-    private Federation createErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
-        return FederationFactory.buildNonStandardErpFederation(
-            members,
-            creationTime,
-            0L,
-            testnetParams,
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay(),
-            activations
-        );
+    private ErpFederation createNonStandardErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(members, creationTime, 0L, testnetParams, erpPubKeys, activationDelay);
+
+        return FederationFactory.buildNonStandardErpFederation(erpFederationArgs, activations);
     }
 
-    private Federation createP2shErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
-        return FederationFactory.buildP2shErpFederation(
-            members,
-            creationTime,
-            0L,
-            testnetParams,
-            bridgeConstants.getErpFedPubKeysList(),
-            bridgeConstants.getErpFedActivationDelay()
-        );
+    private ErpFederation createP2shErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
+        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
+        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        ErpFederationArgs erpFederationArgs =
+            new ErpFederationArgs(members, creationTime, 0L, testnetParams, erpPubKeys, activationDelay);
+        
+        return FederationFactory.buildP2shErpFederation(erpFederationArgs);
     }
 
     private List<FederationMember> getFederationMembersFromPks(int offset, Integer... pks) {

--- a/src/test/java/co/rsk/federate/FederationWatcherTest.java
+++ b/src/test/java/co/rsk/federate/FederationWatcherTest.java
@@ -14,6 +14,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationMember;
 import java.math.BigInteger;
@@ -31,26 +32,23 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
 class FederationWatcherTest {
-    private final Federation federation1 = FederationFactory.buildStandardMultiSigFederation(
-            getFederationMembersFromPksForBtc(1000, 2000, 3000, 4000),
-            Instant.ofEpochMilli(5005L),
-            0L,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-    );
+    List<FederationMember> federation1Members = getFederationMembersFromPksForBtc(1000, 2000, 3000, 4000);
+    Instant federation1CreationTime = Instant.ofEpochMilli(5005L);
+    long creationBlockNumber = 0L;
+    NetworkParameters btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
-    private final Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
-            getFederationMembersFromPksForBtc(2000, 3000, 4000, 5000, 6000, 7000),
-            Instant.ofEpochMilli(15300L),
-            0L,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-    );
+    FederationArgs federation1Args = new FederationArgs(federation1Members, federation1CreationTime, creationBlockNumber, btcParams);
+    private final Federation federation1 = FederationFactory.buildStandardMultiSigFederation(federation1Args);
 
-    private final Federation federation3 = FederationFactory.buildStandardMultiSigFederation(
-            getFederationMembersFromPksForBtc(5000, 6000, 7000),
-            Instant.ofEpochMilli(7400L),
-            0L,
-            NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
-    );
+    List<FederationMember> federation2Members = getFederationMembersFromPksForBtc(2000, 3000, 4000, 5000, 6000, 7000);
+    Instant federation2CreationTime = Instant.ofEpochMilli(15300L);
+    FederationArgs federation2Args = new FederationArgs(federation2Members, federation2CreationTime, creationBlockNumber, btcParams);
+    private final Federation federation2 = FederationFactory.buildStandardMultiSigFederation(federation2Args);
+
+    List<FederationMember> federation3Members = getFederationMembersFromPksForBtc(5000, 6000, 7000);
+    Instant federation3CreationTime = Instant.ofEpochMilli(7400L);
+    FederationArgs federation3Args = new FederationArgs(federation3Members, federation3CreationTime, creationBlockNumber, btcParams);
+    private final Federation federation3 = FederationFactory.buildStandardMultiSigFederation(federation3Args);
 
     private FederationProvider federationProvider;
     private Ethereum ethereumMock;

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -596,8 +596,8 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_erp_fed_ok() throws Exception {
         Federation federation = TestUtils.createFederation(params, 3);
         FederationArgs federationArgs = federation.getArgs();
-        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
-        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, mock(ActivationConfig.ForBlock.class));
+        ErpFederation nonStandardErpFederation =
+            FederationFactory.buildNonStandardErpFederation(federationArgs, erpFedKeys, 5063, mock(ActivationConfig.ForBlock.class));
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = createReleaseTxAndAddInput(federation);
@@ -785,9 +785,9 @@ class BtcReleaseClientTest {
     void extractStandardRedeemScript_erp_redeem_script() {
         Federation federation = TestUtils.createFederation(params, 1);
         FederationArgs federationArgs = federation.getArgs();
-        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
 
-        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, mock(ActivationConfig.ForBlock.class));
+        ErpFederation nonStandardErpFederation =
+            FederationFactory.buildNonStandardErpFederation(federationArgs, erpFedKeys, 5063, mock(ActivationConfig.ForBlock.class));
 
         test_extractStandardRedeemScript(federation.getRedeemScript(), nonStandardErpFederation.getRedeemScript());
     }

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -56,8 +56,7 @@ import co.rsk.federate.signing.hsm.requirements.ReleaseRequirementsEnforcer;
 import co.rsk.federate.signing.hsm.requirements.ReleaseRequirementsEnforcerException;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.net.NodeBlockProcessor;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.ErpFederation;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.StateForFederator;
 
 import java.math.BigInteger;
@@ -72,8 +71,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationMember;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
@@ -598,23 +595,17 @@ class BtcReleaseClientTest {
     @Test
     void validateTxCanBeSigned_erp_fed_ok() throws Exception {
         Federation federation = TestUtils.createFederation(params, 3);
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            federation.getMembers(),
-            federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
-            params,
-            erpFedKeys,
-            5063,
-            mock(ActivationConfig.ForBlock.class)
-        );
+        FederationArgs federationArgs = federation.getArgs();
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, mock(ActivationConfig.ForBlock.class));
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = createReleaseTxAndAddInput(federation);
 
-        BtcECKey fed1Key = erpFederation.getBtcPublicKeys().get(0);
+        BtcECKey fed1Key = nonStandardErpFederation.getBtcPublicKeys().get(0);
         ECPublicKey signerPublicKey = new ECPublicKey(fed1Key.getPubKey());
 
-        test_validateTxCanBeSigned(erpFederation, releaseTx, signerPublicKey);
+        test_validateTxCanBeSigned(nonStandardErpFederation, releaseTx, signerPublicKey);
     }
 
     @Test
@@ -622,12 +613,10 @@ class BtcReleaseClientTest {
         // Arrange
         BtcECKey federator1PrivKey = new BtcECKey();
         BtcECKey federator2PrivKey = new BtcECKey();
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1PrivKey, federator2PrivKey)),
-            Instant.now(),
-            0,
-            params
-        );
+        List<FederationMember> fedMembers = FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1PrivKey, federator2PrivKey));
+        FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.now(), 0, params);
+
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = new BtcTransaction(params);
@@ -720,12 +709,10 @@ class BtcReleaseClientTest {
         // Arrange
         BtcECKey federator1PrivKey = new BtcECKey();
         BtcECKey federator2PrivKey = new BtcECKey();
-        Federation federation = FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1PrivKey, federator2PrivKey)),
-            Instant.now(),
-            0,
-            params
-        );
+        List<FederationMember> fedMembers = FederationMember.getFederationMembersFromKeys(Arrays.asList(federator1PrivKey, federator2PrivKey));
+        FederationArgs federationArgs = new FederationArgs(fedMembers, Instant.now(), 0, params);
+
+        Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = new BtcTransaction(params);
@@ -797,18 +784,12 @@ class BtcReleaseClientTest {
     @Test
     void extractStandardRedeemScript_erp_redeem_script() {
         Federation federation = TestUtils.createFederation(params, 1);
+        FederationArgs federationArgs = federation.getArgs();
+        ErpFederationArgs erpFederationArgs = ErpFederationArgs.fromFederationArgs(federationArgs, erpFedKeys, 5063);
 
-        ErpFederation erpFederation = FederationFactory.buildNonStandardErpFederation(
-            federation.getMembers(),
-            federation.getCreationTime(),
-            federation.getCreationBlockNumber(),
-            params,
-            erpFedKeys,
-            5063,
-            mock(ActivationConfig.ForBlock.class)
-        );
+        ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(erpFederationArgs, mock(ActivationConfig.ForBlock.class));
 
-        test_extractStandardRedeemScript(federation.getRedeemScript(), erpFederation.getRedeemScript());
+        test_extractStandardRedeemScript(federation.getRedeemScript(), nonStandardErpFederation.getRedeemScript());
     }
 
     @Test
@@ -1055,12 +1036,8 @@ class BtcReleaseClientTest {
         btcECKeyList.forEach(btcECKey -> federationMembers.add(
             new FederationMember(btcECKey, new ECKey(), new ECKey()))
         );
+        FederationArgs federationArgs = new FederationArgs(federationMembers, Instant.now(), 0L, params);
 
-        return FederationFactory.buildStandardMultiSigFederation(
-            federationMembers,
-            Instant.now(),
-            0L,
-            params
-        );
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 }

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -16,6 +16,7 @@ import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationMember;
 
@@ -87,13 +88,10 @@ public class TestUtils {
 
     public static Federation createFederation(NetworkParameters params, int amountOfMembers) {
         List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(amountOfMembers).collect(Collectors.toList());
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
+        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 0, params);
 
-        return FederationFactory.buildStandardMultiSigFederation(
-            FederationMember.getFederationMembersFromKeys(keys),
-            Instant.now(),
-            0,
-            params
-        );
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     public static TransactionInput createTransactionInput(


### PR DESCRIPTION
In rskj project, FederationArgs // ErpFederationArgs objects were created to reduce the amount of params we pass to the Federation // ErpFederation constructors.
This pr adapts to that change