### PR TITLE
Adapt powpeg-node to be compatible with latest Federation refactors

### DIFF
--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -274,7 +274,7 @@ public class FedNodeRunner implements NodeRunner {
             // btc to rsk client upon federation changes
             FederationProvider federationProvider = new FederationProviderFromFederatorSupport(
                 federatorSupport,
-                bridgeConstants
+                bridgeConstants.getFederationConstants()
             );
 
             BtcLockSenderProvider btcLockSenderProvider = new BtcLockSenderProvider();

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -21,8 +21,8 @@ package co.rsk.federate;
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.*;
+import co.rsk.peg.federation.constants.FederationConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.crypto.ECKey;
 
@@ -41,11 +41,14 @@ import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
  */
 public class FederationProviderFromFederatorSupport implements FederationProvider {
     private final FederatorSupport federatorSupport;
-    private final BridgeConstants bridgeConstants;
+    private final FederationConstants federationConstants;
 
-    public FederationProviderFromFederatorSupport(FederatorSupport federatorSupport, BridgeConstants bridgeConstants) {
+    public FederationProviderFromFederatorSupport(
+        FederatorSupport federatorSupport,
+        FederationConstants federationConstants) {
+
         this.federatorSupport = federatorSupport;
-        this.bridgeConstants = bridgeConstants;
+        this.federationConstants = federationConstants;
     }
 
     @Override
@@ -153,8 +156,8 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
         Instant creationTime = initialFederation.getCreationTime();
         long creationBlockNumber = initialFederation.getCreationBlockNumber();
         NetworkParameters btcParams = federatorSupport.getBtcParams();
-        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
-        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        List<BtcECKey> erpPubKeys = federationConstants.getErpFedPubKeysList();
+        long activationDelay = federationConstants.getErpFedActivationDelay();
         ActivationConfig.ForBlock activations = federatorSupport.getConfigForBestBlock();
 
         FederationArgs federationArgs =

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -88,8 +88,6 @@ import org.spongycastle.util.encoders.Hex;
  * Created by ajlopez on 6/1/2016.
  */
 class BtcToRskClientTest {
-    private final NetworkParameters networkParameters = ThinConverter.toOriginalInstance(BridgeRegTestConstants.getInstance().getBtcParamsString());
-
     private int nhash = 0;
     private ActivationConfig activationConfig;
     private BridgeConstants bridgeRegTestConstants;
@@ -97,6 +95,7 @@ class BtcToRskClientTest {
     private FederationMember fakeMember;
     private BtcToRskClientBuilder btcToRskClientBuilder;
     private List<BtcECKey> federationPrivateKeys;
+    private NetworkParameters networkParameters;
 
     @BeforeEach
     void setup() throws PeginInstructionsException, IOException {
@@ -104,13 +103,12 @@ class BtcToRskClientTest {
         when(activationConfig.forBlock(anyLong())).thenReturn(mock(ActivationConfig.ForBlock.class));
         when(activationConfig.isActive(eq(ConsensusRule.RSKIP89), anyLong())).thenReturn(true);
 
-        bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+        bridgeRegTestConstants = new BridgeRegTestConstants();
+        networkParameters = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString());
         federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
         activeFederation = TestUtils.createFederation(bridgeRegTestConstants.getBtcParams(), federationPrivateKeys);
         fakeMember = FederationMember.getFederationMemberFromKey(
-            BtcECKey.fromPrivate(
-                HashUtil.keccak256("00".getBytes(StandardCharsets.UTF_8))
-            )
+            BtcECKey.fromPrivate(HashUtil.keccak256("00".getBytes(StandardCharsets.UTF_8)))
         );
         btcToRskClientBuilder = new BtcToRskClientBuilder();
     }

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -13,10 +13,10 @@ import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.script.Script;
-import co.rsk.peg.constants.BridgeConstants;
-import co.rsk.peg.constants.BridgeTestNetConstants;
 import co.rsk.peg.federation.*;
 
+import co.rsk.peg.federation.constants.FederationConstants;
+import co.rsk.peg.federation.constants.FederationTestNetConstants;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Arrays;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 class FederationProviderFromFederatorSupportTest {
     private FederatorSupport federatorSupportMock;
     private FederationProvider federationProvider;
-    private BridgeConstants bridgeConstants;
+    private FederationConstants federationConstants;
     private NetworkParameters testnetParams;
     private Instant creationTime;
 
@@ -50,11 +50,11 @@ class FederationProviderFromFederatorSupportTest {
 
     @BeforeEach
     void createProvider() {
-        bridgeConstants = BridgeTestNetConstants.getInstance();
+        federationConstants = FederationTestNetConstants.getInstance();
         federatorSupportMock = mock(FederatorSupport.class);
         federationProvider = new FederationProviderFromFederatorSupport(
             federatorSupportMock,
-            bridgeConstants
+            federationConstants
         );
         testnetParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
         creationTime = Instant.ofEpochMilli(5005L);
@@ -808,8 +808,8 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     private ErpFederation createNonStandardErpFederation(List<FederationMember> members, ActivationConfig.ForBlock activations) {
-        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
-        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        List<BtcECKey> erpPubKeys = federationConstants.getErpFedPubKeysList();
+        long activationDelay = federationConstants.getErpFedActivationDelay();
         FederationArgs federationArgs =
             new FederationArgs(members, creationTime, 0L, testnetParams);
 
@@ -817,10 +817,14 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     private ErpFederation createP2shErpFederation(List<FederationMember> members) {
-        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
-        long activationDelay = bridgeConstants.getErpFedActivationDelay();
-        FederationArgs federationArgs =
-            new FederationArgs(members, creationTime, 0L, testnetParams);
+        List<BtcECKey> erpPubKeys = federationConstants.getErpFedPubKeysList();
+        long activationDelay = federationConstants.getErpFedActivationDelay();
+        FederationArgs federationArgs = new FederationArgs(
+            members,
+            creationTime,
+            0L,
+            testnetParams
+        );
         
         return FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
     }

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -34,7 +34,7 @@ import org.mockito.stubbing.Answer;
 
 class FederatorSupportTest {
 
-    private final NetworkParameters networkParameters = ThinConverter.toOriginalInstance(BridgeRegTestConstants.getInstance().getBtcParamsString());
+    private final NetworkParameters networkParameters = ThinConverter.toOriginalInstance(new BridgeRegTestConstants().getBtcParamsString());
 
     @Test
     void sendReceiveHeadersSendsBlockHeaders() {

--- a/src/test/java/co/rsk/federate/adapter/ThinConverterTest.java
+++ b/src/test/java/co/rsk/federate/adapter/ThinConverterTest.java
@@ -13,18 +13,16 @@ class ThinConverterTest {
 
     private static int nhash = 0;
 
-    public static org.bitcoinj.core.Sha256Hash createOriginalHash() {
+    private org.bitcoinj.core.Sha256Hash createOriginalHash() {
         byte[] bytes = new byte[32];
         bytes[0] = (byte) nhash++;
-        org.bitcoinj.core.Sha256Hash hash = org.bitcoinj.core.Sha256Hash.wrap(bytes);
-        return hash;
+        return org.bitcoinj.core.Sha256Hash.wrap(bytes);
     }
 
-    public static co.rsk.bitcoinj.core.Sha256Hash createThinHash() {
+    private co.rsk.bitcoinj.core.Sha256Hash createThinHash() {
         byte[] bytes = new byte[32];
         bytes[0] = (byte) nhash++;
-        co.rsk.bitcoinj.core.Sha256Hash hash = co.rsk.bitcoinj.core.Sha256Hash.wrap(bytes);
-        return hash;
+        return co.rsk.bitcoinj.core.Sha256Hash.wrap(bytes);
     }
 
     @Test
@@ -34,12 +32,12 @@ class ThinConverterTest {
         int height = 200;
         org.bitcoinj.core.Block originalBlock = new org.bitcoinj.core.Block(params, 1, createOriginalHash(), createOriginalHash(), 1000, 2000, 3000, new ArrayList<>());
         org.bitcoinj.core.StoredBlock originalStoredBlock = new org.bitcoinj.core.StoredBlock(originalBlock, chainWork, height);
-        co.rsk.bitcoinj.core.StoredBlock thinStoredBlock = ThinConverter.toThinInstance(originalStoredBlock, BridgeRegTestConstants.getInstance());
+        co.rsk.bitcoinj.core.StoredBlock thinStoredBlock = ThinConverter.toThinInstance(originalStoredBlock, new BridgeRegTestConstants());
         assertEquals(chainWork, thinStoredBlock.getChainWork());
         assertEquals(height, thinStoredBlock.getHeight());
         assertArrayEquals(originalBlock.bitcoinSerialize(), thinStoredBlock.getHeader().bitcoinSerialize());
 
-        assertNull(ThinConverter.toThinInstance(null, BridgeRegTestConstants.getInstance()));
+        assertNull(ThinConverter.toThinInstance(null, new BridgeRegTestConstants()));
     }
 
     @Test
@@ -49,12 +47,12 @@ class ThinConverterTest {
         int height = 200;
         co.rsk.bitcoinj.core.BtcBlock thinBlock = new co.rsk.bitcoinj.core.BtcBlock(params, 1, createThinHash(), createThinHash(), 1000, 2000, 3000, new ArrayList<>());
         co.rsk.bitcoinj.core.StoredBlock thinStoredBlock = new co.rsk.bitcoinj.core.StoredBlock(thinBlock, chainWork, height);
-        org.bitcoinj.core.StoredBlock originalStoredBlock = ThinConverter.toOriginalInstance(thinStoredBlock, BridgeRegTestConstants.getInstance());
+        org.bitcoinj.core.StoredBlock originalStoredBlock = ThinConverter.toOriginalInstance(thinStoredBlock, new BridgeRegTestConstants());
         assertEquals(chainWork, originalStoredBlock.getChainWork());
         assertEquals(height, originalStoredBlock.getHeight());
         assertArrayEquals(thinBlock.bitcoinSerialize(), originalStoredBlock.getHeader().bitcoinSerialize());
 
-        assertNull(ThinConverter.toOriginalInstance(null, BridgeRegTestConstants.getInstance()));
+        assertNull(ThinConverter.toOriginalInstance(null, new BridgeRegTestConstants()));
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/bitcoin/KitTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/KitTest.java
@@ -26,13 +26,12 @@ import org.junit.jupiter.api.Test;
 
 class KitTest {
     private static BridgeConstants bridgeConstants;
-    private static NetworkParameters networkParameters;
     private static Context btcContext;
 
     @BeforeEach
     void setUpBeforeClass() {
-        bridgeConstants = BridgeRegTestConstants.getInstance();
-        networkParameters = ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString());
+        bridgeConstants = new BridgeRegTestConstants();
+        NetworkParameters networkParameters = ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString());
         btcContext = new Context(networkParameters);
     }
 

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizerTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
@@ -44,17 +45,16 @@ class BtcReleaseClientStorageSynchronizerTest {
 
     @Test
     void isSynced_returns_false_after_instantiation() {
-        BtcReleaseClientStorageSynchronizer storageSynchronizer =
-            new BtcReleaseClientStorageSynchronizer(
-                mock(BlockStore.class),
-                mock(ReceiptStore.class),
-                mock(NodeBlockProcessor.class),
-                mock(BtcReleaseClientStorageAccessor.class),
-                mock(ScheduledExecutorService.class), // Don't specify behavior for syncing to avoid syncing
-                1000,
-                100,
-                6_000
-            );
+        BtcReleaseClientStorageSynchronizer storageSynchronizer = new BtcReleaseClientStorageSynchronizer(
+            mock(BlockStore.class),
+            mock(ReceiptStore.class),
+            mock(NodeBlockProcessor.class),
+            mock(BtcReleaseClientStorageAccessor.class),
+            mock(ScheduledExecutorService.class), // Don't specify behavior for syncing to avoid syncing
+            1000,
+            100,
+            6_000
+        );
 
         assertFalse(storageSynchronizer.isSynced());
     }
@@ -63,23 +63,22 @@ class BtcReleaseClientStorageSynchronizerTest {
     void processBlock_before_sync_doesnt_do_anything() {
         BtcReleaseClientStorageAccessor storageAccessor = mock(BtcReleaseClientStorageAccessor.class);
 
-        BtcReleaseClientStorageSynchronizer storageSynchronizer =
-            new BtcReleaseClientStorageSynchronizer(
-                mock(BlockStore.class),
-                mock(ReceiptStore.class),
-                mock(NodeBlockProcessor.class),
-                storageAccessor,
-                mock(ScheduledExecutorService.class), // Don't specify behavior for syncing to avoid syncing
-                1000,
-                100,
-                6_000
-            );
+        BtcReleaseClientStorageSynchronizer storageSynchronizer = new BtcReleaseClientStorageSynchronizer(
+            mock(BlockStore.class),
+            mock(ReceiptStore.class),
+            mock(NodeBlockProcessor.class),
+            storageAccessor,
+            mock(ScheduledExecutorService.class), // Don't specify behavior for syncing to avoid syncing
+            1000,
+            100,
+            6_000
+        );
 
         assertFalse(storageSynchronizer.isSynced());
 
         storageSynchronizer.processBlock(mock(Block.class), Collections.emptyList());
 
-        Mockito.verifyNoInteractions(storageAccessor);
+        verifyNoInteractions(storageAccessor);
     }
 
     @Test
@@ -102,16 +101,16 @@ class BtcReleaseClientStorageSynchronizerTest {
             return null;
         }).when(mockedExecutor).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
 
-        BtcReleaseClientStorageSynchronizer storageSynchronizer =
-            new BtcReleaseClientStorageSynchronizer(
-                blockStore,
-                mock(ReceiptStore.class),
-                mock(NodeBlockProcessor.class),
-                mock(BtcReleaseClientStorageAccessor.class),
-                mockedExecutor,
-                0,
-                1,
-                6_000);
+        BtcReleaseClientStorageSynchronizer storageSynchronizer = new BtcReleaseClientStorageSynchronizer(
+            blockStore,
+            mock(ReceiptStore.class),
+            mock(NodeBlockProcessor.class),
+            mock(BtcReleaseClientStorageAccessor.class),
+            mockedExecutor,
+            0,
+            1,
+            6_000
+        );
 
         assertTrue(storageSynchronizer.isSynced());
     }
@@ -144,16 +143,16 @@ class BtcReleaseClientStorageSynchronizerTest {
         }).when(mockedExecutor).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
 
 
-        BtcReleaseClientStorageSynchronizer storageSynchronizer =
-            new BtcReleaseClientStorageSynchronizer(
-                blockStore,
-                mock(ReceiptStore.class),
-                mock(NodeBlockProcessor.class),
-                storageAccessor,
-                mockedExecutor,
-                0,
-                1,
-                6_000);
+        BtcReleaseClientStorageSynchronizer storageSynchronizer = new BtcReleaseClientStorageSynchronizer(
+            blockStore,
+            mock(ReceiptStore.class),
+            mock(NodeBlockProcessor.class),
+            storageAccessor,
+            mockedExecutor,
+            0,
+            1,
+            6_000
+        );
 
         assertTrue(storageSynchronizer.isSynced());
 
@@ -191,7 +190,7 @@ class BtcReleaseClientStorageSynchronizerTest {
         SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
 
         BridgeEventLoggerImpl bridgeEventLogger = new BridgeEventLoggerImpl(
-            BridgeRegTestConstants.getInstance(),
+            new BridgeRegTestConstants(),
             activations,
             logs,
             signatureCache
@@ -227,16 +226,16 @@ class BtcReleaseClientStorageSynchronizerTest {
             return null;
         }).when(mockedExecutor).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
 
-        BtcReleaseClientStorageSynchronizer storageSynchronizer =
-            new BtcReleaseClientStorageSynchronizer(
-                blockStore,
-                mock(ReceiptStore.class),
-                mock(NodeBlockProcessor.class),
-                storageAccessor,
-                mockedExecutor,
-                0,
-                1,
-                6_000);
+        BtcReleaseClientStorageSynchronizer storageSynchronizer = new BtcReleaseClientStorageSynchronizer(
+            blockStore,
+            mock(ReceiptStore.class),
+            mock(NodeBlockProcessor.class),
+            storageAccessor,
+            mockedExecutor,
+            0,
+            1,
+            6_000
+        );
 
         // Verify sync
         assertTrue(storageSynchronizer.isSynced());
@@ -252,8 +251,6 @@ class BtcReleaseClientStorageSynchronizerTest {
         assertEquals(secondHash, calls.get(1));
         assertEquals(thirdHash, calls.get(2));
         verify(storageAccessor, times(1)).putBtcTxHashRskTxHash(key, value);
-
-
     }
 
     @Test
@@ -289,7 +286,7 @@ class BtcReleaseClientStorageSynchronizerTest {
         SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
 
         BridgeEventLoggerImpl bridgeEventLogger = new BridgeEventLoggerImpl(
-            BridgeRegTestConstants.getInstance(),
+            new BridgeRegTestConstants(),
             activations,
             logs,
             signatureCache
@@ -336,16 +333,16 @@ class BtcReleaseClientStorageSynchronizerTest {
             return null;
         }).when(mockedExecutor).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
 
-        BtcReleaseClientStorageSynchronizer storageSynchronizer =
-            new BtcReleaseClientStorageSynchronizer(
-                blockStore,
-                mock(ReceiptStore.class),
-                mock(NodeBlockProcessor.class),
-                storageAccessor,
-                mockedExecutor,
-                0,
-                1,
-                6_000);
+        BtcReleaseClientStorageSynchronizer storageSynchronizer = new BtcReleaseClientStorageSynchronizer(
+            blockStore,
+            mock(ReceiptStore.class),
+            mock(NodeBlockProcessor.class),
+            storageAccessor,
+            mockedExecutor,
+            0,
+            1,
+            6_000
+        );
 
         // Verify sync
         assertTrue(storageSynchronizer.isSynced());
@@ -362,7 +359,5 @@ class BtcReleaseClientStorageSynchronizerTest {
         assertEquals(thirdHash, calls.get(2));
         verify(storageAccessor, times(1)).putBtcTxHashRskTxHash(releaseBtcTxHash, updateCollectionsTx.getHash());
         verify(storageAccessor, times(1)).putBtcTxHashRskTxHash(secondReleaseBtcTxHash, updateCollectionsTx.getHash());
-
     }
-
 }


### PR DESCRIPTION
- Apply changes in powpeg node classes and tests to be compatible with the latest changes implemented in `federation-support-refactor-integration` branch in rskj

