### PR TITLE
Dynamically load the difficultyTarget config value from PowHSM blockchainParameters RPC

### DIFF
--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -223,7 +223,7 @@ public class FedNodeRunner implements NodeRunner {
             fedNodeContext.getBlockStore(),
             bookKeepingClient,
             new ConfirmedBlocksProvider(
-                bookKeepingConfig.getDifficultyTarget(),
+                bookKeepingConfig.getDifficultyTarget(bookKeepingClient),
                 bookKeepingConfig.getMaxAmountBlockHeaders(),
                 fedNodeContext.getBlockStore(),
                 bookKeepingConfig.getDifficultyCap(),

--- a/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
+++ b/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
@@ -4,11 +4,9 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.signing.hsm.HSMClientException;
 import co.rsk.federate.signing.hsm.client.HSMBookkeepingClient;
 import co.rsk.federate.signing.hsm.message.PowHSMBlockchainParameters;
-
 import com.typesafe.config.Config;
 import java.math.BigInteger;
 import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +69,6 @@ public class PowHSMBookkeepingConfig {
      */
     public BigInteger getDifficultyTarget(HSMBookkeepingClient hsmClient)
         throws HSMClientException {
-    System.out.println(hsmClient);
-    System.out.println(hsmClient.getVersion());
       if (hsmClient.getVersion() < 3) {
           return Optional.ofNullable(signerConfig.getString(DIFFICULTY_TARGET_PATH))
               .map(BigInteger::new)

--- a/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
+++ b/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
@@ -56,8 +56,7 @@ public class PowHSMBookkeepingConfig {
      * <p>
      * This method first attempts to retrieve the difficulty target from the PowHSM using the provided
      * {@link HSMBookkeepingClient}. If the PowHSM version is unsupported, it falls back to retrieving
-     * the difficulty target from the configuration file. If there is a client exception, it logs the error
-     * and rethrows the exception.
+     * the difficulty target from the configuration file.
      * </p>
      *
      * @param hsmClient The client used to communicate with the PowHSM.
@@ -74,11 +73,6 @@ public class PowHSMBookkeepingConfig {
               "[getDifficultyTarget] Unsupported PowHSM version, retrieve difficulty target from config file", e);
 
           return new BigInteger(signerConfig.getString(DIFFICULTY_TARGET_PATH));
-      } catch (HSMClientException e) {
-          logger.error(
-              "[getDifficultyTarget] Unable to retrieve difficulty target from the PowHSM", e);
-
-          throw e;
       }
     }
 

--- a/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
@@ -1,5 +1,6 @@
 package co.rsk.federate;
 
+import static co.rsk.federate.config.PowHSMBookkeepingConfig.DIFFICULTY_TARGET_PATH;
 import static co.rsk.federate.signing.PowPegNodeKeyId.BTC_KEY_ID;
 import static co.rsk.federate.signing.PowPegNodeKeyId.MST_KEY_ID;
 import static co.rsk.federate.signing.PowPegNodeKeyId.RSK_KEY_ID;
@@ -8,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -35,6 +37,7 @@ import co.rsk.federate.signing.hsm.client.HSMClientProtocolFactory;
 import co.rsk.federate.signing.hsm.message.PowHSMBlockchainParameters;
 import co.rsk.federate.signing.utils.TestUtils;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
@@ -436,6 +439,16 @@ class FedNodeRunnerTest {
 
         HSMBookkeepingService hsmBookkeepingService = TestUtils.getInternalState(fedNodeRunner, "hsmBookkeepingService");
         assertNull(hsmBookkeepingService);
+    }
+
+    @Test
+    void run_whenHsmVersionIsLowerThanThreeAndDifficultyTargetConfigIsNotPresent_shouldThrowException() throws Exception {
+        SignerConfig btcSignerConfig = getHSMBTCSignerConfig(2);
+        when(btcSignerConfig.getConfig().getString(DIFFICULTY_TARGET_PATH))
+           .thenThrow(new ConfigException.Missing(DIFFICULTY_TARGET_PATH));
+        when(fedNodeSystemProperties.signerConfig(BTC_KEY_ID.getId())).thenReturn(btcSignerConfig);
+
+        assertThrows(ConfigException.class, () -> fedNodeRunner.run());
     }
 
     private SignerConfig getBTCSignerConfig() {

--- a/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
@@ -26,6 +26,7 @@ import co.rsk.federate.signing.ECDSAHSMSigner;
 import co.rsk.federate.signing.ECDSASigner;
 import co.rsk.federate.signing.ECDSASignerFromFileKey;
 import co.rsk.federate.signing.hsm.HSMClientException;
+import co.rsk.federate.signing.hsm.HSMUnsupportedTypeException;
 import co.rsk.federate.signing.hsm.advanceblockchain.HSMBookKeepingClientProvider;
 import co.rsk.federate.signing.hsm.advanceblockchain.HSMBookkeepingService;
 import co.rsk.federate.signing.hsm.client.HSMBookkeepingClient;
@@ -479,6 +480,8 @@ class FedNodeRunnerTest {
             when(hsmConfig.getInt("maxAttempts")).thenReturn(3);
             when(hsmConfig.hasPath("intervalBetweenAttempts")).thenReturn(true);
             when(hsmConfig.getInt("intervalBetweenAttempts")).thenReturn(2000);
+            when(hsmBookkeepingClient.getBlockchainParameters()).thenThrow(
+                new HSMUnsupportedTypeException("PowHSM version: " + version));
             when(hsmConfig.getString("bookkeeping.difficultyTarget")).thenReturn("4405500");
             when(hsmConfig.hasPath("bookkeeping.informerInterval")).thenReturn(true);
             when(hsmConfig.getLong("bookkeeping.informerInterval")).thenReturn(500000L);

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -17,6 +17,7 @@ import co.rsk.federate.signing.hsm.HSMUnsupportedTypeException;
 import co.rsk.federate.signing.hsm.client.HSMBookkeepingClient;
 import co.rsk.federate.signing.hsm.message.PowHSMBlockchainParameters;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import java.math.BigInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,11 +62,22 @@ class PowHSMBookkeepingConfigTest {
     }
 
     @Test
+    void getDifficultyTarget_whenPowHSMCallFailsWithHSMUnsupportedTypeExceptionAndCustomConfigIsNotPresent_shouldThrowConfigException()
+          throws Exception {
+        when(hsmClient.getBlockchainParameters()).thenThrow(new HSMUnsupportedTypeException("error"));
+        when(config.getString(DIFFICULTY_TARGET_PATH)).thenThrow(new ConfigException.Missing(DIFFICULTY_TARGET_PATH));
+
+        assertThrows(ConfigException.class,
+            () -> powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
+    }
+
+    @Test
     void getDifficultyTarget_whenPowHSMCallFailsWithSomeHSMClientException_shouldThrowHSMClientException()
           throws Exception {
         when(hsmClient.getBlockchainParameters()).thenThrow(new HSMBlockchainBookkeepingRelatedException("error"));
 
-        assertThrows(HSMClientException.class, () -> powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
+        assertThrows(HSMClientException.class,
+            () -> powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -1,6 +1,7 @@
 package co.rsk.federate.config;
 
 import static co.rsk.federate.config.PowHSMBookkeepingConfig.*;
+import static co.rsk.federate.signing.utils.TestUtils.createHash;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,6 +11,10 @@ import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.config.PowHSMBookkeepingConfig.NetworkDifficultyCap;
+import co.rsk.federate.signing.hsm.HSMClientException;
+import co.rsk.federate.signing.hsm.HSMUnknownErrorException;
+import co.rsk.federate.signing.hsm.client.HSMBookkeepingClient;
+import co.rsk.federate.signing.hsm.message.PowHSMBlockchainParameters;
 import com.typesafe.config.Config;
 import java.math.BigInteger;
 import java.util.stream.Stream;
@@ -24,6 +29,7 @@ class PowHSMBookkeepingConfigTest {
     private PowHSMBookkeepingConfig powHsmBookkeepingConfig;
     private final SignerConfig signerConfig = mock(SignerConfig.class);
     private final Config config = mock(Config.class);
+    private final HSMBookkeepingClient hsmClient = mock(HSMBookkeepingClient.class);
 
     @BeforeEach
     void setup() {
@@ -32,19 +38,50 @@ class PowHSMBookkeepingConfigTest {
     }
 
     @Test
-    void getDifficultyTarget_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+    void getDifficultyTarget_whenPowHSMVersionIsLessThanThreeAndCustomConfigIsPresent_shouldReturnCustomConfig() throws Exception {
         BigInteger customDifficultyTarget = BigInteger.valueOf(1L); 
-        when(config.hasPath(DIFFICULTY_TARGET_PATH)).thenReturn(true);
+        when(hsmClient.getVersion()).thenReturn(2);
         when(config.getString(DIFFICULTY_TARGET_PATH)).thenReturn("1");
 
-        assertEquals(customDifficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget());
+        assertEquals(customDifficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
     }
 
     @Test
-    void getDifficultyTarget_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(DIFFICULTY_TARGET_PATH)).thenReturn(false);
+    void getDifficultyTarget_whenPowHSMVersionIsLessThanThreeAndCustomConfigIsNotPresent_shouldThrowException() throws Exception {
+        when(hsmClient.getVersion()).thenReturn(2);
+        when(config.getString(DIFFICULTY_TARGET_PATH)).thenReturn(null);
 
-        assertEquals(DIFFICULTY_TARGET_DEFAULT, powHsmBookkeepingConfig.getDifficultyTarget());
+        assertThrows(IllegalStateException.class,
+            () -> powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
+    }
+
+    @Test
+    void getDifficultyTarget_whenPowHSMVersionIsGreaterThanTwo_shouldRetriveConfigValueFromPowHSM() throws Exception {
+        BigInteger difficultyTarget = BigInteger.valueOf(1L); 
+        PowHSMBlockchainParameters response =
+            new PowHSMBlockchainParameters(
+                createHash(1).toHexString(), difficultyTarget, NetworkParameters.ID_UNITTESTNET.toString());
+        when(hsmClient.getVersion()).thenReturn(3);
+        when(hsmClient.getBlockchainParameters()).thenReturn(response);
+
+        assertEquals(difficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
+    }
+
+    @Test
+    void getDifficultyTarget_whenPowHSMVersionIsGreaterThanTwoAndPowHSMReturnsNullValue_shouldThrowException() throws Exception {
+        when(hsmClient.getVersion()).thenReturn(3);
+        when(hsmClient.getBlockchainParameters()).thenReturn(null);
+
+        assertThrows(IllegalStateException.class,
+            () -> powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
+    }
+
+    @Test
+    void getDifficultyTarget_whenFailedCallToPowHSM_shouldThrowException() throws Exception {
+        when(hsmClient.getVersion()).thenThrow(HSMUnknownErrorException.class);
+
+        assertThrows(HSMClientException.class,
+            () -> powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -57,14 +57,14 @@ class PowHSMBookkeepingConfigTest {
 
     @Test
     void getDifficultyTarget_whenPowHSMVersionIsGreaterThanTwo_shouldRetriveConfigValueFromPowHSM() throws Exception {
-        BigInteger difficultyTarget = BigInteger.valueOf(1L); 
+        BigInteger expectedDifficultyTarget = BigInteger.valueOf(1L); 
         PowHSMBlockchainParameters response =
             new PowHSMBlockchainParameters(
-                createHash(1).toHexString(), difficultyTarget, NetworkParameters.ID_UNITTESTNET.toString());
+                createHash(1).toHexString(), expectedDifficultyTarget, NetworkParameters.ID_UNITTESTNET.toString());
         when(hsmClient.getVersion()).thenReturn(3);
         when(hsmClient.getBlockchainParameters()).thenReturn(response);
 
-        assertEquals(difficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
+        assertEquals(expectedDifficultyTarget, powHsmBookkeepingConfig.getDifficultyTarget(hsmClient));
     }
 
     @Test


### PR DESCRIPTION
### Summary

As it stands right now, the powpeg node allows a configuration field, signers.btc.bookkeeping.difficultyTarget, to define the minimum amount collected by the next segmented chain to pass for the advanceBlockchain RPC. The algorithm to find the next valid chain is implemented [here](https://github.com/rsksmart/powpeg-node/blob/master/src/main/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProvider.java#L34). 

In reality this value does not need to be approximated and configured since the PowHSM exposes this value by the blockchainParameters RPC. The idea is to use this value by default, and if the custom configured value exists then do an override.

We can use this method to replace the config sent in the powpeg node, only for HSM >= 3. For HSM2 we need the values to be provided in the config.

### Requirements

Remove de default config value for difficultyTarget since it might be misleading

For HSM <= 2, if the value is not present in the config value do not let the node to start up by throwing an exception. Else continue to operate as usual.

For HSM >= 3, if the value is not present in the config, use the value provided by the HSM. In other words, extract the minimum_difficulty value at start time by calling blockchainParameters if there is no custom value configured. If the call fails as well, do not let the node to start up.