### PR TITLE
Add java.time.Clock to Pegouts Signed Cache

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -37,6 +37,7 @@ import co.rsk.peg.BridgeUtils;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.ErpFederation;
 import co.rsk.peg.StateForFederator;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -116,7 +117,7 @@ public class BtcReleaseClient {
         this.isPegoutEnabled = systemProperties.isPegoutEnabled();
         this.nodeBlockProcessor = nodeBlockProcessor;
         this.pegoutSignedCache = new PegoutSignedCacheImpl(
-            systemProperties.getPegoutSignedCacheTtl());
+            systemProperties.getPegoutSignedCacheTtl(), Clock.systemUTC());
     }
 
     public void setup(
@@ -146,7 +147,7 @@ public class BtcReleaseClient {
         }
         peerGroup.start();
 
-        blockListener = new BtcReleaseEthereumListener();
+        this.blockListener = new BtcReleaseEthereumListener();
         this.signerMessageBuilderFactory = signerMessageBuilderFactory;
         this.releaseCreationInformationGetter = pegoutCreationInformationGetter;
         this.releaseRequirementsEnforcer = releaseRequirementsEnforcer;

--- a/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImpl.java
@@ -25,8 +25,8 @@ public class PegoutSignedCacheImpl implements PegoutSignedCache {
 
   public PegoutSignedCacheImpl(Duration ttl, Clock clock) {
     validateTtl(ttl);
-    this.ttl = ttl;
 
+    this.ttl = ttl;
     this.clock = clock;
 
     // Start a background thread for periodic cleanup

--- a/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +29,7 @@ class PegoutSignedCacheImplTest {
   private static final Keccak256 PEGOUT_CREATION_RSK_HASH = TestUtils.createHash(1);
 
   private final Map<Keccak256, Instant> cache = new ConcurrentHashMap<>();
-  private final Clock clock = Clock.systemUTC();
+  private final Clock clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
   private final PegoutSignedCache pegoutSignedCache = new PegoutSignedCacheImpl(DEFAULT_TTL, clock);
 
   @BeforeEach
@@ -93,9 +94,9 @@ class PegoutSignedCacheImplTest {
   void putIfAbsent_shouldThrowIllegalArgumentException_whenPegoutCreationRskTxHashIsNull() {
     Keccak256 pegoutCreationRskTxHash = null;
 
-    assertEquals(0, cache.size());
     assertThrows(IllegalArgumentException.class,
         () -> pegoutSignedCache.putIfAbsent(pegoutCreationRskTxHash));
+    assertEquals(0, cache.size());
   }
 
   @Test
@@ -110,25 +111,21 @@ class PegoutSignedCacheImplTest {
   void putIfAbsent_shouldPutInCacheBoth_whenPegoutCreationRskTxHashAreNotSame() {
     // first insert
     pegoutSignedCache.putIfAbsent(PEGOUT_CREATION_RSK_HASH);
-    Instant pegoutCreationRskTxHashTimestamp = cache.get(PEGOUT_CREATION_RSK_HASH);
     // second insert
     Keccak256 otherPegoutCreationRskTxHash = TestUtils.createHash(2);
     pegoutSignedCache.putIfAbsent(otherPegoutCreationRskTxHash);
-    Instant otherPegoutCreationRskTxHashTimestamp = cache.get(otherPegoutCreationRskTxHash);
 
-    assertNotSame(pegoutCreationRskTxHashTimestamp, otherPegoutCreationRskTxHashTimestamp);
+    assertEquals(2, cache.size());
   }
 
   @Test
   void putIfAbsent_shouldPutInCacheOnce_whenPegoutCreationRskTxHashIsTheSame() {
     // first insert
     pegoutSignedCache.putIfAbsent(PEGOUT_CREATION_RSK_HASH);
-    Instant pegoutCreationRskTxHashTimestamp1 = cache.get(PEGOUT_CREATION_RSK_HASH);
     // second insert
     pegoutSignedCache.putIfAbsent(PEGOUT_CREATION_RSK_HASH);
-    Instant pegoutCreationRskTxHashTimestamp2 = cache.get(PEGOUT_CREATION_RSK_HASH);
 
-    assertSame(pegoutCreationRskTxHashTimestamp1, pegoutCreationRskTxHashTimestamp2);
+    assertEquals(1, cache.size());
   }
 
   @Test

--- a/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/cache/PegoutSignedCacheImplTest.java
@@ -2,8 +2,6 @@ package co.rsk.federate.btcreleaseclient.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
### Summary

Start using java.time.Clock for granular time manipulation. 

### Test Plan

Remove need for sleeping main thread by updating unit test. 