### PR TITLE
Build and push docker image on tag

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -5,8 +5,8 @@ on:
       - '*'
 
 env:
-  GHCR_TAG: "ghcr.io/rsksmart/powpeg-node"
-  DOCKERHUB_TAG: "rsk/powpeg-node"
+  GHCR_REPO: "ghcr.io/rsksmart/powpeg-node"
+  DOCKERHUB_REPO: "rsk/powpeg-node"
 
 jobs:
   build:
@@ -24,8 +24,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.DOCKERHUB_TAG }}
-            ${{ env.GHCR_TAG }}
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
           tags: |
             type=ref,event=tag
             type=edge
@@ -60,5 +60,5 @@ jobs:
 
       - name: Push Images
         run: |
-          docker push ${{ env.DOCKERHUB_TAG }}
-          docker push ${{ env.GHCR_TAG }}
+          docker push ${{ env.DOCKERHUB_REPO }}
+          docker push ${{ env.GHCR_REPO }}

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,64 @@
+name: Docker Image Build and Push
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  GHCR_TAG: "ghcr.io/rsksmart/powpeg-node"
+  DOCKERHUB_TAG: "rsk/powpeg-node"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_TAG }}
+            ${{ env.GHCR_TAG }}
+          tags: |
+            type=ref,event=tag
+            type=edge
+            # This is used for generating IRIS-3 out of IRIS-3.x.y.
+            type=match,pattern=(\w+-\d+)\.\d+\.\d+.*,group=1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: RSK_RELEASE=${{ steps.vars.outputs.tag }}
+
+      - name: DockerHub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: GitHub container registry login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Images
+        run: |
+          docker push ${{ env.DOCKERHUB_TAG }}
+          docker push ${{ env.GHCR_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim-buster AS build
+FROM openjdk:8-jdk-slim-buster AS build
 
 ARG RSK_RELEASE
 ENV RSK_VERSION $RSK_RELEASE
@@ -20,8 +20,8 @@ RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991
     ./gradlew --no-daemon clean build -x test && \
     cp "build/libs/federate-node-$RSK_VERSION-all.jar" rsk.jar
 
-FROM openjdk:11-jre-slim-buster
-LABEL org.opencontainers.image.authors="ops@iovlabs.org"
+FROM openjdk:8-jre-slim-buster
+LABEL org.opencontainers.image.authors="ops@rootstocklabs.com"
 
 RUN useradd -ms /sbin/nologin -d /var/lib/rsk rsk
 USER rsk
@@ -34,4 +34,4 @@ ENV RSKJ_SYS_PROPS="-Dlogback.configurationFile='/etc/rsk/logback.xml' -Drsk.con
 ENV RSKJ_CLASS=co.rsk.federate.FederateRunner
 ENV RSKJ_OPTS=""
 
-ENTRYPOINT ["/bin/sh", "-c", "java $DEFAULT_JVM_OPTS $RSKJ_SYS_PROPS -cp rsk.jar $RSKJ_CLASS $RSKJ_OPTS \"${@}\"", "--"]
+ENTRYPOINT ["/bin/sh", "-c", "exec java $DEFAULT_JVM_OPTS $RSKJ_SYS_PROPS -cp rsk.jar $RSKJ_CLASS $RSKJ_OPTS \"${@}\"", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:11-jdk-slim-buster AS build
+
+ARG RSK_RELEASE
+ENV RSK_VERSION $RSK_RELEASE
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get install -y git curl gnupg
+
+RUN useradd -ms /bin/bash rsk
+USER rsk
+
+WORKDIR /home/rsk
+COPY --chown=rsk:rsk . ./
+
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
+    cp "build/libs/federate-node-$RSK_VERSION-all.jar" rsk.jar
+
+FROM openjdk:11-jre-slim-buster
+LABEL org.opencontainers.image.authors="ops@iovlabs.org"
+
+RUN useradd -ms /sbin/nologin -d /var/lib/rsk rsk
+USER rsk
+
+WORKDIR /var/lib/rsk
+COPY --from=build --chown=rsk:rsk /home/rsk/rsk.jar ./
+
+ENV DEFAULT_JVM_OPTS="-Xss4M"
+ENV RSKJ_SYS_PROPS="-Dlogback.configurationFile='/etc/rsk/logback.xml' -Drsk.conf.file=/etc/rsk/node.conf"
+ENV RSKJ_CLASS=co.rsk.federate.FederateRunner
+ENV RSKJ_OPTS=""
+
+ENTRYPOINT ["/bin/sh", "-c", "java $DEFAULT_JVM_OPTS $RSKJ_SYS_PROPS -cp rsk.jar $RSKJ_CLASS $RSKJ_OPTS \"${@}\"", "--"]


### PR DESCRIPTION
I've added a new github workflow to generate and push a docker image to use the PowPeg-Node in.

The new workflow logs in on both DockerHub and GitHub Container Registry, builds the code, builds the docker image, then pushes it to both repos. For now, the action will be triggered when a tag is pushed.

The required secrets needed to be set up in this repo for this to work are:
DOCKERHUB_USERNAME : username to login on dockerhub
DOCKERHUB_TOKEN : token to use to login on dockerhub
Please contact the DevOps team to request these credentials

The images will be pushed as:
rsksmart/powpeg-node:<RELEASE_NAME>
ghcr.io/rsksmart/powpeg-node:<RELEASE_NAME>