### PR TITLE
Revisit default config values for PowHSMBookkeepingConfig

### DIFF
--- a/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
+++ b/src/main/java/co/rsk/federate/config/PowHSMBookkeepingConfig.java
@@ -26,20 +26,20 @@ public class PowHSMBookkeepingConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(PowHSMBookkeepingConfig.class);
 
-    private static final String DIFFICULTY_TARGET_PATH = "bookkeeping.difficultyTarget";
-    private static final BigInteger DIFFICULTY_TARGET_DEFAULT = BigInteger.valueOf(3);
+    public static final String DIFFICULTY_TARGET_PATH = "bookkeeping.difficultyTarget";
+    public static final BigInteger DIFFICULTY_TARGET_DEFAULT = BigInteger.valueOf(3);
 
-    private static final String MAX_AMOUNT_BLOCK_HEADERS_PATH = "bookkeeping.maxAmountBlockHeaders";
-    private static final int MAX_AMOUNT_BLOCK_HEADERS_DEFAULT = 7;
+    public static final String MAX_AMOUNT_BLOCK_HEADERS_PATH = "bookkeeping.maxAmountBlockHeaders";
+    public static final int MAX_AMOUNT_BLOCK_HEADERS_DEFAULT = 100;
 
-    private static final String MAX_CHUNK_SIZE_TO_HSM_PATH = "bookkeeping.maxChunkSizeToHsm";
-    private static final int MAX_CHUNK_SIZE_TO_HSM_DEFAULT = 10;
+    public static final String MAX_CHUNK_SIZE_TO_HSM_PATH = "bookkeeping.maxChunkSizeToHsm";
+    public static final int MAX_CHUNK_SIZE_TO_HSM_DEFAULT = 100;
 
-    private static final String INFORMER_INTERVAL_PATH = "bookkeeping.informerInterval";
-    private static final long INFORMER_INTERVAL_DEFAULT = 2_000;
+    public static final String INFORMER_INTERVAL_PATH = "bookkeeping.informerInterval";
+    public static final long INFORMER_INTERVAL_DEFAULT = 6 * 60 * 1000L; // 6 minutes in milliseconds
 
-    private static final String STOP_BOOKKEPING_SCHEDULER_PATH = "bookkeeping.stopBookkeepingScheduler";
-    private static final boolean STOP_BOOKKEPING_SCHEDULER_DEFAULT = false;
+    public static final String STOP_BOOKKEPING_SCHEDULER_PATH = "bookkeeping.stopBookkeepingScheduler";
+    public static final boolean STOP_BOOKKEPING_SCHEDULER_DEFAULT = false;
 
     private final Config signerConfig;
     private final String networkParameter;

--- a/src/main/java/co/rsk/federate/signing/hsm/client/HSMClientProtocolFactory.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/client/HSMClientProtocolFactory.java
@@ -14,9 +14,9 @@ public class HSMClientProtocolFactory {
     public static final String INTERVAL_BETWEEN_ATTEMPTS = "intervalBetweenAttempts";
     public static final String HSM_CONFIG_TYPE = "hsm";
 
-    public static final int DEFAULT_SOCKET_TIMEOUT = 10_000;
+    public static final int DEFAULT_SOCKET_TIMEOUT = 20_000;
     public static final int DEFAULT_ATTEMPTS = 2;
-    public static final int DEFAULT_INTERVAL = 1000;
+    public static final int DEFAULT_INTERVAL = 1_000;
 
     public HSMClientProtocol buildHSMClientProtocolFromConfig(SignerConfig config) throws HSMUnsupportedTypeException {
         if (!HSM_CONFIG_TYPE.equalsIgnoreCase(config.getType())) {

--- a/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
+++ b/src/test/java/co/rsk/federate/config/PowHSMBookkeepingConfigTest.java
@@ -1,5 +1,6 @@
 package co.rsk.federate.config;
 
+import static co.rsk.federate.config.PowHSMBookkeepingConfig.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,24 +21,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class PowHSMBookkeepingConfigTest {
 
-    private static final String DIFFICULTY_TARGET_PATH = "bookkeeping.difficultyTarget";
-    private static final BigInteger DIFFICULTY_TARGET_DEFAULT = BigInteger.valueOf(3);
-
-    private static final String MAX_AMOUNT_BLOCK_HEADERS_PATH = "bookkeeping.maxAmountBlockHeaders";
-    private static final int MAX_AMOUNT_BLOCK_HEADERS_DEFAULT = 7;
-
-    private static final String MAX_CHUNK_SIZE_TO_HSM_PATH = "bookkeeping.maxChunkSizeToHsm";
-    private static final int MAX_CHUNK_SIZE_TO_HSM_DEFAULT = 10;
-
-    private static final String INFORMER_INTERVAL_PATH = "bookkeeping.informerInterval";
-    private static final long INFORMER_INTERVAL_DEFAULT = 2_000;
-
-    private static final String STOP_BOOKKEPING_SCHEDULER_PATH = "bookkeeping.stopBookkeepingScheduler";
-    private static final boolean STOP_BOOKKEPING_SCHEDULER_DEFAULT = false;
-
     private PowHSMBookkeepingConfig powHsmBookkeepingConfig;
-    private SignerConfig signerConfig = mock(SignerConfig.class);
-    private Config config = mock(Config.class);
+    private final SignerConfig signerConfig = mock(SignerConfig.class);
+    private final Config config = mock(Config.class);
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
### Summary

The default config values found in the `PowHSMBookeeingConfig` class don’t make a lot of sense. The idea is to come up with better default values.