### PR TITLE
Allow pegout cache TTL to be loaded from configuration file

### DIFF
--- a/src/main/java/co/rsk/federate/config/FedNodeSystemProperties.java
+++ b/src/main/java/co/rsk/federate/config/FedNodeSystemProperties.java
@@ -3,6 +3,8 @@ package co.rsk.federate.config;
 import co.rsk.config.ConfigLoader;
 import co.rsk.config.RskSystemProperties;
 import com.typesafe.config.Config;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,5 +84,18 @@ public class FedNodeSystemProperties extends RskSystemProperties {
         return configFromFiles.hasPath("federator.pegoutStorageInitializationDepth") ?
             configFromFiles.getInt("federator.pegoutStorageInitializationDepth") :
             6_000;
+    }
+
+    /**
+     * Retrieves the time to live (TTL) duration for the pegout signed cache.
+     * The TTL duration specifies the validity period for cache entries.
+     * If the TTL value is not configured, a default value of 30 minutes is used.
+     * 
+     * @return The time to live (TTL) duration for the pegout signed cache,
+     *         or a default value of 30 minutes if not configured.
+     */
+    public Duration getPegoutSignedCacheTtl() {
+        return Duration.ofMinutes(
+            getInt("federator.pegoutSignedCacheTtl", 30));
     }
 }

--- a/src/main/java/co/rsk/federate/config/FedNodeSystemProperties.java
+++ b/src/main/java/co/rsk/federate/config/FedNodeSystemProperties.java
@@ -3,7 +3,6 @@ package co.rsk.federate.config;
 import co.rsk.config.ConfigLoader;
 import co.rsk.config.RskSystemProperties;
 import com.typesafe.config.Config;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/co/rsk/federate/config/FedNodeSystemProperties.java
+++ b/src/main/java/co/rsk/federate/config/FedNodeSystemProperties.java
@@ -95,6 +95,6 @@ public class FedNodeSystemProperties extends RskSystemProperties {
      */
     public Duration getPegoutSignedCacheTtl() {
         return Duration.ofMinutes(
-            getInt("federator.pegoutSignedCacheTtl", 30));
+            getInt("federator.pegoutSignedCacheTtlInMinutes", 30));
     }
 }

--- a/src/main/resources/config/fed-sample.conf
+++ b/src/main/resources/config/fed-sample.conf
@@ -46,4 +46,7 @@ federator {
 
     # Gas price to use for federate node transactions
     gasPrice = 1000
+
+    # Pegout signed cache ttl value to avoid signing the same pegout btc transaction
+    pegoutSignedCacheTtl = 30
 }

--- a/src/main/resources/config/fed-sample.conf
+++ b/src/main/resources/config/fed-sample.conf
@@ -48,5 +48,5 @@ federator {
     gasPrice = 1000
 
     # Pegout signed cache ttl value to avoid signing the same pegout btc transaction
-    pegoutSignedCacheTtl = 30
+    pegoutSignedCacheTtlInMinutes = 30
 }

--- a/src/test/java/co/rsk/federate/FedNodeSystemPropertiesTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeSystemPropertiesTest.java
@@ -150,8 +150,10 @@ class FedNodeSystemPropertiesTest {
     void getPegoutSignedCacheTtl_whenConfigurationPathExists_shouldUseCustomTtl() {
         int customTtlInMinutes = 10;
         when(configLoader.getConfig()).thenReturn(config);
-        when(config.hasPath("federator.pegoutSignedCacheTtl")).thenReturn(true);
-        when(config.getInt("federator.pegoutSignedCacheTtl")).thenReturn(customTtlInMinutes);
+        when(config.hasPath(
+            "federator.pegoutSignedCacheTtlInMinutes")).thenReturn(true);
+        when(config.getInt(
+            "federator.pegoutSignedCacheTtlInMinutes")).thenReturn(customTtlInMinutes);
         when(config.root()).thenReturn(configObject);
 
         FedNodeSystemProperties fedNodeSystemProperties = new FedNodeSystemProperties(configLoader);
@@ -165,7 +167,8 @@ class FedNodeSystemPropertiesTest {
     void getPegoutSignedCacheTtl_whenConfigurationPathDoesNotExist_shouldUseDefaultTtl() {
         int defaultTtlInMinutes = 30;
         when(configLoader.getConfig()).thenReturn(config);
-        when(config.hasPath("federator.pegoutSignedCacheTtl")).thenReturn(false);
+        when(config.hasPath(
+            "federator.pegoutSignedCacheTtlInMinutes")).thenReturn(false);
         when(config.root()).thenReturn(configObject);
 
         FedNodeSystemProperties fedNodeSystemProperties = new FedNodeSystemProperties(configLoader);

--- a/src/test/java/co/rsk/federate/FedNodeSystemPropertiesTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeSystemPropertiesTest.java
@@ -1,9 +1,12 @@
 package co.rsk.federate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.time.Duration;
 
 import co.rsk.config.ConfigLoader;
 import co.rsk.federate.config.FedNodeSystemProperties;
@@ -142,5 +145,34 @@ class FedNodeSystemPropertiesTest {
         FedNodeSystemProperties fedNodeSystemProperties = new FedNodeSystemProperties(configLoader);
 
         assertTrue(fedNodeSystemProperties.isUpdateBridgeTimerEnabled());
+    }
+
+    @Test
+    void getPegoutSignedCacheTtl_whenConfigurationPathExists_shouldUseCustomTtl() {
+        int customTtlInMinutes = 10;
+        when(configLoader.getConfig()).thenReturn(config);
+        when(config.hasPath("federator.pegoutSignedCacheTtl")).thenReturn(true);
+        when(config.getInt("federator.pegoutSignedCacheTtl")).thenReturn(customTtlInMinutes);
+        when(config.root()).thenReturn(configObject);
+
+        FedNodeSystemProperties fedNodeSystemProperties = new FedNodeSystemProperties(configLoader);
+
+        assertEquals(
+            Duration.ofMinutes(customTtlInMinutes),
+            fedNodeSystemProperties.getPegoutSignedCacheTtl());
+    }
+
+    @Test
+    void getPegoutSignedCacheTtl_whenConfigurationPathDoesNotExist_shouldUseDefaultTtl() {
+        int defaultTtlInMinutes = 30;
+        when(configLoader.getConfig()).thenReturn(config);
+        when(config.hasPath("federator.pegoutSignedCacheTtl")).thenReturn(false);
+        when(config.root()).thenReturn(configObject);
+
+        FedNodeSystemProperties fedNodeSystemProperties = new FedNodeSystemProperties(configLoader);
+
+        assertEquals(
+            Duration.ofMinutes(defaultTtlInMinutes),
+            fedNodeSystemProperties.getPegoutSignedCacheTtl());
     }
 }

--- a/src/test/java/co/rsk/federate/FedNodeSystemPropertiesTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeSystemPropertiesTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
-
 import co.rsk.config.ConfigLoader;
 import co.rsk.federate.config.FedNodeSystemProperties;
 import com.typesafe.config.Config;


### PR DESCRIPTION
### Summary

We noticed that in a period of 10 Rootstock blocks there are multiple unnecessary calls to add_signature Bridge method. This stresses the PowHSM devices, reducing their utility life. It also makes the pegnatories waste gas by doing unnecessary transactions.

The idea is to implement a caching mechanism that caches rsk pegout tx hashes and prevent double signing the same pegout.

This task focuses on getting the system properties from the configuration file. There should be a field for the pegout cache TTL.

### Test Plan

* Unit tests
* Tested locally to make sure the value is loaded as intended