### PR TITLE
Update ReleaseCreationInformation class to decode outpoints from receipt

### DIFF
--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
@@ -68,7 +68,6 @@ public class ReleaseCreationInformation {
             .map(LogInfo::getData)
             .map(this::decodePegoutTransactionEventData)
             .map(UtxoUtils::decodeOutpointValues)
-            .map(Collections::unmodifiableList)
             .orElse(Collections.emptyList());
     }
 
@@ -82,8 +81,7 @@ public class ReleaseCreationInformation {
 
     private byte[] decodePegoutTransactionEventData(byte[] pegoutCreatedTransactionEventData) {
         Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-        byte[] serializedOutpointValues = (byte[]) pegoutTransactionCreatedEvent.decodeEventData(pegoutCreatedTransactionEventData)[0];
-        return serializedOutpointValues;
+        return (byte[]) pegoutTransactionCreatedEvent.decodeEventData(pegoutCreatedTransactionEventData)[0];
     }
 
     public Block getPegoutCreationBlock() {
@@ -113,6 +111,6 @@ public class ReleaseCreationInformation {
     }
 
     public List<Coin> getUtxoOutpointValues() {
-        return utxoOutpointValues;
+        return Collections.unmodifiableList(utxoOutpointValues);
     }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
@@ -14,6 +14,7 @@ import org.ethereum.core.TransactionReceipt;
 import org.ethereum.vm.LogInfo;
 
 public class ReleaseCreationInformation {
+
     private final Block pegoutCreationBlock;
     private final TransactionReceipt transactionReceipt;
     private final Keccak256 pegoutCreationRskTxHash;
@@ -22,11 +23,10 @@ public class ReleaseCreationInformation {
     private final List<Coin> utxoOutpointValues;
 
     /**
-     *
-     * @param pegoutCreationBlock                 The rsk block where pegout was created
-     * @param transactionReceipt    The rsk transaction receipt where pegout was created
-     * @param pegoutCreationRskTxHash      The rsk transaction hash where the pegout was created
-     * @param pegoutBtcTx        The BTC transaction to sign
+     * @param pegoutCreationBlock     The rsk block where pegout was created
+     * @param transactionReceipt      The rsk transaction receipt where pegout was created
+     * @param pegoutCreationRskTxHash The rsk transaction hash where the pegout was created
+     * @param pegoutBtcTx             The BTC transaction to sign
      **/
     public ReleaseCreationInformation(
         Block pegoutCreationBlock,
@@ -34,16 +34,17 @@ public class ReleaseCreationInformation {
         Keccak256 pegoutCreationRskTxHash,
         BtcTransaction pegoutBtcTx
     ) {
-        this(pegoutCreationBlock, transactionReceipt, pegoutCreationRskTxHash, pegoutBtcTx, pegoutCreationRskTxHash);
+        this(pegoutCreationBlock, transactionReceipt, pegoutCreationRskTxHash, pegoutBtcTx,
+            pegoutCreationRskTxHash);
     }
 
     /**
-     *
-     * @param pegoutCreationBlock                 The rsk block where the pegout was created
-     * @param transactionReceipt    The rsk transaction receipt where the pegout was created
-     * @param pegoutCreationRskTxHash      The rsk transaction hash where the pegout was created
-     * @param pegoutBtcTx        The BTC transaction to sign
-     * @param pegoutConfirmationRskTxHash  The rsk transaction hash where the pegout was confirmed to be signed
+     * @param pegoutCreationBlock         The rsk block where the pegout was created
+     * @param transactionReceipt          The rsk transaction receipt where the pegout was created
+     * @param pegoutCreationRskTxHash     The rsk transaction hash where the pegout was created
+     * @param pegoutBtcTx                 The BTC transaction to sign
+     * @param pegoutConfirmationRskTxHash The rsk transaction hash where the pegout was confirmed to
+     *                                    be signed
      **/
     public ReleaseCreationInformation(
         Block pegoutCreationBlock,
@@ -58,7 +59,7 @@ public class ReleaseCreationInformation {
         this.pegoutBtcTx = pegoutBtcTx;
         this.pegoutConfirmationRskTxHash = pegoutConfirmationRskTxHash;
 
-        this.utxoOutpointValues = this.decodeUtxoOutpointValues(transactionReceipt);
+        this.utxoOutpointValues = decodeUtxoOutpointValues(transactionReceipt);
     }
 
     private List<Coin> decodeUtxoOutpointValues(TransactionReceipt transactionReceipt) {
@@ -81,7 +82,8 @@ public class ReleaseCreationInformation {
 
     private byte[] decodePegoutTransactionEventData(byte[] pegoutCreatedTransactionEventData) {
         Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-        return (byte[]) pegoutTransactionCreatedEvent.decodeEventData(pegoutCreatedTransactionEventData)[0];
+        return (byte[]) pegoutTransactionCreatedEvent.decodeEventData(
+            pegoutCreatedTransactionEventData)[0];
     }
 
     public Block getPegoutCreationBlock() {

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
@@ -59,10 +59,10 @@ public class ReleaseCreationInformation {
         this.pegoutBtcTx = pegoutBtcTx;
         this.pegoutConfirmationRskTxHash = pegoutConfirmationRskTxHash;
 
-        this.utxoOutpointValues = decodeUtxoOutpointValues(transactionReceipt);
+        this.utxoOutpointValues = decodeUtxoOutpointValues();
     }
 
-    private List<Coin> decodeUtxoOutpointValues(TransactionReceipt transactionReceipt) {
+    private List<Coin> decodeUtxoOutpointValues() {
         return transactionReceipt.getLogInfoList().stream()
             .filter(this::isPegoutTransactionCreatedLog)
             .findFirst()

--- a/src/test/java/co/rsk/federate/EventsTestUtils.java
+++ b/src/test/java/co/rsk/federate/EventsTestUtils.java
@@ -1,0 +1,102 @@
+package co.rsk.federate;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import co.rsk.peg.BridgeEvents;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.ethereum.core.CallTransaction;
+import org.ethereum.vm.DataWord;
+import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
+
+public final class EventsTestUtils {
+
+    private EventsTestUtils() {
+    }
+
+    public static LogInfo createPegoutTransactionCreatedLog(Sha256Hash pegoutBtcTxHash,
+        byte[] serializedOutpointValues) {
+        CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
+        byte[] pegoutTransactionCreatedSignatureTopic = pegoutTransactionCreatedEvent.encodeSignatureLong();
+        List<DataWord> topics = new ArrayList<>();
+        topics.add(
+            DataWord.valueOf(pegoutTransactionCreatedSignatureTopic));
+        topics.add(DataWord.valueOf(pegoutBtcTxHash.getBytes()));
+
+        byte[] pegoutTransactionCreatedEncodedData = pegoutTransactionCreatedEvent.encodeEventData(
+            serializedOutpointValues);
+
+        return new LogInfo(
+            PrecompiledContracts.BRIDGE_ADDR.getBytes(),
+            topics, pegoutTransactionCreatedEncodedData);
+    }
+
+    public static LogInfo createBatchPegoutCreatedLog(Sha256Hash pegoutBtcTxHash,
+        List<Keccak256> pegoutRequestRskTxHashes) {
+        CallTransaction.Function batchPegoutCreatedEvent = BridgeEvents.BATCH_PEGOUT_CREATED.getEvent();
+        byte[] batchPegoutEventSignatureTopic = batchPegoutCreatedEvent.encodeSignatureLong();
+        List<DataWord> topics = new ArrayList<>();
+        topics.add(
+            DataWord.valueOf(batchPegoutEventSignatureTopic));
+        topics.add(DataWord.valueOf(pegoutBtcTxHash.getBytes()));
+
+        byte[] encodedData = batchPegoutCreatedEvent.encodeEventData(
+            serializeRskTxHashes(pegoutRequestRskTxHashes));
+
+        return new LogInfo(PrecompiledContracts.BRIDGE_ADDR.getBytes(),
+            topics, encodedData);
+    }
+
+    public static LogInfo createReleaseRequestedLog(Keccak256 pegoutRskTxHash,
+        Sha256Hash pegoutBtcTxHash,
+        Coin amount) {
+        CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
+
+        byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
+        List<DataWord> topics = new ArrayList<>();
+        topics.add(DataWord.valueOf(releaseRequestedSignatureTopic));
+        topics.add(DataWord.valueOf(pegoutRskTxHash.getBytes()));
+        topics.add(DataWord.valueOf(pegoutBtcTxHash.getBytes()));
+
+        byte[] encodedData = releaseRequestedEvent.encodeEventData(amount.getValue());
+
+        return new LogInfo(PrecompiledContracts.BRIDGE_ADDR.getBytes(),
+            topics, encodedData);
+    }
+
+    public static LogInfo createUpdateCollectionsLog(RskAddress senderAddress) {
+        CallTransaction.Function updateCollectionsEvent = BridgeEvents.UPDATE_COLLECTIONS.getEvent();
+
+        byte[] updateCollectionsSignatureTopic = updateCollectionsEvent.encodeSignatureLong();
+        List<DataWord> topics = new ArrayList<>();
+        topics.add(DataWord.valueOf(updateCollectionsSignatureTopic));
+
+        byte[] encodedData = updateCollectionsEvent.encodeEventData(senderAddress.toString());
+
+        return new LogInfo(PrecompiledContracts.BRIDGE_ADDR.getBytes(),
+            topics, encodedData);
+    }
+
+    /*
+    TODO: Remove this method once {@link co.rsk.peg.utils.BridgeEventLoggerImpl#serializeRskTxHashes(List<Keccak256> rskTxHashes)} is moved to a util class
+     */
+    private static byte[] serializeRskTxHashes(List<Keccak256> rskTxHashes) {
+        List<byte[]> rskTxHashesList = rskTxHashes.stream()
+            .map(Keccak256::getBytes)
+            .collect(Collectors.toList());
+        int rskTxHashesLength = rskTxHashesList.stream().mapToInt(key -> key.length).sum();
+
+        byte[] serializedRskTxHashes = new byte[rskTxHashesLength];
+        int copyPos = 0;
+        for (byte[] rskTxHash : rskTxHashesList) {
+            System.arraycopy(rskTxHash, 0, serializedRskTxHashes, copyPos, rskTxHash.length);
+            copyPos += rskTxHash.length;
+        }
+
+        return serializedRskTxHashes;
+    }
+}

--- a/src/test/java/co/rsk/federate/EventsTestUtils.java
+++ b/src/test/java/co/rsk/federate/EventsTestUtils.java
@@ -5,6 +5,7 @@ import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.BridgeEvents;
+import co.rsk.peg.pegin.RejectedPeginReason;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -76,6 +77,20 @@ public final class EventsTestUtils {
         topics.add(DataWord.valueOf(updateCollectionsSignatureTopic));
 
         byte[] encodedData = updateCollectionsEvent.encodeEventData(senderAddress.toString());
+
+        return new LogInfo(PrecompiledContracts.BRIDGE_ADDR.getBytes(),
+            topics, encodedData);
+    }
+
+    public static LogInfo creatRejectedPeginLog(Sha256Hash pegoutBtcTxHash, RejectedPeginReason reason) {
+        CallTransaction.Function rejectedPeginEvent = BridgeEvents.REJECTED_PEGIN.getEvent();
+
+        byte[] rejectedPeginSignatureTopic = rejectedPeginEvent.encodeSignatureLong();
+        List<DataWord> topics = new ArrayList<>();
+        topics.add(DataWord.valueOf(rejectedPeginSignatureTopic));
+        topics.add(DataWord.valueOf(pegoutBtcTxHash.getBytes()));
+
+        byte[] encodedData = rejectedPeginEvent.encodeEventData(reason.getValue());
 
         return new LogInfo(PrecompiledContracts.BRIDGE_ADDR.getBytes(),
             topics, encodedData);

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -1,0 +1,28 @@
+package co.rsk.federate.bitcoin;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BitcoinTestUtils {
+
+    private BitcoinTestUtils() { }
+
+    public static List<Coin> coinListOf(long... values) {
+        return Arrays.stream(values)
+            .mapToObj(Coin::valueOf)
+            .collect(Collectors.toList());
+    }
+
+    public static Sha256Hash createHash(int nHash) {
+        byte[] bytes = new byte[32];
+        bytes[0] = (byte) (0xFF & nHash);
+        bytes[1] = (byte) (0xFF & nHash >> 8);
+        bytes[2] = (byte) (0xFF & nHash >> 16);
+        bytes[3] = (byte) (0xFF & nHash >> 24);
+
+        return Sha256Hash.wrap(bytes);
+    }
+}

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BitcoinTestUtils {
+public final class BitcoinTestUtils {
 
     private BitcoinTestUtils() { }
 


### PR DESCRIPTION
## Description

- Update the ReleaseCreationInformation class to include one new properties, List<Coin> utxoOutpointValues. Get the pegoutTransactionCreatedSignatureTopic value from BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent().encodeSignature().
- Initialize the utxoOutpointValues list to an empty list like this.outpointValues = Collections.emptyList();
- Add a new List<Coin> getUtxoOutpointValues() method.
- Add a new void decodeUtxoOutpointValues(TransactionReceipt transactionReceipt) method and save the outpoint values list in the utxoOutpointValues state variable in a Collections.unmodifiableList structure. Do a lazy loading when the getUtxoOutpointValues() method is called; if the list is null, call decodeUtxoOutpointValues.
- Add new tests for ReleaseCreationInformation class.
- Do some refactors to existing test cases of ReleaseCreationInformationGetterTest

## Motivation and Context

To add support to HSM segwit to the powpeg node

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)