### PR TITLE
Implement cache scheduler that performs periodic cleanup

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
@@ -38,7 +38,7 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
   public boolean hasAlreadyBeenSigned(Keccak256 pegoutCreationRskTxHash) {
     return Optional.ofNullable(pegoutCreationRskTxHash)
         .map(cache::get)
-        .map(this::hasTimestampNotExpired)
+        .map(this::isValidTimestamp)
         .orElse(false);
   }
 
@@ -57,12 +57,12 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
     logger.trace(
         "[performCleanup] Pegouts signed cache before cleanup: {}", cache.keySet());
     cache.entrySet().removeIf(
-        entry -> !hasTimestampNotExpired(entry.getValue()));
+        entry -> !isValidTimestamp(entry.getValue()));
     logger.trace(
         "[performCleanup] Pegouts signed cache after cleanup: {}", cache.keySet());
   }
 
-  private boolean hasTimestampNotExpired(Instant timestampInCache) {
+  private boolean isValidTimestamp(Instant timestampInCache) {
     return Optional.ofNullable(timestampInCache)
         .map(timestamp -> Instant.now().toEpochMilli() - timestamp.toEpochMilli())
         .map(timeCachedInMillis -> timeCachedInMillis <= ttl.toMillis())

--- a/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
@@ -54,8 +54,12 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
   }
 
   void performCleanup() {
+    logger.trace(
+        "[performCleanup] Pegouts signed cache before cleanup: {}", cache.keySet());
     cache.entrySet().removeIf(
         entry -> !hasTimestampNotExpired(entry.getValue()));
+    logger.trace(
+        "[performCleanup] Pegouts signed cache after cleanup: {}", cache.keySet());
   }
 
   private boolean hasTimestampNotExpired(Instant timestampInCache) {
@@ -70,7 +74,7 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
       Long ttlInMinutes = ttl != null ? ttl.toMinutes() : null;
       String message = String.format(
           "Invalid pegouts signed cache TTL value in minutes supplied: %d", ttlInMinutes);
-      logger.error("[assertValidTtl] {}", message);
+      logger.error("[validateTtl] {}", message);
 
       throw new IllegalArgumentException(message);
     }

--- a/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
@@ -22,14 +22,16 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
   private final Duration ttl;
 
   public PegoutSignedCacheImpl(Duration ttl) {
-    this.ttl = validateTtl(ttl);
+    validateTtl(ttl);
+    this.ttl = ttl;
 
     // Start a background thread for periodic cleanup
     cleanupScheduler.scheduleAtFixedRate(
         this::performCleanup,
         CLEANUP_INTERVAL_IN_HOURS, // initial delay
         CLEANUP_INTERVAL_IN_HOURS, // period
-        TimeUnit.HOURS);
+        TimeUnit.HOURS
+    );
   }
 
   @Override
@@ -63,7 +65,7 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
         .orElse(false);
   }
 
-  private Duration validateTtl(Duration ttl) {
+  private static void validateTtl(Duration ttl) {
     if (ttl == null || ttl.isNegative() || ttl.isZero()) {
       Long ttlInMinutes = ttl != null ? ttl.toMinutes() : null;
       String message = String.format(
@@ -72,7 +74,5 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
 
       throw new IllegalArgumentException(message);
     }
-    
-    return ttl;
   }
 }

--- a/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
@@ -6,20 +6,30 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class PegoutSignedCacheImpl implements PegoutSignedCache {
+public class PegoutSignedCacheImpl implements PegoutSignedCache {
 
   private static final Logger logger = LoggerFactory.getLogger(PegoutSignedCacheImpl.class);
+  private static final Integer CLEANUP_INTERVAL_IN_HOURS = 1;
 
   private final Map<Keccak256, Instant> cache = new ConcurrentHashMap<>();
+  private final ScheduledExecutorService cleanupScheduler = Executors.newSingleThreadScheduledExecutor();
   private final Duration ttl;
 
-  PegoutSignedCacheImpl(Duration ttl) {
-    assertValidTtl(ttl);
+  public PegoutSignedCacheImpl(Duration ttl) {
+    this.ttl = validateTtl(ttl);
 
-    this.ttl = ttl;
+    // Start a background thread for periodic cleanup
+    cleanupScheduler.scheduleAtFixedRate(
+        this::performCleanup,
+        CLEANUP_INTERVAL_IN_HOURS, // initial delay
+        CLEANUP_INTERVAL_IN_HOURS, // period
+        TimeUnit.HOURS);
   }
 
   @Override
@@ -41,6 +51,11 @@ class PegoutSignedCacheImpl implements PegoutSignedCache {
         .ifPresent(rskTxHash -> cache.putIfAbsent(rskTxHash, Instant.now()));
   }
 
+  void performCleanup() {
+    cache.entrySet().removeIf(
+        entry -> !hasTimestampNotExpired(entry.getValue()));
+  }
+
   private boolean hasTimestampNotExpired(Instant timestampInCache) {
     return Optional.ofNullable(timestampInCache)
         .map(timestamp -> Instant.now().toEpochMilli() - timestamp.toEpochMilli())
@@ -48,7 +63,7 @@ class PegoutSignedCacheImpl implements PegoutSignedCache {
         .orElse(false);
   }
 
-  private static void assertValidTtl(Duration ttl) {
+  private Duration validateTtl(Duration ttl) {
     if (ttl == null || ttl.isNegative() || ttl.isZero()) {
       Long ttlInMinutes = ttl != null ? ttl.toMinutes() : null;
       String message = String.format(
@@ -57,5 +72,7 @@ class PegoutSignedCacheImpl implements PegoutSignedCache {
 
       throw new IllegalArgumentException(message);
     }
+    
+    return ttl;
   }
 }

--- a/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
@@ -12,6 +12,7 @@ import co.rsk.federate.signing.utils.TestUtils;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +68,7 @@ class PegoutSignedCacheImplTest {
   @Test
   void hasAlreadyBeenSigned_shouldReturnFalse_whenCacheContainsExpiredTimestamp() {
     Instant currentTimestamp = Instant.now();
-    Instant expiredTimestamp = currentTimestamp.minusMillis(Duration.ofMinutes(60).toMillis());
+    Instant expiredTimestamp = currentTimestamp.minus(60, ChronoUnit.MINUTES);
     cache.put(PEGOUT_CREATION_RSK_HASH, expiredTimestamp);
 
     boolean result = pegoutSignedCache.hasAlreadyBeenSigned(PEGOUT_CREATION_RSK_HASH);
@@ -78,7 +79,7 @@ class PegoutSignedCacheImplTest {
   @Test
   void hasAlreadyBeenSigned_shouldReturnTrue_whenCacheContainsNotExpiredTimestamp() {
     Instant currentTimestamp = Instant.now();
-    Instant notExpiredTimestamp = currentTimestamp.minusMillis(Duration.ofMinutes(10).toMillis());
+    Instant notExpiredTimestamp = currentTimestamp.minus(10, ChronoUnit.MINUTES);
     cache.put(PEGOUT_CREATION_RSK_HASH, notExpiredTimestamp);
 
     boolean result = pegoutSignedCache.hasAlreadyBeenSigned(PEGOUT_CREATION_RSK_HASH);
@@ -138,10 +139,8 @@ class PegoutSignedCacheImplTest {
 
     // put an expired and not expired timestamp in the cache
     Instant currentTimestamp = Instant.now();
-    Instant notExpiredTimestamp = currentTimestamp.minusMillis(
-        Duration.ofMinutes(10).toMillis());
-    Instant expiredTimestamp = currentTimestamp.minusMillis(
-        Duration.ofMinutes(60).toMillis());
+    Instant notExpiredTimestamp = currentTimestamp.minus(10, ChronoUnit.MINUTES);
+    Instant expiredTimestamp = currentTimestamp.minus(60, ChronoUnit.MINUTES);
     Keccak256 otherPegoutCreationRskHash = TestUtils.createHash(2);
     cache.put(PEGOUT_CREATION_RSK_HASH, notExpiredTimestamp);
     cache.put(otherPegoutCreationRskHash, expiredTimestamp);

--- a/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
@@ -66,10 +66,10 @@ class PegoutSignedCacheImplTest {
   }
 
   @Test
-  void hasAlreadyBeenSigned_shouldReturnFalse_whenCacheContainsExpiredTimestamp() {
+  void hasAlreadyBeenSigned_shouldReturnFalse_whenCacheContainsInvalidTimestamp() {
     Instant currentTimestamp = Instant.now();
-    Instant expiredTimestamp = currentTimestamp.minus(60, ChronoUnit.MINUTES);
-    cache.put(PEGOUT_CREATION_RSK_HASH, expiredTimestamp);
+    Instant invalidTimestamp = currentTimestamp.minus(60, ChronoUnit.MINUTES);
+    cache.put(PEGOUT_CREATION_RSK_HASH, invalidTimestamp);
 
     boolean result = pegoutSignedCache.hasAlreadyBeenSigned(PEGOUT_CREATION_RSK_HASH);
 
@@ -77,10 +77,10 @@ class PegoutSignedCacheImplTest {
   }
 
   @Test
-  void hasAlreadyBeenSigned_shouldReturnTrue_whenCacheContainsNotExpiredTimestamp() {
+  void hasAlreadyBeenSigned_shouldReturnTrue_whenCacheContainsValidTimestamp() {
     Instant currentTimestamp = Instant.now();
-    Instant notExpiredTimestamp = currentTimestamp.minus(10, ChronoUnit.MINUTES);
-    cache.put(PEGOUT_CREATION_RSK_HASH, notExpiredTimestamp);
+    Instant validTimestamp = currentTimestamp.minus(10, ChronoUnit.MINUTES);
+    cache.put(PEGOUT_CREATION_RSK_HASH, validTimestamp);
 
     boolean result = pegoutSignedCache.hasAlreadyBeenSigned(PEGOUT_CREATION_RSK_HASH);
 
@@ -130,20 +130,20 @@ class PegoutSignedCacheImplTest {
   }
 
   @Test
-  void performCleanup_shouldRemoveOnlyExpiredPegouts_whenPerformCleanupIsTriggered() throws Exception {
+  void performCleanup_shouldRemoveOnlyInvalidPegouts_whenPerformCleanupIsTriggered() throws Exception {
     // setup cache
     PegoutSignedCacheImpl pegoutSignedCacheImpl = new PegoutSignedCacheImpl(DEFAULT_TTL);
     Field field = pegoutSignedCacheImpl.getClass().getDeclaredField("cache");
     field.setAccessible(true);
     field.set(pegoutSignedCacheImpl, cache);
 
-    // put an expired and not expired timestamp in the cache
+    // put a valid and invalid timestamp in the cache
     Instant currentTimestamp = Instant.now();
-    Instant notExpiredTimestamp = currentTimestamp.minus(10, ChronoUnit.MINUTES);
-    Instant expiredTimestamp = currentTimestamp.minus(60, ChronoUnit.MINUTES);
+    Instant validTimestamp = currentTimestamp.minus(10, ChronoUnit.MINUTES);
+    Instant notValidTimestamp = currentTimestamp.minus(60, ChronoUnit.MINUTES);
     Keccak256 otherPegoutCreationRskHash = TestUtils.createHash(2);
-    cache.put(PEGOUT_CREATION_RSK_HASH, notExpiredTimestamp);
-    cache.put(otherPegoutCreationRskHash, expiredTimestamp);
+    cache.put(PEGOUT_CREATION_RSK_HASH, validTimestamp);
+    cache.put(otherPegoutCreationRskHash, notValidTimestamp);
 
     // trigger cleanup
     pegoutSignedCacheImpl.performCleanup();


### PR DESCRIPTION
### Summary

We noticed that in a period of 10 Rootstock blocks there are multiple unnecessary calls to add_signature Bridge method. This stresses the PowHSM devices, reducing their utility life. It also makes the pegnatories waste gas by doing unnecessary transactions.

The idea of this PR is to implement a scheduler that performs a periodic cleanup.

### Test Plan

* Unit tests