### PR TITLE
Refactor PowHSMBookkeepingConfig and Add missing test coverage 

### DIFF
--- a/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
+++ b/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
@@ -9,7 +9,7 @@ public class PowHSMBookkeepingConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(PowHSMBookkeepingConfig.class);
 
-    enum NetworkDifficultyCap {
+    public enum NetworkDifficultyCap {
         MAINNET(new BigInteger("7000000000000000000000")),
         TESTNET(BigInteger.valueOf(1000000000000000L)),
         REGTEST(BigInteger.valueOf(20L));
@@ -20,7 +20,7 @@ public class PowHSMBookkeepingConfig {
             this.difficultyCap = difficultyCap;
         }
 
-        BigInteger getDifficultyCap() {
+        public BigInteger getDifficultyCap() {
             return difficultyCap;
         }
     }

--- a/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
+++ b/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
@@ -1,13 +1,12 @@
 package co.rsk.federate.config;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
+import com.typesafe.config.Config;
 import java.math.BigInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PowHSMBookkeepingConfig {
-
-    private static final Logger logger = LoggerFactory.getLogger(PowHSMBookkeepingConfig.class);
 
     public enum NetworkDifficultyCap {
         MAINNET(new BigInteger("7000000000000000000000")),
@@ -25,48 +24,59 @@ public class PowHSMBookkeepingConfig {
         }
     }
 
-    private static final BigInteger DEFAULT_DIFFICULTY_TARGET = BigInteger.valueOf(3);
-    private static final boolean DEFAULT_STOP_BOOKKEPING_SCHEDULER = false;
-    private static final int DEFAULT_MAX_AMOUNT_BLOCK_HEADERS = 7;
-    private static final int DEFAULT_MAX_CHUNK_SIZE = 10;
-    private static final long DEFAULT_INFORMER_INTERVAL = 2_000;
+    private static final Logger logger = LoggerFactory.getLogger(PowHSMBookkeepingConfig.class);
 
-    private final SignerConfig signerConfig;
+    private static final String DIFFICULTY_TARGET_PATH = "bookkeeping.difficultyTarget";
+    private static final BigInteger DIFFICULTY_TARGET_DEFAULT = BigInteger.valueOf(3);
+
+    private static final String MAX_AMOUNT_BLOCK_HEADERS_PATH = "bookkeeping.maxAmountBlockHeaders";
+    private static final int MAX_AMOUNT_BLOCK_HEADERS_DEFAULT = 7;
+
+    private static final String MAX_CHUNK_SIZE_TO_HSM_PATH = "bookkeeping.maxChunkSizeToHsm";
+    private static final int MAX_CHUNK_SIZE_TO_HSM_DEFAULT = 10;
+
+    private static final String INFORMER_INTERVAL_PATH = "bookkeeping.informerInterval";
+    private static final long INFORMER_INTERVAL_DEFAULT = 2_000;
+
+    private static final String STOP_BOOKKEPING_SCHEDULER_PATH = "bookkeeping.stopBookkeepingScheduler";
+    private static final boolean STOP_BOOKKEPING_SCHEDULER_DEFAULT = false;
+
+    private final Config signerConfig;
     private final String networkParameter;
 
     public PowHSMBookkeepingConfig(SignerConfig signerConfig, String networkParameter) {
-        this.signerConfig = signerConfig;
+        this.signerConfig = signerConfig.getConfig();
         this.networkParameter = networkParameter;
     }
 
     public BigInteger getDifficultyTarget() {
-        return signerConfig.getConfig().hasPath("bookkeeping.difficultyTarget")
-            ? new BigInteger(signerConfig.getConfig().getString("bookkeeping.difficultyTarget"))
-            : DEFAULT_DIFFICULTY_TARGET;
+        return signerConfig.hasPath(DIFFICULTY_TARGET_PATH)
+            ? new BigInteger(signerConfig.getString(DIFFICULTY_TARGET_PATH))
+            : DIFFICULTY_TARGET_DEFAULT;
     }
 
     public int getMaxAmountBlockHeaders() {
-        return signerConfig.getConfig().hasPath("bookkeeping.maxAmountBlockHeaders")
-            ? signerConfig.getConfig().getInt("bookkeeping.maxAmountBlockHeaders")
-            : DEFAULT_MAX_AMOUNT_BLOCK_HEADERS;
+        return signerConfig.hasPath(MAX_AMOUNT_BLOCK_HEADERS_PATH)
+            ? signerConfig.getInt(MAX_AMOUNT_BLOCK_HEADERS_PATH)
+            : MAX_AMOUNT_BLOCK_HEADERS_DEFAULT;
     }
 
     public long getInformerInterval() {
-        return signerConfig.getConfig().hasPath("bookkeeping.informerInterval")
-            ? signerConfig.getConfig().getLong("bookkeeping.informerInterval")
-            : DEFAULT_INFORMER_INTERVAL;
+        return signerConfig.hasPath(INFORMER_INTERVAL_PATH)
+            ? signerConfig.getLong(INFORMER_INTERVAL_PATH)
+            : INFORMER_INTERVAL_DEFAULT;
     }
 
     public boolean isStopBookkeepingScheduler() {
-        return signerConfig.getConfig().hasPath("bookkeeping.stopBookkeepingScheduler")
-            ? signerConfig.getConfig().getBoolean("bookkeeping.stopBookkeepingScheduler")
-            : DEFAULT_STOP_BOOKKEPING_SCHEDULER;
+        return signerConfig.hasPath(STOP_BOOKKEPING_SCHEDULER_PATH)
+            ? signerConfig.getBoolean(STOP_BOOKKEPING_SCHEDULER_PATH)
+            : STOP_BOOKKEPING_SCHEDULER_DEFAULT;
     }
 
     public int getMaxChunkSizeToHsm() {
-        return signerConfig.getConfig().hasPath("bookkeeping.maxChunkSizeToHsm")
-            ? signerConfig.getConfig().getInt("bookkeeping.maxChunkSizeToHsm")
-            : DEFAULT_MAX_CHUNK_SIZE;
+        return signerConfig.hasPath(MAX_CHUNK_SIZE_TO_HSM_PATH)
+            ? signerConfig.getInt(MAX_CHUNK_SIZE_TO_HSM_PATH)
+            : MAX_CHUNK_SIZE_TO_HSM_DEFAULT;
     }
 
     public BigInteger getDifficultyCap() {

--- a/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
+++ b/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
@@ -1,87 +1,86 @@
 package co.rsk.federate.config;
 
-/**
- * Represents the configuration for a signer.
- * Mainly has an identifier for the signer, the
- * type of signer and additional configuration options.
- *
- * @author Pamela Gonzalez
- */
-
 import co.rsk.bitcoinj.core.NetworkParameters;
+import java.math.BigInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.math.BigInteger;
 
 public class PowHSMBookkeepingConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(PowHSMBookkeepingConfig.class);
-    public static final BigInteger DIFFICULTY_CAP_MAINNET = new BigInteger("7000000000000000000000");
-    public static final BigInteger DIFFICULTY_CAP_TESTNET = BigInteger.valueOf(1000000000000000L);
-    public static final BigInteger DIFFICULTY_CAP_REGTEST = BigInteger.valueOf(20);
-    private final BigInteger difficultyCap;
-    private BigInteger difficultyTarget = BigInteger.valueOf(3);
-    private int maxAmountBlockHeaders = 7;
-    private long informerInterval = 2_000;
-    private boolean stopBookkeepingScheduler = false;
-    private int maxChunkSizeToHsm = 10;
+
+    enum NetworkDifficultyCap {
+        MAINNET(new BigInteger("7000000000000000000000")),
+        TESTNET(BigInteger.valueOf(1000000000000000L)),
+        REGTEST(BigInteger.valueOf(20L));
+
+        private final BigInteger difficultyCap;
+
+        NetworkDifficultyCap(BigInteger difficultyCap) {
+            this.difficultyCap = difficultyCap;
+        }
+
+        BigInteger getDifficultyCap() {
+            return difficultyCap;
+        }
+    }
+
+    private static final BigInteger DEFAULT_DIFFICULTY_TARGET = BigInteger.valueOf(3);
+    private static final boolean DEFAULT_STOP_BOOKKEPING_SCHEDULER = false;
+    private static final int DEFAULT_MAX_AMOUNT_BLOCK_HEADERS = 7;
+    private static final int DEFAULT_MAX_CHUNK_SIZE = 10;
+    private static final long DEFAULT_INFORMER_INTERVAL = 2_000;
+
+    private final SignerConfig signerConfig;
+    private final String networkParameter;
 
     public PowHSMBookkeepingConfig(SignerConfig signerConfig, String networkParameter) {
-        if (signerConfig.getConfig().hasPath("bookkeeping.difficultyTarget")) {
-            this.difficultyTarget = new BigInteger(signerConfig.getConfig().getString("bookkeeping.difficultyTarget"));
-        }
-        if (signerConfig.getConfig().hasPath("bookkeeping.maxAmountBlockHeaders")) {
-            this.maxAmountBlockHeaders = signerConfig.getConfig().getInt("bookkeeping.maxAmountBlockHeaders");
-        }
-        if (signerConfig.getConfig().hasPath("bookkeeping.informerInterval")) {
-            this.informerInterval = signerConfig.getConfig().getLong("bookkeeping.informerInterval");
-        }
-        if (signerConfig.getConfig().hasPath("bookkeeping.stopBookkeepingScheduler")) {
-            this.stopBookkeepingScheduler = signerConfig.getConfig().getBoolean("bookkeeping.stopBookkeepingScheduler");
-        }
-        if (signerConfig.getConfig().hasPath("bookkeeping.maxChunkSizeToHsm")) {
-            this.maxChunkSizeToHsm = signerConfig.getConfig().getInt("bookkeeping.maxChunkSizeToHsm");
-        }
+        this.signerConfig = signerConfig;
+        this.networkParameter = networkParameter;
+    }
 
+    public BigInteger getDifficultyTarget() {
+        return signerConfig.getConfig().hasPath("bookkeeping.difficultyTarget")
+            ? new BigInteger(signerConfig.getConfig().getString("bookkeeping.difficultyTarget"))
+            : DEFAULT_DIFFICULTY_TARGET;
+    }
+
+    public int getMaxAmountBlockHeaders() {
+        return signerConfig.getConfig().hasPath("bookkeeping.maxAmountBlockHeaders")
+            ? signerConfig.getConfig().getInt("bookkeeping.maxAmountBlockHeaders")
+            : DEFAULT_MAX_AMOUNT_BLOCK_HEADERS;
+    }
+
+    public long getInformerInterval() {
+        return signerConfig.getConfig().hasPath("bookkeeping.informerInterval")
+            ? signerConfig.getConfig().getLong("bookkeeping.informerInterval")
+            : DEFAULT_INFORMER_INTERVAL;
+    }
+
+    public boolean isStopBookkeepingScheduler() {
+        return signerConfig.getConfig().hasPath("bookkeeping.stopBookkeepingScheduler")
+            ? signerConfig.getConfig().getBoolean("bookkeeping.stopBookkeepingScheduler")
+            : DEFAULT_STOP_BOOKKEPING_SCHEDULER;
+    }
+
+    public int getMaxChunkSizeToHsm() {
+        return signerConfig.getConfig().hasPath("bookkeeping.maxChunkSizeToHsm")
+            ? signerConfig.getConfig().getInt("bookkeeping.maxChunkSizeToHsm")
+            : DEFAULT_MAX_CHUNK_SIZE;
+    }
+
+    public BigInteger getDifficultyCap() {
         switch (networkParameter) {
             case NetworkParameters.ID_MAINNET:
-                this.difficultyCap = DIFFICULTY_CAP_MAINNET;
-                break;
+                return NetworkDifficultyCap.MAINNET.getDifficultyCap();
             case NetworkParameters.ID_TESTNET:
-                this.difficultyCap = DIFFICULTY_CAP_TESTNET;
-                break;
+                return NetworkDifficultyCap.TESTNET.getDifficultyCap();
             case NetworkParameters.ID_REGTEST:
-                this.difficultyCap = DIFFICULTY_CAP_REGTEST;
-                break;
+                return NetworkDifficultyCap.REGTEST.getDifficultyCap();
             default:
                 String message = "Invalid network specified for the Bookkeeping Config: " + networkParameter;
                 logger.error(message);
                 throw new IllegalArgumentException(message);
         }
-    }
-
-    public BigInteger getDifficultyTarget() {
-        return difficultyTarget;
-    }
-
-    public int getMaxAmountBlockHeaders() {
-        return maxAmountBlockHeaders;
-    }
-
-    public long getInformerInterval() {
-        return informerInterval;
-    }
-
-    public boolean isStopBookkeepingScheduler() {
-        return stopBookkeepingScheduler;
-    }
-
-    public int getMaxChunkSizeToHsm() {
-        return maxChunkSizeToHsm;
-    }
-
-    public BigInteger getDifficultyCap() {
-        return difficultyCap;
     }
 }

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -120,19 +120,18 @@ class PowHSMBookkeepingConfigTest {
     @MethodSource("provideNetworkParametersAndExpectedCaps")
     void getDifficultyCap_whenGivenNetwork_shouldMatchExpectedDifficultyCap(String networkId,
           NetworkDifficultyCap expectedNetworkDifficultyCap) {
-        PowHSMBookkeepingConfig powHsmBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfig, networkId);
+        PowHSMBookkeepingConfig powHSMBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfig, networkId);
 
         assertEquals(expectedNetworkDifficultyCap.getDifficultyCap(),
-            powHsmBookkeepingConfig.getDifficultyCap());
+            powHSMBookkeepingConfig.getDifficultyCap());
     }
 
     @Test
     void getDifficultyCap_whenGivenInvalidNetwork_showThrowIllegalArgumentException() {
-        PowHSMBookkeepingConfig powHsmBookkeepingConfig =
+        PowHSMBookkeepingConfig powHSMBookkeepingConfig =
             new PowHSMBookkeepingConfig(signerConfig, NetworkParameters.ID_UNITTESTNET);
 
-        assertThrows(IllegalArgumentException.class,
-            () -> powHsmBookkeepingConfig.getDifficultyCap());
+        assertThrows(IllegalArgumentException.class, powHSMBookkeepingConfig::getDifficultyCap);
     }
 
     static Stream<Arguments> provideNetworkParametersAndExpectedCaps() {

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -1,57 +1,145 @@
 package co.rsk.federate.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.federate.config.PowHSMBookkeepingConfig.NetworkDifficultyCap;
 import com.typesafe.config.Config;
+import java.math.BigInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-/**
- * Test class for PowHSMBookkeepingConfig.
- *
- * @author kelvin.isievwore
- */
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class PowHSMBookkeepingConfigTest {
 
+    private static final BigInteger DEFAULT_DIFFICULTY_TARGET = BigInteger.valueOf(3);
+    private static final boolean DEFAULT_STOP_BOOKKEPING_SCHEDULER = false;
+    private static final int DEFAULT_MAX_AMOUNT_BLOCK_HEADERS = 7;
+    private static final int DEFAULT_MAX_CHUNK_SIZE = 10;
+    private static final long DEFAULT_INFORMER_INTERVAL = 2_000;
+
     private PowHSMBookkeepingConfig powHsmBookkeepingConfig;
-    private SignerConfig signerConfigMock;
-    private Config configMock;
+    private SignerConfig signerConfig = mock(SignerConfig.class);
+    private Config config = mock(Config.class);
 
     @BeforeEach
     void setup() {
-        signerConfigMock = mock(SignerConfig.class);
-        configMock = mock(Config.class);
+        when(signerConfig.getConfig()).thenReturn(config);
+        powHsmBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfig, NetworkParameters.ID_MAINNET);
     }
 
     @Test
-    void testGetDifficultyCapForMainnet() {
-        when(signerConfigMock.getConfig()).thenReturn(configMock);
-        powHsmBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfigMock, NetworkParameters.ID_MAINNET);
-        assertEquals(PowHSMBookkeepingConfig.DIFFICULTY_CAP_MAINNET, powHsmBookkeepingConfig.getDifficultyCap());
+    void getDifficultyTarget_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+        BigInteger customDifficultyTarget = BigInteger.valueOf(1L); 
+        when(config.hasPath("bookkeeping.difficultyTarget")).thenReturn(true);
+        when(config.getString("bookkeeping.difficultyTarget")).thenReturn("1");
+
+        assertEquals(customDifficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget());
     }
 
     @Test
-    void testGetDifficultyCapForTestnet() {
-        when(signerConfigMock.getConfig()).thenReturn(configMock);
-        powHsmBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfigMock, NetworkParameters.ID_TESTNET);
-        assertEquals(PowHSMBookkeepingConfig.DIFFICULTY_CAP_TESTNET, powHsmBookkeepingConfig.getDifficultyCap());
+    void getDifficultyTarget_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath("bookkeeping.difficultyTarget")).thenReturn(false);
+
+        assertEquals(DEFAULT_DIFFICULTY_TARGET, powHsmBookkeepingConfig.getDifficultyTarget());
     }
 
     @Test
-    void testGetDifficultyCapForRegtest() {
-        when(signerConfigMock.getConfig()).thenReturn(configMock);
-        powHsmBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfigMock, NetworkParameters.ID_REGTEST);
-        assertEquals(PowHSMBookkeepingConfig.DIFFICULTY_CAP_REGTEST, powHsmBookkeepingConfig.getDifficultyCap());
+    void getMaxAmountBlockHeaders_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+        int customMaxAmountBlockHeaders = 1; 
+        when(config.hasPath("bookkeeping.maxAmountBlockHeaders")).thenReturn(true);
+        when(config.getInt("bookkeeping.maxAmountBlockHeaders")).thenReturn(customMaxAmountBlockHeaders);
+
+        assertEquals(customMaxAmountBlockHeaders, powHsmBookkeepingConfig.getMaxAmountBlockHeaders());
     }
 
     @Test
-    void testGetDifficultyCapForInvalidNetwork() {
-        when(signerConfigMock.getConfig()).thenReturn(configMock);
-        assertThrows(IllegalArgumentException.class, () -> new PowHSMBookkeepingConfig(signerConfigMock, NetworkParameters.ID_UNITTESTNET));
+    void getMaxAmountBlockHeaders_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath("bookkeeping.maxAmountBlockHeaders")).thenReturn(false);
+
+        assertEquals(DEFAULT_MAX_AMOUNT_BLOCK_HEADERS, powHsmBookkeepingConfig.getMaxAmountBlockHeaders());
+    }
+
+    @Test
+    void getMaxChunkSizeToHsm_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+        int customMaxChunkSize = 1; 
+        when(config.hasPath("bookkeeping.maxChunkSizeToHsm")).thenReturn(true);
+        when(config.getInt("bookkeeping.maxChunkSizeToHsm")).thenReturn(customMaxChunkSize);
+
+        assertEquals(customMaxChunkSize, powHsmBookkeepingConfig.getMaxChunkSizeToHsm());
+    }
+
+    @Test
+    void getMaxChunkSizeToHsm_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath("bookkeeping.maxChunkSizeToHsm")).thenReturn(false);
+
+        assertEquals(DEFAULT_MAX_CHUNK_SIZE, powHsmBookkeepingConfig.getMaxChunkSizeToHsm());
+    }
+
+    @Test
+    void getInformerInterval_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+        long customInformerInterval = 1L; 
+        when(config.hasPath("bookkeeping.informerInterval")).thenReturn(true);
+        when(config.getLong("bookkeeping.informerInterval")).thenReturn(customInformerInterval);
+
+        assertEquals(customInformerInterval, powHsmBookkeepingConfig.getInformerInterval());
+    }
+
+    @Test
+    void getInformerInterval_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath("bookkeeping.informerInterval")).thenReturn(false);
+
+        assertEquals(DEFAULT_INFORMER_INTERVAL, powHsmBookkeepingConfig.getInformerInterval());
+    }
+
+    @Test
+    void isStoppingBookkepingScheduler_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+        boolean customIsStoppingInformerInterval = !DEFAULT_STOP_BOOKKEPING_SCHEDULER; 
+        when(config.hasPath("bookkeeping.stopBookkeepingScheduler")).thenReturn(true);
+        when(config.getBoolean("bookkeeping.stopBookkeepingScheduler")).thenReturn(customIsStoppingInformerInterval);
+
+        assertTrue(powHsmBookkeepingConfig.isStopBookkeepingScheduler());
+    }
+
+    @Test
+    void isStoppingBookkepingScheduler_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath("bookkeeping.stopBookkeepingScheduler")).thenReturn(false);
+
+        assertFalse(powHsmBookkeepingConfig.isStopBookkeepingScheduler());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNetworkParametersAndExpectedCaps")
+    void getDifficultyCap_whenGivenNetwork_shouldMatchExpectedDifficultyCap(String networkId,
+          NetworkDifficultyCap expectedNetworkDifficultyCap) {
+        PowHSMBookkeepingConfig powHsmBookkeepingConfig = new PowHSMBookkeepingConfig(signerConfig, networkId);
+
+        assertEquals(expectedNetworkDifficultyCap.getDifficultyCap(),
+            powHsmBookkeepingConfig.getDifficultyCap());
+    }
+
+    @Test
+    void getDifficultyCap_whenGivenInvalidNetwork_showThrowIllegalArgumentException() {
+        PowHSMBookkeepingConfig powHsmBookkeepingConfig =
+            new PowHSMBookkeepingConfig(signerConfig, NetworkParameters.ID_UNITTESTNET);
+
+        assertThrows(IllegalArgumentException.class,
+            () -> powHsmBookkeepingConfig.getDifficultyCap());
+    }
+
+    static Stream<Arguments> provideNetworkParametersAndExpectedCaps() {
+        return Stream.of(
+            Arguments.of(NetworkParameters.ID_MAINNET, PowHSMBookkeepingConfig.NetworkDifficultyCap.MAINNET),
+            Arguments.of(NetworkParameters.ID_TESTNET, PowHSMBookkeepingConfig.NetworkDifficultyCap.TESTNET),
+            Arguments.of(NetworkParameters.ID_REGTEST, PowHSMBookkeepingConfig.NetworkDifficultyCap.REGTEST)
+        );
     }
 }

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -20,11 +20,20 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class PowHSMBookkeepingConfigTest {
 
-    private static final BigInteger DEFAULT_DIFFICULTY_TARGET = BigInteger.valueOf(3);
-    private static final boolean DEFAULT_STOP_BOOKKEPING_SCHEDULER = false;
-    private static final int DEFAULT_MAX_AMOUNT_BLOCK_HEADERS = 7;
-    private static final int DEFAULT_MAX_CHUNK_SIZE = 10;
-    private static final long DEFAULT_INFORMER_INTERVAL = 2_000;
+    private static final String DIFFICULTY_TARGET_PATH = "bookkeeping.difficultyTarget";
+    private static final BigInteger DIFFICULTY_TARGET_DEFAULT = BigInteger.valueOf(3);
+
+    private static final String MAX_AMOUNT_BLOCK_HEADERS_PATH = "bookkeeping.maxAmountBlockHeaders";
+    private static final int MAX_AMOUNT_BLOCK_HEADERS_DEFAULT = 7;
+
+    private static final String MAX_CHUNK_SIZE_TO_HSM_PATH = "bookkeeping.maxChunkSizeToHsm";
+    private static final int MAX_CHUNK_SIZE_TO_HSM_DEFAULT = 10;
+
+    private static final String INFORMER_INTERVAL_PATH = "bookkeeping.informerInterval";
+    private static final long INFORMER_INTERVAL_DEFAULT = 2_000;
+
+    private static final String STOP_BOOKKEPING_SCHEDULER_PATH = "bookkeeping.stopBookkeepingScheduler";
+    private static final boolean STOP_BOOKKEPING_SCHEDULER_DEFAULT = false;
 
     private PowHSMBookkeepingConfig powHsmBookkeepingConfig;
     private SignerConfig signerConfig = mock(SignerConfig.class);
@@ -39,79 +48,79 @@ class PowHSMBookkeepingConfigTest {
     @Test
     void getDifficultyTarget_whenCustomConfigAvailable_shouldReturnCustomConfig() {
         BigInteger customDifficultyTarget = BigInteger.valueOf(1L); 
-        when(config.hasPath("bookkeeping.difficultyTarget")).thenReturn(true);
-        when(config.getString("bookkeeping.difficultyTarget")).thenReturn("1");
+        when(config.hasPath(DIFFICULTY_TARGET_PATH)).thenReturn(true);
+        when(config.getString(DIFFICULTY_TARGET_PATH)).thenReturn("1");
 
         assertEquals(customDifficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget());
     }
 
     @Test
     void getDifficultyTarget_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath("bookkeeping.difficultyTarget")).thenReturn(false);
+        when(config.hasPath(DIFFICULTY_TARGET_PATH)).thenReturn(false);
 
-        assertEquals(DEFAULT_DIFFICULTY_TARGET, powHsmBookkeepingConfig.getDifficultyTarget());
+        assertEquals(DIFFICULTY_TARGET_DEFAULT, powHsmBookkeepingConfig.getDifficultyTarget());
     }
 
     @Test
     void getMaxAmountBlockHeaders_whenCustomConfigAvailable_shouldReturnCustomConfig() {
         int customMaxAmountBlockHeaders = 1; 
-        when(config.hasPath("bookkeeping.maxAmountBlockHeaders")).thenReturn(true);
-        when(config.getInt("bookkeeping.maxAmountBlockHeaders")).thenReturn(customMaxAmountBlockHeaders);
+        when(config.hasPath(MAX_AMOUNT_BLOCK_HEADERS_PATH)).thenReturn(true);
+        when(config.getInt(MAX_AMOUNT_BLOCK_HEADERS_PATH)).thenReturn(customMaxAmountBlockHeaders);
 
         assertEquals(customMaxAmountBlockHeaders, powHsmBookkeepingConfig.getMaxAmountBlockHeaders());
     }
 
     @Test
     void getMaxAmountBlockHeaders_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath("bookkeeping.maxAmountBlockHeaders")).thenReturn(false);
+        when(config.hasPath(MAX_AMOUNT_BLOCK_HEADERS_PATH)).thenReturn(false);
 
-        assertEquals(DEFAULT_MAX_AMOUNT_BLOCK_HEADERS, powHsmBookkeepingConfig.getMaxAmountBlockHeaders());
+        assertEquals(MAX_AMOUNT_BLOCK_HEADERS_DEFAULT, powHsmBookkeepingConfig.getMaxAmountBlockHeaders());
     }
 
     @Test
     void getMaxChunkSizeToHsm_whenCustomConfigAvailable_shouldReturnCustomConfig() {
         int customMaxChunkSize = 1; 
-        when(config.hasPath("bookkeeping.maxChunkSizeToHsm")).thenReturn(true);
-        when(config.getInt("bookkeeping.maxChunkSizeToHsm")).thenReturn(customMaxChunkSize);
+        when(config.hasPath(MAX_CHUNK_SIZE_TO_HSM_PATH)).thenReturn(true);
+        when(config.getInt(MAX_CHUNK_SIZE_TO_HSM_PATH)).thenReturn(customMaxChunkSize);
 
         assertEquals(customMaxChunkSize, powHsmBookkeepingConfig.getMaxChunkSizeToHsm());
     }
 
     @Test
     void getMaxChunkSizeToHsm_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath("bookkeeping.maxChunkSizeToHsm")).thenReturn(false);
+        when(config.hasPath(MAX_CHUNK_SIZE_TO_HSM_PATH)).thenReturn(false);
 
-        assertEquals(DEFAULT_MAX_CHUNK_SIZE, powHsmBookkeepingConfig.getMaxChunkSizeToHsm());
+        assertEquals(MAX_CHUNK_SIZE_TO_HSM_DEFAULT, powHsmBookkeepingConfig.getMaxChunkSizeToHsm());
     }
 
     @Test
     void getInformerInterval_whenCustomConfigAvailable_shouldReturnCustomConfig() {
         long customInformerInterval = 1L; 
-        when(config.hasPath("bookkeeping.informerInterval")).thenReturn(true);
-        when(config.getLong("bookkeeping.informerInterval")).thenReturn(customInformerInterval);
+        when(config.hasPath(INFORMER_INTERVAL_PATH)).thenReturn(true);
+        when(config.getLong(INFORMER_INTERVAL_PATH)).thenReturn(customInformerInterval);
 
         assertEquals(customInformerInterval, powHsmBookkeepingConfig.getInformerInterval());
     }
 
     @Test
     void getInformerInterval_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath("bookkeeping.informerInterval")).thenReturn(false);
+        when(config.hasPath(INFORMER_INTERVAL_PATH)).thenReturn(false);
 
-        assertEquals(DEFAULT_INFORMER_INTERVAL, powHsmBookkeepingConfig.getInformerInterval());
+        assertEquals(INFORMER_INTERVAL_DEFAULT, powHsmBookkeepingConfig.getInformerInterval());
     }
 
     @Test
     void isStoppingBookkepingScheduler_whenCustomConfigAvailable_shouldReturnCustomConfig() {
-        boolean customIsStoppingInformerInterval = !DEFAULT_STOP_BOOKKEPING_SCHEDULER; 
-        when(config.hasPath("bookkeeping.stopBookkeepingScheduler")).thenReturn(true);
-        when(config.getBoolean("bookkeeping.stopBookkeepingScheduler")).thenReturn(customIsStoppingInformerInterval);
+        boolean customIsStoppingInformerInterval = !STOP_BOOKKEPING_SCHEDULER_DEFAULT; 
+        when(config.hasPath(STOP_BOOKKEPING_SCHEDULER_PATH)).thenReturn(true);
+        when(config.getBoolean(STOP_BOOKKEPING_SCHEDULER_PATH)).thenReturn(customIsStoppingInformerInterval);
 
         assertTrue(powHsmBookkeepingConfig.isStopBookkeepingScheduler());
     }
 
     @Test
     void isStoppingBookkepingScheduler_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath("bookkeeping.stopBookkeepingScheduler")).thenReturn(false);
+        when(config.hasPath(STOP_BOOKKEPING_SCHEDULER_PATH)).thenReturn(false);
 
         assertFalse(powHsmBookkeepingConfig.isStopBookkeepingScheduler());
     }

--- a/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
@@ -3,10 +3,10 @@ package co.rsk.federate.signing.hsm.advanceblockchain;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static co.rsk.federate.config.PowHSMBookkeepingConfig.NetworkDifficultyCap;
 
 import co.rsk.core.BlockDifficulty;
 import co.rsk.crypto.Keccak256;
-import co.rsk.federate.config.PowHSMBookkeepingConfig;
 import co.rsk.federate.signing.utils.TestUtils;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ class ConfirmedBlocksProviderTest {
 
     private final int HSM_VERSION_2 = 2;
     private final int HSM_VERSION_4 = 4;
-    private final BigInteger difficultyCapRegTest = PowHSMBookkeepingConfig.DIFFICULTY_CAP_REGTEST;
+    private final BigInteger difficultyCapRegTest = NetworkDifficultyCap.REGTEST.getDifficultyCap();
     private final BlockHeaderBuilder blockHeaderBuilder = new BlockHeaderBuilder(mock(ActivationConfig.class));
 
     @Test


### PR DESCRIPTION
### Summary

* Refactor of `PowHSMBokkepingConfig` class to be more consistent with the rest of the config classes in the `powpeg-node` project.
* Add missing tests to `PowHSMBookeepingConfigTest` for other exposed config related methods.

In the next PR we will change the difficultyTarget method to take the hsmVersion and return the needed difficultyTraget. 

*No new main logic is introduced*

### Test Plan

Unit tests 
