### PR TITLE
Avoid possible NPE when searching for event in past blocks

### DIFF
--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -132,7 +132,8 @@ public class ReleaseCreationInformationGetter {
         Keccak256 informingRskTxHash
     ) throws HSMReleaseCreationInformationException {
         Block block = blockStore.getChainBlockByNumber(blockNumber);
-        // If the block cannot be found by its number, the event cannot be searched further.
+        // If the block cannot be found by its number, the event cannot be
+        // searched further.
         if (block == null) {
             throw new HSMReleaseCreationInformationException(
                     String.format("[searchEventInFollowingBlocks] Block not found. Transaction hash: [%s]", rskTxHash)
@@ -144,24 +145,30 @@ public class ReleaseCreationInformationGetter {
             blockNumber,
             block.getTransactionsList().size()
         );
-        for (Transaction transaction : block.getTransactionsList()) {
-            TransactionInfo transactionInfo = receiptStore.getInMainChain(transaction.getHash().getBytes(), blockStore).orElse(null);
-            TransactionReceipt transactionReceipt = transactionInfo.getReceipt();
-            transactionReceipt.setTransaction(transaction);
-            Optional<ReleaseCreationInformation> optionalReleaseCreationInformation =
-                getInformationFromEvent(block, transactionReceipt, btcTransaction, rskTxHash, informingRskTxHash);
-            if (optionalReleaseCreationInformation.isPresent()) {
-                return optionalReleaseCreationInformation.get();
-            }
+        for (Transaction tx : block.getTransactionsList()) {
+            TransactionReceipt txReceipt = receiptStore.getInMainChain(tx.getHash().getBytes(), blockStore)
+                .map(TransactionInfo::getReceipt)
+                .orElseThrow(() -> new HSMReleaseCreationInformationException(
+                    String.format("[searchEventInFollowingBlocks] Transaction hash [%s] should exist", tx.getHash())));
 
+            txReceipt.setTransaction(tx);
+
+            Optional<ReleaseCreationInformation> releaseCreationInformation =
+                getInformationFromEvent(block, txReceipt, btcTransaction, rskTxHash, informingRskTxHash);
+            if (releaseCreationInformation.isPresent()) {
+                return releaseCreationInformation.get();
+            }
         }
-        // If the block being checked is the last block, and was not found, then the event does not exist.
-        if (block.getNumber() == (blockStore.getBestBlock().getNumber())) {
+
+        // If the block being checked is the last block, and was not found,
+        // then the event does not exist.
+        if (block.getNumber() == blockStore.getBestBlock().getNumber()) {
             throw new HSMReleaseCreationInformationException(
                     String.format("[searchEventInFollowingBlocks] Event not found. Transaction hash: [%s]", rskTxHash)
             );
         }
-        // If the event was not found in this block, the next block is requested and the same search is performed.
+        // If the event was not found in this block, the next block is
+        // requested and the same search is performed.
         return searchEventInFollowingBlocks(blockNumber + 1, btcTransaction, rskTxHash, informingRskTxHash);
     }
 

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -136,7 +136,7 @@ public class ReleaseCreationInformationGetter {
         // searched further.
         if (block == null) {
             throw new HSMReleaseCreationInformationException(
-                    String.format("[searchEventInFollowingBlocks] Block not found. Transaction hash: [%s]", rskTxHash)
+                    String.format("[searchEventInFollowingBlocks] Block not found. Rsk Transaction hash: [%s]", rskTxHash)
             );
         }
 
@@ -145,16 +145,16 @@ public class ReleaseCreationInformationGetter {
             blockNumber,
             block.getTransactionsList().size()
         );
-        for (Transaction tx : block.getTransactionsList()) {
-            TransactionReceipt txReceipt = receiptStore.getInMainChain(tx.getHash().getBytes(), blockStore)
+        for (Transaction rskTx : block.getTransactionsList()) {
+            TransactionReceipt rskTxReceipt = receiptStore.getInMainChain(rskTx.getHash().getBytes(), blockStore)
                 .map(TransactionInfo::getReceipt)
                 .orElseThrow(() -> new HSMReleaseCreationInformationException(
-                    String.format("[searchEventInFollowingBlocks] Transaction hash [%s] should exist", tx.getHash())));
+                    String.format("[searchEventInFollowingBlocks] Rsk Transaction hash [%s] should exist", rskTx.getHash())));
 
-            txReceipt.setTransaction(tx);
+            rskTxReceipt.setTransaction(rskTx);
 
             Optional<ReleaseCreationInformation> releaseCreationInformation =
-                getInformationFromEvent(block, txReceipt, btcTransaction, rskTxHash, informingRskTxHash);
+                getInformationFromEvent(block, rskTxReceipt, btcTransaction, rskTxHash, informingRskTxHash);
             if (releaseCreationInformation.isPresent()) {
                 return releaseCreationInformation.get();
             }
@@ -164,7 +164,7 @@ public class ReleaseCreationInformationGetter {
         // then the event does not exist.
         if (block.getNumber() == blockStore.getBestBlock().getNumber()) {
             throw new HSMReleaseCreationInformationException(
-                    String.format("[searchEventInFollowingBlocks] Event not found. Transaction hash: [%s]", rskTxHash)
+                    String.format("[searchEventInFollowingBlocks] Event not found. Rsk Transaction hash: [%s]", rskTxHash)
             );
         }
         // If the event was not found in this block, the next block is

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -307,11 +307,9 @@ class ReleaseCreationInformationGetterTest {
 
         Transaction transaction = mock(Transaction.class);
         when(transaction.getHash()).thenReturn(rskTxHash);
-        when(transaction.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
 
         TransactionReceipt transactionReceipt = mock(TransactionReceipt.class);
         when(transactionReceipt.getTransaction()).thenReturn(transaction);
-        when(transactionReceipt.getLogInfoList()).thenReturn(new ArrayList<>());
 
         TransactionInfo transactionInfo = mock(TransactionInfo.class);
         when(transactionInfo.getReceipt()).thenReturn(transactionReceipt);
@@ -321,7 +319,7 @@ class ReleaseCreationInformationGetterTest {
         when(block.getHash()).thenReturn(blockHash);
         when(block.getTransactionsList()).thenReturn(Collections.singletonList(transaction));
 
-        // The event is now searched in the next block
+        // The event is now searched in the following block
         Keccak256 secondBlockHash = TestUtils.createHash(5);
         Keccak256 rskTxHashInSecondBlock = TestUtils.createHash(4);
 

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -34,8 +34,8 @@ class ReleaseCreationInformationGetterTest {
         Keccak256 blockHash = TestUtils.createHash(3);
         Keccak256 rskTxHash = TestUtils.createHash(1);
         byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        BtcTransaction btcTransaction = mock(BtcTransaction.class);
-        when(btcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
+        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
+        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
 
         CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
         byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
@@ -70,36 +70,36 @@ class ReleaseCreationInformationGetterTest {
         ReceiptStore receiptStore = mock(ReceiptStore.class);
         when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfo));
 
-        ReleaseCreationInformationGetter information = new ReleaseCreationInformationGetter(
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
                 receiptStore,
                 blockStore
         );
         // HSM V2
-        createGetTxInfoToSign_returnOK(information, rskTxHash, btcTransaction, block, transactionReceipt, 2);
+        createGetTxInfoToSign_returnOK(pegoutCreationInformation, rskTxHash, pegoutBtcTransaction, block, transactionReceipt, 2);
 
         // HSM V3
-        createGetTxInfoToSign_returnOK(information, rskTxHash, btcTransaction, block, transactionReceipt, 3);
+        createGetTxInfoToSign_returnOK(pegoutCreationInformation, rskTxHash, pegoutBtcTransaction, block, transactionReceipt, 3);
 
         // HSM V4
-        createGetTxInfoToSign_returnOK(information, rskTxHash, btcTransaction, block, transactionReceipt, 4);
+        createGetTxInfoToSign_returnOK(pegoutCreationInformation, rskTxHash, pegoutBtcTransaction, block, transactionReceipt, 4);
     }
 
-    private void createGetTxInfoToSign_returnOK(ReleaseCreationInformationGetter information,
+    private void createGetTxInfoToSign_returnOK(ReleaseCreationInformationGetter pegoutCreationInformation,
                                                Keccak256 rskTxHash,
-                                               BtcTransaction btcTransaction,
+                                               BtcTransaction pegoutBtcTransaction,
                                                Block block,
                                                TransactionReceipt transactionReceipt,
                                                int hsmVersion) throws HSMReleaseCreationInformationException {
-        ReleaseCreationInformation releaseCreationInformation = information.getTxInfoToSign(
+        ReleaseCreationInformation releaseCreationInformation = pegoutCreationInformation.getTxInfoToSign(
             hsmVersion,
             rskTxHash,
-            btcTransaction
+            pegoutBtcTransaction
         );
 
         assertEquals(releaseCreationInformation.getBlock(), block);
         assertEquals(transactionReceipt, releaseCreationInformation.getTransactionReceipt());
         assertEquals(rskTxHash, releaseCreationInformation.getReleaseRskTxHash());
-        assertEquals(btcTransaction, releaseCreationInformation.getBtcTransaction());
+        assertEquals(pegoutBtcTransaction, releaseCreationInformation.getBtcTransaction());
     }
 
     @Test
@@ -128,8 +128,8 @@ class ReleaseCreationInformationGetterTest {
         Keccak256 secondBlockHash = TestUtils.createHash(5);
         Keccak256 rskTxHashInSecondBlock = TestUtils.createHash(4);
         byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        BtcTransaction btcTransaction = mock(BtcTransaction.class);
-        when(btcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
+        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
+        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
 
         CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
         byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
@@ -165,16 +165,16 @@ class ReleaseCreationInformationGetterTest {
         when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfo));
         when(receiptStore.getInMainChain(rskTxHashInSecondBlock.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfoInSecondBlock));
 
-        ReleaseCreationInformationGetter information = new ReleaseCreationInformationGetter(
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
             receiptStore,
             blockStore
         );
-        ReleaseCreationInformation releaseCreationInformation = information.getTxInfoToSign(2, rskTxHash, btcTransaction);
+        ReleaseCreationInformation releaseCreationInformation = pegoutCreationInformation.getTxInfoToSign(2, rskTxHash, pegoutBtcTransaction);
 
         assertEquals(secondBlock, releaseCreationInformation.getBlock());
         assertEquals(transactionReceiptInSecondBlock, releaseCreationInformation.getTransactionReceipt());
         assertEquals(rskTxHash, releaseCreationInformation.getReleaseRskTxHash());
-        assertEquals(btcTransaction, releaseCreationInformation.getBtcTransaction());
+        assertEquals(pegoutBtcTransaction, releaseCreationInformation.getBtcTransaction());
 
     }
 
@@ -183,8 +183,8 @@ class ReleaseCreationInformationGetterTest {
         Keccak256 blockHash = TestUtils.createHash(3);
         Keccak256 rskTxHash = TestUtils.createHash(1);
         byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        BtcTransaction btcTransaction = mock(BtcTransaction.class);
-        when(btcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
+        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
+        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
 
         Transaction transaction = mock(Transaction.class);
         when(transaction.getHash()).thenReturn(rskTxHash);
@@ -202,15 +202,15 @@ class ReleaseCreationInformationGetterTest {
         ReceiptStore receiptStore = mock(ReceiptStore.class);
         when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfo));
 
-        ReleaseCreationInformationGetter information = new ReleaseCreationInformationGetter(
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
             receiptStore,
             blockStore
         );
 
-        assertThrows(HSMReleaseCreationInformationException.class, () -> information.getTxInfoToSign(
+        assertThrows(HSMReleaseCreationInformationException.class, () -> pegoutCreationInformation.getTxInfoToSign(
             2,
             rskTxHash,
-            btcTransaction
+            pegoutBtcTransaction
         ));
     }
 
@@ -219,8 +219,8 @@ class ReleaseCreationInformationGetterTest {
         Keccak256 blockHash = TestUtils.createHash(3);
         Keccak256 rskTxHash = TestUtils.createHash(1);
         byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        BtcTransaction btcTransaction = mock(BtcTransaction.class);
-        when(btcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
+        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
+        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
 
         Transaction transaction = mock(Transaction.class);
         when(transaction.getHash()).thenReturn(rskTxHash);
@@ -243,15 +243,15 @@ class ReleaseCreationInformationGetterTest {
         ReceiptStore receiptStore = mock(ReceiptStore.class);
         when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfo));
 
-        ReleaseCreationInformationGetter information = new ReleaseCreationInformationGetter(
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
             receiptStore,
             blockStore
         );
 
-        assertThrows(HSMReleaseCreationInformationException.class, () -> information.getTxInfoToSign(
+        assertThrows(HSMReleaseCreationInformationException.class, () -> pegoutCreationInformation.getTxInfoToSign(
             2,
             rskTxHash,
-            btcTransaction
+            pegoutBtcTransaction
         ));
     }
 
@@ -260,8 +260,8 @@ class ReleaseCreationInformationGetterTest {
         Keccak256 blockHash = TestUtils.createHash(3);
         Keccak256 rskTxHash = TestUtils.createHash(1);
         byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        BtcTransaction btcTransaction = mock(BtcTransaction.class);
-        when(btcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
+        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
+        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
 
         Transaction transaction = mock(Transaction.class);
         when(transaction.getHash()).thenReturn(rskTxHash);
@@ -287,20 +287,20 @@ class ReleaseCreationInformationGetterTest {
         ReceiptStore receiptStore = mock(ReceiptStore.class);
         when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfo));
 
-        ReleaseCreationInformationGetter information = new ReleaseCreationInformationGetter(
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
                 receiptStore,
                 blockStore
         );
 
-        assertThrows(HSMReleaseCreationInformationException.class, () -> information.getTxInfoToSign(
+        assertThrows(HSMReleaseCreationInformationException.class, () -> pegoutCreationInformation.getTxInfoToSign(
             2,
             rskTxHash,
-            btcTransaction
+            pegoutBtcTransaction
         ));
     }
 
     @Test
-    void getTxInfoToSign_whenTransactionReceiptNotFoundInSubsequentBlock_shouldThrowHSMRelaseCreationInformationException() {
+    void getTxInfoToSign_whenTransactionReceiptNotFoundInSubsequentBlock_shouldThrowHSMReleaseCreationInformationException() {
         // The event that is searched is not found in the first block
         Keccak256 blockHash = TestUtils.createHash(3);
         Keccak256 rskTxHash = TestUtils.createHash(1);
@@ -340,19 +340,19 @@ class ReleaseCreationInformationGetterTest {
         when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(transactionInfo));
         when(receiptStore.getInMainChain(rskTxHashInSecondBlock.getBytes(), blockStore)).thenReturn(Optional.empty());
 
-        ReleaseCreationInformationGetter information = new ReleaseCreationInformationGetter(
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
                 receiptStore,
                 blockStore
         );
 
-        BtcTransaction btcTransaction = mock(BtcTransaction.class);
+        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
         byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        when(btcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
+        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
 
-        assertThrows(HSMReleaseCreationInformationException.class, () -> information.getTxInfoToSign(
+        assertThrows(HSMReleaseCreationInformationException.class, () -> pegoutCreationInformation.getTxInfoToSign(
             2,
             rskTxHash,
-            btcTransaction
+            pegoutBtcTransaction
         ));
     }
 }


### PR DESCRIPTION
### Summary

The method `receiptStore.getInMainChain(transaction.getHash().getBytes(), blockStore)` returns an `Optional`. The code is not currently checking if the value is present in the returned `Optional`.

There is no reason really for the transaction to not be in the storage, if it’s part of the block then the transaction should exist. But avoiding this check is what’s causing a code smell.

Note: Added minor refactor.

### Test Plan

Added unit test, and verified with `./gradlew test`