### PR TITLE
Remove Dependency Between BridgeConstants and Federation classes

### DIFF
--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -93,9 +93,10 @@ class BtcToRskClientTest {
     private int nhash = 0;
     private ActivationConfig activationConfig;
     private BridgeConstants bridgeRegTestConstants;
-    private Federation genesisFederation;
+    private Federation activeFederation;
     private FederationMember fakeMember;
     private BtcToRskClientBuilder btcToRskClientBuilder;
+    private List<BtcECKey> federationPrivateKeys;
 
     @BeforeEach
     void setup() throws PeginInstructionsException, IOException {
@@ -104,7 +105,8 @@ class BtcToRskClientTest {
         when(activationConfig.isActive(eq(ConsensusRule.RSKIP89), anyLong())).thenReturn(true);
 
         bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-        genesisFederation = TestUtils.getGenesisFederation(bridgeRegTestConstants);
+        federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
+        activeFederation = TestUtils.createFederation(bridgeRegTestConstants.getBtcParams(), federationPrivateKeys);
         fakeMember = FederationMember.getFederationMemberFromKey(
             BtcECKey.fromPrivate(
                 HashUtil.keccak256("00".getBytes(StandardCharsets.UTF_8))
@@ -118,10 +120,10 @@ class BtcToRskClientTest {
         BitcoinWrapper bw = new SimpleBitcoinWrapper();
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
 
-        FederationMember fedMember = genesisFederation.getMembers().get(0);
+        FederationMember fedMember = activeFederation.getMembers().get(0);
         fh.setMember(fedMember);
         BtcToRskClient client = createClientWithMocks(bw, fh);
-        assertDoesNotThrow(() -> client.start(genesisFederation));
+        assertDoesNotThrow(() -> client.start(activeFederation));
     }
 
     @Test
@@ -131,7 +133,7 @@ class BtcToRskClientTest {
 
         fh.setMember(fakeMember);
         BtcToRskClient client = createClientWithMocks(bw, fh);
-        assertDoesNotThrow(() -> client.start(genesisFederation));
+        assertDoesNotThrow(() -> client.start(activeFederation));
     }
 
     @Test
@@ -139,7 +141,7 @@ class BtcToRskClientTest {
         BitcoinWrapper bw = new SimpleBitcoinWrapper();
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
         Federation federation = mock(Federation.class);
-        FederationMember fedMember = genesisFederation.getMembers().get(0);
+        FederationMember fedMember = activeFederation.getMembers().get(0);
 
         fh.setMember(fedMember);
         when(federation.isMember(fedMember)).thenReturn(true);
@@ -190,7 +192,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
     }
@@ -225,7 +227,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(fs)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcToRskClientFileStorage(btcToRskClientFileStorage)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
     }
 
@@ -815,7 +817,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -943,7 +945,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -986,7 +988,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1092,7 +1094,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1151,7 +1153,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1225,7 +1227,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1299,7 +1301,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1357,7 +1359,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         for (Transaction tx : txs) {
@@ -1418,7 +1420,7 @@ class BtcToRskClientTest {
                 .withFederatorSupport(federatorSupport)
                 .withBridgeConstants(bridgeRegTestConstants)
                 .withBtcLockSenderProvider(btcLockSenderProvider)
-                .withFederation(genesisFederation)
+                .withFederation(activeFederation)
                 .build();
 
             client.onTransaction(tx);
@@ -1522,7 +1524,7 @@ class BtcToRskClientTest {
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1569,7 +1571,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1622,7 +1624,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1677,7 +1679,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1696,7 +1698,6 @@ class BtcToRskClientTest {
     @Test
     void updateTransaction_with_release_before_rskip143() throws Exception {
         co.rsk.bitcoinj.core.NetworkParameters params = RegTestParams.get();
-        List<BtcECKey> federationPrivateKeys = BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS;
         co.rsk.bitcoinj.core.Address randomAddress =
                 new co.rsk.bitcoinj.core.Address(params, org.bouncycastle.util.encoders.Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
 
@@ -1709,23 +1710,23 @@ class BtcToRskClientTest {
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);
         releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN, randomAddress);
-        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), genesisFederation.getAddress()); // Change output
+        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), activeFederation.getAddress()); // Change output
         co.rsk.bitcoinj.core.TransactionInput releaseInput1 =
                 new co.rsk.bitcoinj.core.TransactionInput(params, releaseTx1,
                         new byte[]{}, new co.rsk.bitcoinj.core.TransactionOutPoint(params, 0, co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH));
         releaseTx1.addInput(releaseInput1);
 
         // Sign it using the Federation members
-        co.rsk.bitcoinj.script.Script redeemScript = genesisFederation.getRedeemScript();
+        co.rsk.bitcoinj.script.Script redeemScript = activeFederation.getRedeemScript();
         co.rsk.bitcoinj.script.Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(
-            genesisFederation);
+            activeFederation);
         releaseInput1.setScriptSig(inputScript);
 
         co.rsk.bitcoinj.core.Sha256Hash sighash = releaseTx1.hashForSignature(0, redeemScript, BtcTransaction.SigHash.ALL, false);
 
-        for (int i = 0; i < genesisFederation.getNumberOfSignaturesRequired(); i++) {
+        for (int i = 0; i < activeFederation.getNumberOfSignaturesRequired(); i++) {
             BtcECKey federatorPrivKey = federationPrivateKeys.get(i);
-            BtcECKey federatorPublicKey = genesisFederation.getBtcPublicKeys().get(i);
+            BtcECKey federatorPublicKey = activeFederation.getBtcPublicKeys().get(i);
 
             BtcECKey.ECDSASignature sig = federatorPrivKey.sign(sighash);
             TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);
@@ -1737,7 +1738,7 @@ class BtcToRskClientTest {
 
         // Verify it was properly signed
         assertTrue(PegUtilsLegacy.isPegOutTx(releaseTx1, Collections.singletonList(
-            genesisFederation), activations));
+            activeFederation), activations));
 
         Transaction releaseTx = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString(), releaseTx1);
 
@@ -1769,7 +1770,7 @@ class BtcToRskClientTest {
         );
 
         // Assign Federation to BtcToRskClient
-        client.start(genesisFederation);
+        client.start(activeFederation);
 
         // Ensure tx is loaded and its proof is also loaded
         client.onTransaction(releaseTx);
@@ -1821,7 +1822,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1872,7 +1873,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1922,7 +1923,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1972,7 +1973,7 @@ class BtcToRskClientTest {
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2028,7 +2029,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2078,7 +2079,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithoutOutputs);
@@ -2123,7 +2124,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2526,7 +2527,7 @@ class BtcToRskClientTest {
             false,
             100
         );
-        btcToRskClient.start(genesisFederation);
+        btcToRskClient.start(activeFederation);
 
         return btcToRskClient;
     }
@@ -2560,7 +2561,7 @@ class BtcToRskClientTest {
     private Transaction createTransaction() {
         Transaction tx = new SimpleBtcTransaction(networkParameters, createHash(), createHash(), false);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, org.bitcoinj.script.ScriptBuilder.createInputScript(null, new ECKey()));
-        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, genesisFederation.getAddress().toBase58()));
+        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, activeFederation.getAddress().toBase58()));
 
         return tx;
     }
@@ -2568,7 +2569,7 @@ class BtcToRskClientTest {
     private Transaction createSegwitTransaction() {
         Transaction tx = new SimpleBtcTransaction(networkParameters, createHash(), createHash(), true);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, org.bitcoinj.script.ScriptBuilder.createInputScript(null, new ECKey()));
-        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, genesisFederation.getAddress().toBase58()));
+        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, activeFederation.getAddress().toBase58()));
 
         return tx;
     }

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -25,6 +25,7 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.federate.adapter.ThinConverter;
@@ -92,7 +93,7 @@ class BtcToRskClientTest {
     private int nhash = 0;
     private ActivationConfig activationConfig;
     private BridgeConstants bridgeRegTestConstants;
-    private Federation genesisFederation;
+    private Federation activeFederation;
     private FederationMember fakeMember;
     private BtcToRskClientBuilder btcToRskClientBuilder;
 
@@ -103,7 +104,7 @@ class BtcToRskClientTest {
         when(activationConfig.isActive(eq(ConsensusRule.RSKIP89), anyLong())).thenReturn(true);
 
         bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-        genesisFederation = bridgeRegTestConstants.getGenesisFederation();
+        activeFederation = TestUtils.createFederation(bridgeRegTestConstants.getBtcParams(),1);
         fakeMember = FederationMember.getFederationMemberFromKey(
             BtcECKey.fromPrivate(
                 HashUtil.keccak256("00".getBytes(StandardCharsets.UTF_8))
@@ -117,10 +118,10 @@ class BtcToRskClientTest {
         BitcoinWrapper bw = new SimpleBitcoinWrapper();
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
 
-        FederationMember fedMember = genesisFederation.getMembers().get(0);
+        FederationMember fedMember = activeFederation.getMembers().get(0);
         fh.setMember(fedMember);
         BtcToRskClient client = createClientWithMocks(bw, fh);
-        assertDoesNotThrow(() -> client.start(genesisFederation));
+        assertDoesNotThrow(() -> client.start(activeFederation));
     }
 
     @Test
@@ -130,7 +131,7 @@ class BtcToRskClientTest {
 
         fh.setMember(fakeMember);
         BtcToRskClient client = createClientWithMocks(bw, fh);
-        assertDoesNotThrow(() -> client.start(genesisFederation));
+        assertDoesNotThrow(() -> client.start(activeFederation));
     }
 
     @Test
@@ -138,7 +139,7 @@ class BtcToRskClientTest {
         BitcoinWrapper bw = new SimpleBitcoinWrapper();
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
         Federation federation = mock(Federation.class);
-        FederationMember fedMember = genesisFederation.getMembers().get(0);
+        FederationMember fedMember = activeFederation.getMembers().get(0);
 
         fh.setMember(fedMember);
         when(federation.isMember(fedMember)).thenReturn(true);
@@ -189,7 +190,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
     }
@@ -224,7 +225,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(fs)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcToRskClientFileStorage(btcToRskClientFileStorage)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
     }
 
@@ -814,7 +815,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -942,7 +943,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -985,7 +986,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1091,7 +1092,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1150,7 +1151,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1224,7 +1225,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1298,7 +1299,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1356,7 +1357,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         for (Transaction tx : txs) {
@@ -1417,7 +1418,7 @@ class BtcToRskClientTest {
                 .withFederatorSupport(federatorSupport)
                 .withBridgeConstants(bridgeRegTestConstants)
                 .withBtcLockSenderProvider(btcLockSenderProvider)
-                .withFederation(genesisFederation)
+                .withFederation(activeFederation)
                 .build();
 
             client.onTransaction(tx);
@@ -1521,7 +1522,7 @@ class BtcToRskClientTest {
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1568,7 +1569,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1621,7 +1622,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1676,7 +1677,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1708,22 +1709,23 @@ class BtcToRskClientTest {
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);
         releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN, randomAddress);
-        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), genesisFederation.getAddress()); // Change output
+        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), activeFederation.getAddress()); // Change output
         co.rsk.bitcoinj.core.TransactionInput releaseInput1 =
                 new co.rsk.bitcoinj.core.TransactionInput(params, releaseTx1,
                         new byte[]{}, new co.rsk.bitcoinj.core.TransactionOutPoint(params, 0, co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH));
         releaseTx1.addInput(releaseInput1);
 
         // Sign it using the Federation members
-        co.rsk.bitcoinj.script.Script redeemScript = genesisFederation.getRedeemScript();
-        co.rsk.bitcoinj.script.Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(genesisFederation);
+        co.rsk.bitcoinj.script.Script redeemScript = activeFederation.getRedeemScript();
+        co.rsk.bitcoinj.script.Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(
+            activeFederation);
         releaseInput1.setScriptSig(inputScript);
 
         co.rsk.bitcoinj.core.Sha256Hash sighash = releaseTx1.hashForSignature(0, redeemScript, BtcTransaction.SigHash.ALL, false);
 
-        for (int i = 0; i < genesisFederation.getNumberOfSignaturesRequired(); i++) {
+        for (int i = 0; i < activeFederation.getNumberOfSignaturesRequired(); i++) {
             BtcECKey federatorPrivKey = federationPrivateKeys.get(i);
-            BtcECKey federatorPublicKey = genesisFederation.getBtcPublicKeys().get(i);
+            BtcECKey federatorPublicKey = activeFederation.getBtcPublicKeys().get(i);
 
             BtcECKey.ECDSASignature sig = federatorPrivKey.sign(sighash);
             TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);
@@ -1734,7 +1736,7 @@ class BtcToRskClientTest {
         releaseInput1.setScriptSig(inputScript);
 
         // Verify it was properly signed
-        assertTrue(PegUtilsLegacy.isPegOutTx(releaseTx1, Collections.singletonList(genesisFederation), activations));
+        assertTrue(PegUtilsLegacy.isPegOutTx(releaseTx1, Collections.singletonList(activeFederation), activations));
 
         Transaction releaseTx = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString(), releaseTx1);
 
@@ -1766,7 +1768,7 @@ class BtcToRskClientTest {
         );
 
         // Assign Federation to BtcToRskClient
-        client.start(genesisFederation);
+        client.start(activeFederation);
 
         // Ensure tx is loaded and its proof is also loaded
         client.onTransaction(releaseTx);
@@ -1818,7 +1820,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1869,7 +1871,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1919,7 +1921,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1969,7 +1971,7 @@ class BtcToRskClientTest {
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2025,7 +2027,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2075,7 +2077,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(txWithoutOutputs);
@@ -2120,7 +2122,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(genesisFederation)
+            .withFederation(activeFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2523,7 +2525,7 @@ class BtcToRskClientTest {
             false,
             100
         );
-        btcToRskClient.start(genesisFederation);
+        btcToRskClient.start(activeFederation);
 
         return btcToRskClient;
     }
@@ -2557,7 +2559,7 @@ class BtcToRskClientTest {
     private Transaction createTransaction() {
         Transaction tx = new SimpleBtcTransaction(networkParameters, createHash(), createHash(), false);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, org.bitcoinj.script.ScriptBuilder.createInputScript(null, new ECKey()));
-        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, genesisFederation.getAddress().toBase58()));
+        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, activeFederation.getAddress().toBase58()));
 
         return tx;
     }
@@ -2565,7 +2567,7 @@ class BtcToRskClientTest {
     private Transaction createSegwitTransaction() {
         Transaction tx = new SimpleBtcTransaction(networkParameters, createHash(), createHash(), true);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, org.bitcoinj.script.ScriptBuilder.createInputScript(null, new ECKey()));
-        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, genesisFederation.getAddress().toBase58()));
+        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, activeFederation.getAddress().toBase58()));
 
         return tx;
     }

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -93,7 +93,7 @@ class BtcToRskClientTest {
     private int nhash = 0;
     private ActivationConfig activationConfig;
     private BridgeConstants bridgeRegTestConstants;
-    private Federation activeFederation;
+    private Federation genesisFederation;
     private FederationMember fakeMember;
     private BtcToRskClientBuilder btcToRskClientBuilder;
 
@@ -104,7 +104,7 @@ class BtcToRskClientTest {
         when(activationConfig.isActive(eq(ConsensusRule.RSKIP89), anyLong())).thenReturn(true);
 
         bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-        activeFederation = TestUtils.createFederation(bridgeRegTestConstants.getBtcParams(),1);
+        genesisFederation = TestUtils.getGenesisFederation(bridgeRegTestConstants);
         fakeMember = FederationMember.getFederationMemberFromKey(
             BtcECKey.fromPrivate(
                 HashUtil.keccak256("00".getBytes(StandardCharsets.UTF_8))
@@ -118,10 +118,10 @@ class BtcToRskClientTest {
         BitcoinWrapper bw = new SimpleBitcoinWrapper();
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
 
-        FederationMember fedMember = activeFederation.getMembers().get(0);
+        FederationMember fedMember = genesisFederation.getMembers().get(0);
         fh.setMember(fedMember);
         BtcToRskClient client = createClientWithMocks(bw, fh);
-        assertDoesNotThrow(() -> client.start(activeFederation));
+        assertDoesNotThrow(() -> client.start(genesisFederation));
     }
 
     @Test
@@ -131,7 +131,7 @@ class BtcToRskClientTest {
 
         fh.setMember(fakeMember);
         BtcToRskClient client = createClientWithMocks(bw, fh);
-        assertDoesNotThrow(() -> client.start(activeFederation));
+        assertDoesNotThrow(() -> client.start(genesisFederation));
     }
 
     @Test
@@ -139,7 +139,7 @@ class BtcToRskClientTest {
         BitcoinWrapper bw = new SimpleBitcoinWrapper();
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
         Federation federation = mock(Federation.class);
-        FederationMember fedMember = activeFederation.getMembers().get(0);
+        FederationMember fedMember = genesisFederation.getMembers().get(0);
 
         fh.setMember(fedMember);
         when(federation.isMember(fedMember)).thenReturn(true);
@@ -190,7 +190,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
     }
@@ -225,7 +225,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(fs)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcToRskClientFileStorage(btcToRskClientFileStorage)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
     }
 
@@ -815,7 +815,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -943,7 +943,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -986,7 +986,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1092,7 +1092,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1151,7 +1151,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1225,7 +1225,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1299,7 +1299,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(txWithProof1);
@@ -1357,7 +1357,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         for (Transaction tx : txs) {
@@ -1418,7 +1418,7 @@ class BtcToRskClientTest {
                 .withFederatorSupport(federatorSupport)
                 .withBridgeConstants(bridgeRegTestConstants)
                 .withBtcLockSenderProvider(btcLockSenderProvider)
-                .withFederation(activeFederation)
+                .withFederation(genesisFederation)
                 .build();
 
             client.onTransaction(tx);
@@ -1522,7 +1522,7 @@ class BtcToRskClientTest {
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1569,7 +1569,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1622,7 +1622,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1677,7 +1677,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1709,23 +1709,23 @@ class BtcToRskClientTest {
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);
         releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN, randomAddress);
-        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), activeFederation.getAddress()); // Change output
+        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), genesisFederation.getAddress()); // Change output
         co.rsk.bitcoinj.core.TransactionInput releaseInput1 =
                 new co.rsk.bitcoinj.core.TransactionInput(params, releaseTx1,
                         new byte[]{}, new co.rsk.bitcoinj.core.TransactionOutPoint(params, 0, co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH));
         releaseTx1.addInput(releaseInput1);
 
         // Sign it using the Federation members
-        co.rsk.bitcoinj.script.Script redeemScript = activeFederation.getRedeemScript();
+        co.rsk.bitcoinj.script.Script redeemScript = genesisFederation.getRedeemScript();
         co.rsk.bitcoinj.script.Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(
-            activeFederation);
+            genesisFederation);
         releaseInput1.setScriptSig(inputScript);
 
         co.rsk.bitcoinj.core.Sha256Hash sighash = releaseTx1.hashForSignature(0, redeemScript, BtcTransaction.SigHash.ALL, false);
 
-        for (int i = 0; i < activeFederation.getNumberOfSignaturesRequired(); i++) {
+        for (int i = 0; i < genesisFederation.getNumberOfSignaturesRequired(); i++) {
             BtcECKey federatorPrivKey = federationPrivateKeys.get(i);
-            BtcECKey federatorPublicKey = activeFederation.getBtcPublicKeys().get(i);
+            BtcECKey federatorPublicKey = genesisFederation.getBtcPublicKeys().get(i);
 
             BtcECKey.ECDSASignature sig = federatorPrivKey.sign(sighash);
             TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);
@@ -1736,7 +1736,8 @@ class BtcToRskClientTest {
         releaseInput1.setScriptSig(inputScript);
 
         // Verify it was properly signed
-        assertTrue(PegUtilsLegacy.isPegOutTx(releaseTx1, Collections.singletonList(activeFederation), activations));
+        assertTrue(PegUtilsLegacy.isPegOutTx(releaseTx1, Collections.singletonList(
+            genesisFederation), activations));
 
         Transaction releaseTx = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString(), releaseTx1);
 
@@ -1768,7 +1769,7 @@ class BtcToRskClientTest {
         );
 
         // Assign Federation to BtcToRskClient
-        client.start(activeFederation);
+        client.start(genesisFederation);
 
         // Ensure tx is loaded and its proof is also loaded
         client.onTransaction(releaseTx);
@@ -1820,7 +1821,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1871,7 +1872,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .withAmountOfHeadersToSend(amountOfHeadersToSend)
             .build();
 
@@ -1921,7 +1922,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -1971,7 +1972,7 @@ class BtcToRskClientTest {
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2027,7 +2028,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2077,7 +2078,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(txWithoutOutputs);
@@ -2122,7 +2123,7 @@ class BtcToRskClientTest {
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
             .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
+            .withFederation(genesisFederation)
             .build();
 
         client.onTransaction(tx);
@@ -2525,7 +2526,7 @@ class BtcToRskClientTest {
             false,
             100
         );
-        btcToRskClient.start(activeFederation);
+        btcToRskClient.start(genesisFederation);
 
         return btcToRskClient;
     }
@@ -2559,7 +2560,7 @@ class BtcToRskClientTest {
     private Transaction createTransaction() {
         Transaction tx = new SimpleBtcTransaction(networkParameters, createHash(), createHash(), false);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, org.bitcoinj.script.ScriptBuilder.createInputScript(null, new ECKey()));
-        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, activeFederation.getAddress().toBase58()));
+        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, genesisFederation.getAddress().toBase58()));
 
         return tx;
     }
@@ -2567,7 +2568,7 @@ class BtcToRskClientTest {
     private Transaction createSegwitTransaction() {
         Transaction tx = new SimpleBtcTransaction(networkParameters, createHash(), createHash(), true);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, org.bitcoinj.script.ScriptBuilder.createInputScript(null, new ECKey()));
-        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, activeFederation.getAddress().toBase58()));
+        tx.addOutput(Coin.COIN, Address.fromString(networkParameters, genesisFederation.getAddress().toBase58()));
 
         return tx;
     }

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -59,7 +59,7 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_validPegInTx() throws PeginInstructionsException {
         // Arrange
-        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),6);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),9);
         Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
@@ -103,7 +103,7 @@ class BitcoinWrapperImplTest {
         throws PeginInstructionsException {
 
         // Arrange
-        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),9);
         Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
@@ -148,7 +148,7 @@ class BitcoinWrapperImplTest {
         throws PeginInstructionsException {
 
         // Arrange
-        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),9);
         Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
@@ -189,8 +189,10 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_validPegOutTx() {
         // Arrange
-        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
-        Transaction pegOutTx = createPegOutTx(activeFederation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS);
+        final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+        final Context btcContext = new Context(ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString()));
+        final Federation genesisFederation = TestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Transaction pegOutTx = createPegOutTx(genesisFederation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS);
 
         BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
         PeginInstructionsProvider peginInstructionsProvider = mock(PeginInstructionsProvider.class);
@@ -200,7 +202,7 @@ class BitcoinWrapperImplTest {
 
         BitcoinWrapperImpl bitcoinWrapper = new BitcoinWrapperImpl(
             btcContext,
-            bridgeConstants,
+            bridgeRegTestConstants,
             btcLockSenderProvider,
             peginInstructionsProvider,
             federatorSupport,
@@ -211,7 +213,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(activeFederation, listener);
+        bitcoinWrapper.addFederationListener(genesisFederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegOutTx);
@@ -223,7 +225,7 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_txNotPegInNorPegOut() {
         // Arrange
-        final Federation activefederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
+        final Federation activefederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),9);
         Transaction tx = new Transaction(networkParameters);
 
         BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -13,7 +13,6 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.adapter.ThinConverter;
 import co.rsk.peg.federation.Federation;
@@ -103,7 +102,7 @@ class BitcoinWrapperImplTest {
         throws PeginInstructionsException {
 
         // Arrange
-        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),9);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), 9);
         Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
@@ -148,7 +147,7 @@ class BitcoinWrapperImplTest {
         throws PeginInstructionsException {
 
         // Arrange
-        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),9);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), 9);
         Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
@@ -189,10 +188,9 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_validPegOutTx() {
         // Arrange
-        final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-        final Context btcContext = new Context(ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString()));
-        final Federation genesisFederation = TestUtils.getGenesisFederation(bridgeRegTestConstants);
-        Transaction pegOutTx = createPegOutTx(genesisFederation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS);
+        final List<BtcECKey> federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), federationPrivateKeys);
+        final Transaction pegOutTx = createPegOutTx(activeFederation, federationPrivateKeys);
 
         BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
         PeginInstructionsProvider peginInstructionsProvider = mock(PeginInstructionsProvider.class);
@@ -202,7 +200,7 @@ class BitcoinWrapperImplTest {
 
         BitcoinWrapperImpl bitcoinWrapper = new BitcoinWrapperImpl(
             btcContext,
-            bridgeRegTestConstants,
+            bridgeConstants,
             btcLockSenderProvider,
             peginInstructionsProvider,
             federatorSupport,
@@ -213,7 +211,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(genesisFederation, listener);
+        bitcoinWrapper.addFederationListener(activeFederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegOutTx);

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -10,7 +10,9 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.adapter.ThinConverter;
@@ -49,7 +51,7 @@ class BitcoinWrapperImplTest {
 
     @BeforeAll
     public static void setUpBeforeClass() {
-        bridgeConstants = BridgeRegTestConstants.getInstance();
+        bridgeConstants = BridgeMainNetConstants.getInstance();
         networkParameters = ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString());
         btcContext = new Context(networkParameters);
     }
@@ -57,8 +59,8 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_validPegInTx() throws PeginInstructionsException {
         // Arrange
-        Federation federation = bridgeConstants.getGenesisFederation();
-        Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, federation.getAddress());
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),6);
+        Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
         BtcTransaction btcTx = ThinConverter.toThinInstance(bridgeConstants.getBtcParams(), pegInTx);
@@ -87,7 +89,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(federation, listener);
+        bitcoinWrapper.addFederationListener(activeFederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegInTx);
@@ -101,8 +103,8 @@ class BitcoinWrapperImplTest {
         throws PeginInstructionsException {
 
         // Arrange
-        Federation federation = bridgeConstants.getGenesisFederation();
-        Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, federation.getAddress());
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
+        Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
         BtcTransaction btcTx = ThinConverter.toThinInstance(bridgeConstants.getBtcParams(), pegInTx);
@@ -132,7 +134,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(federation, listener);
+        bitcoinWrapper.addFederationListener(activeFederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegInTx);
@@ -146,8 +148,8 @@ class BitcoinWrapperImplTest {
         throws PeginInstructionsException {
 
         // Arrange
-        Federation federation = bridgeConstants.getGenesisFederation();
-        Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, federation.getAddress());
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
+        Address federationAddress = ThinConverter.toOriginalInstance(networkParameters, activeFederation.getAddress());
 
         Transaction pegInTx = createPegInTx(federationAddress);
         BtcTransaction btcTx = ThinConverter.toThinInstance(bridgeConstants.getBtcParams(), pegInTx);
@@ -175,7 +177,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(federation, listener);
+        bitcoinWrapper.addFederationListener(activeFederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegInTx);
@@ -187,8 +189,8 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_validPegOutTx() {
         // Arrange
-        Federation federation = bridgeConstants.getGenesisFederation();
-        Transaction pegOutTx = createPegOutTx(federation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS);
+        final Federation activeFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
+        Transaction pegOutTx = createPegOutTx(activeFederation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS);
 
         BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
         PeginInstructionsProvider peginInstructionsProvider = mock(PeginInstructionsProvider.class);
@@ -209,7 +211,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(federation, listener);
+        bitcoinWrapper.addFederationListener(activeFederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegOutTx);
@@ -221,7 +223,7 @@ class BitcoinWrapperImplTest {
     @Test
     void coinsReceivedOrSent_txNotPegInNorPegOut() {
         // Arrange
-        Federation federation = bridgeConstants.getGenesisFederation();
+        final Federation activefederation = TestUtils.createFederation(bridgeConstants.getBtcParams(),1);
         Transaction tx = new Transaction(networkParameters);
 
         BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
@@ -243,7 +245,7 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.start();
 
         TransactionListener listener = mock(TransactionListener.class);
-        bitcoinWrapper.addFederationListener(federation, listener);
+        bitcoinWrapper.addFederationListener(activefederation, listener);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(tx);

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -62,7 +62,7 @@ class PowHSMSignerMessageBuilderTest {
         when(receiptStore.get(rskTxHash.getBytes(), Keccak256.ZERO_HASH.getBytes())).thenReturn(Optional.of(txInfo));
 
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),6);
+        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),9);
         BtcTransaction releaseTx = createReleaseTx(activeFederation);
         int inputIndex = 0;
 

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -14,7 +14,9 @@ import co.rsk.bitcoinj.core.TransactionInput;
 import co.rsk.bitcoinj.core.TransactionOutPoint;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.Script;
-import co.rsk.peg.constants.BridgeRegTestConstants;
+import co.rsk.federate.signing.utils.TestUtils;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.federation.Federation;
@@ -59,9 +61,9 @@ class PowHSMSignerMessageBuilderTest {
 
         when(receiptStore.get(rskTxHash.getBytes(), Keccak256.ZERO_HASH.getBytes())).thenReturn(Optional.of(txInfo));
 
-        BridgeRegTestConstants bridgeConstants = BridgeRegTestConstants.getInstance();
-        Federation federation = bridgeConstants.getGenesisFederation();
-        BtcTransaction releaseTx = createReleaseTx(federation);
+        final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
+        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),6);
+        BtcTransaction releaseTx = createReleaseTx(activeFederation);
         int inputIndex = 0;
 
         //Act
@@ -84,7 +86,7 @@ class PowHSMSignerMessageBuilderTest {
         for (int i = 0; i < encodedReceipts.length; i++) {
             encodedReceipts[i] = Hex.toHexString(receiptMerkleProof.get(i).toMessage());
         }
-        Sha256Hash sigHash = releaseTx.hashForSignature(0, federation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
+        Sha256Hash sigHash = releaseTx.hashForSignature(0, activeFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
 
         assertEquals(Hex.toHexString(releaseTx.bitcoinSerialize()), message.getBtcTransactionSerialized());
         assertEquals(inputIndex, message.getInputIndex());

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -62,7 +62,7 @@ class PowHSMSignerMessageBuilderTest {
         when(receiptStore.get(rskTxHash.getBytes(), Keccak256.ZERO_HASH.getBytes())).thenReturn(Optional.of(txInfo));
 
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),9);
+        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(), 9);
         BtcTransaction releaseTx = createReleaseTx(activeFederation);
         int inputIndex = 0;
 

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
@@ -9,7 +9,9 @@ import co.rsk.bitcoinj.core.TransactionInput;
 import co.rsk.bitcoinj.core.TransactionOutPoint;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.Script;
-import co.rsk.peg.constants.BridgeRegTestConstants;
+import co.rsk.federate.signing.utils.TestUtils;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.federation.Federation;
 import org.junit.jupiter.api.Test;
 
@@ -18,8 +20,8 @@ class SignerMessageBuilderV1Test {
     @Test
     void createHSMVersion1Message() {
         NetworkParameters params = RegTestParams.get();
-        BridgeRegTestConstants bridgeConstants = BridgeRegTestConstants.getInstance();
-        Federation federation = bridgeConstants.getGenesisFederation();
+        final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
+        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),6);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);
@@ -32,12 +34,12 @@ class SignerMessageBuilderV1Test {
         releaseTx1.addInput(releaseInput1);
 
         // Sign it using the Federation members
-        Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(federation);
+        Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(activeFederation);
         releaseInput1.setScriptSig(inputScript);
 
         Sha256Hash sigHash = releaseTx1.hashForSignature(
             0,
-            federation.getRedeemScript(),
+            activeFederation.getRedeemScript(),
             BtcTransaction.SigHash.ALL,
             false
         );

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
@@ -21,7 +21,7 @@ class SignerMessageBuilderV1Test {
     void createHSMVersion1Message() {
         NetworkParameters params = RegTestParams.get();
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),6);
+        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),9);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
@@ -21,7 +21,7 @@ class SignerMessageBuilderV1Test {
     void createHSMVersion1Message() {
         NetworkParameters params = RegTestParams.get();
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(),9);
+        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(), 9);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -15,6 +15,7 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
@@ -32,7 +33,10 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 
-public class TestUtils {
+public final class TestUtils {
+
+    private TestUtils() {
+    }
 
     public static Keccak256 createHash(int nHash) {
         byte[] bytes = new byte[32];
@@ -91,6 +95,15 @@ public class TestUtils {
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
         FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 0, params);
 
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
+    }
+
+    public static Federation getGenesisFederation(BridgeConstants bridgeConstants) {
+        final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
+        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
+        final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
+        final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
+        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -15,7 +15,6 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
@@ -25,6 +24,7 @@ import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,6 +34,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 
 public final class TestUtils {
+    private static final long CREATION_BLOCK_NUMBER = 0;
 
     private TestUtils() {
     }
@@ -93,18 +94,24 @@ public final class TestUtils {
     public static Federation createFederation(NetworkParameters params, int amountOfMembers) {
         List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(amountOfMembers).collect(Collectors.toList());
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), 0, params);
+        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
 
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
-    public static Federation getGenesisFederation(BridgeConstants bridgeConstants) {
-        final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
-        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
-        final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-        final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
-        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
+    public static Federation createFederation(NetworkParameters params, List<BtcECKey> federationPrivatekeys) {
+        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPrivatekeys);
+        FederationArgs federationArgs = new FederationArgs(federationMembers, Instant.now(), CREATION_BLOCK_NUMBER, params);
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
+    }
+
+    public static List<BtcECKey> getFederationPrivateKeys(int amountOfMembers) {
+        final int START_SEED_PRIVATE_KEY= 100;
+        List<BtcECKey> federationPrivateKeys = new ArrayList<>();
+        for (int i=1; i<=amountOfMembers;i++){
+            federationPrivateKeys.add(BtcECKey.fromPrivate(BigInteger.valueOf((long) i * START_SEED_PRIVATE_KEY)));
+        }
+        return federationPrivateKeys;
     }
 
     public static TransactionInput createTransactionInput(

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -106,7 +106,7 @@ public final class TestUtils {
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
-    public static List<BtcECKey> getFederationPrivateKeys(int amountOfMembers) {
+    public static List<BtcECKey> getFederationPrivateKeys(long amountOfMembers) {
         final long START_SEED_PRIVATE_KEY= 100;
         List<BtcECKey> federationPrivateKeys = new ArrayList<>();
         for (long i=1; i<=amountOfMembers;i++){

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -34,7 +34,6 @@ import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
 
 public final class TestUtils {
-    private static final long CREATION_BLOCK_NUMBER = 0;
 
     private TestUtils() {
     }
@@ -92,6 +91,7 @@ public final class TestUtils {
     }
 
     public static Federation createFederation(NetworkParameters params, int amountOfMembers) {
+        final long CREATION_BLOCK_NUMBER = 0;
         List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(amountOfMembers).collect(Collectors.toList());
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
         FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
@@ -100,16 +100,17 @@ public final class TestUtils {
     }
 
     public static Federation createFederation(NetworkParameters params, List<BtcECKey> federationPrivatekeys) {
+        final long CREATION_BLOCK_NUMBER = 0;
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPrivatekeys);
         FederationArgs federationArgs = new FederationArgs(federationMembers, Instant.now(), CREATION_BLOCK_NUMBER, params);
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     public static List<BtcECKey> getFederationPrivateKeys(int amountOfMembers) {
-        final int START_SEED_PRIVATE_KEY= 100;
+        final long START_SEED_PRIVATE_KEY= 100;
         List<BtcECKey> federationPrivateKeys = new ArrayList<>();
-        for (int i=1; i<=amountOfMembers;i++){
-            federationPrivateKeys.add(BtcECKey.fromPrivate(BigInteger.valueOf((long) i * START_SEED_PRIVATE_KEY)));
+        for (long i=1; i<=amountOfMembers;i++){
+            federationPrivateKeys.add(BtcECKey.fromPrivate(BigInteger.valueOf(i * START_SEED_PRIVATE_KEY)));
         }
         return federationPrivateKeys;
     }


### PR DESCRIPTION
## Description

- Modifying some tests in Powpeg Node related to the way how to get Genesis Federation to Remove Dependency Between BridgeConstants and Federation classes.

rskj:bridge-constants-refactor-integration