### PR TITLE
Add use of PowHSMSignerMessage::getMessageToSign  method to PowHSMSigningClientBtc

### DIFF
--- a/src/main/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtc.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtc.java
@@ -23,12 +23,11 @@ public class PowHSMSigningClientBtc extends PowHSMSigningClient {
     protected final ObjectNode createObjectToSend(String keyId, SignerMessage message) {
         PowHSMSignerMessage powHSMSignerMessage = (PowHSMSignerMessage) message;
 
-        ObjectNode objectToSign = this.hsmClientProtocol.buildCommand(SIGN.getCommand(),
-            this.getVersion());
+        ObjectNode objectToSign = hsmClientProtocol.buildCommand(SIGN.getCommand(),
+            getVersion());
         objectToSign.put(KEY_ID.getFieldName(), keyId);
         objectToSign.set(AUTH.getFieldName(), createAuthField(powHSMSignerMessage));
-        objectToSign.set(MESSAGE.getFieldName(),
-            ((PowHSMSignerMessage) message).getMessageToSign(version));
+        objectToSign.set(MESSAGE.getFieldName(), powHSMSignerMessage.getMessageToSign(version));
 
         return objectToSign;
     }

--- a/src/main/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtc.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtc.java
@@ -1,16 +1,17 @@
 package co.rsk.federate.signing.hsm.client;
 
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.federate.signing.hsm.HSMClientException;
+import static co.rsk.federate.signing.HSMCommand.SIGN;
+import static co.rsk.federate.signing.HSMField.AUTH;
+import static co.rsk.federate.signing.HSMField.KEY_ID;
+import static co.rsk.federate.signing.HSMField.MESSAGE;
+import static co.rsk.federate.signing.HSMField.RECEIPT;
+import static co.rsk.federate.signing.HSMField.RECEIPT_MERKLE_PROOF;
+
 import co.rsk.federate.signing.hsm.message.PowHSMSignerMessage;
 import co.rsk.federate.signing.hsm.message.SignerMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.ethereum.crypto.ECKey;
-
-import static co.rsk.federate.signing.HSMCommand.SIGN;
-import static co.rsk.federate.signing.HSMField.*;
 
 public class PowHSMSigningClientBtc extends PowHSMSigningClient {
 
@@ -22,10 +23,12 @@ public class PowHSMSigningClientBtc extends PowHSMSigningClient {
     protected final ObjectNode createObjectToSend(String keyId, SignerMessage message) {
         PowHSMSignerMessage powHSMSignerMessage = (PowHSMSignerMessage) message;
 
-        ObjectNode objectToSign = this.hsmClientProtocol.buildCommand(SIGN.getCommand(), this.getVersion());
+        ObjectNode objectToSign = this.hsmClientProtocol.buildCommand(SIGN.getCommand(),
+            this.getVersion());
         objectToSign.put(KEY_ID.getFieldName(), keyId);
         objectToSign.set(AUTH.getFieldName(), createAuthField(powHSMSignerMessage));
-        objectToSign.set(MESSAGE.getFieldName(), createMessageField(powHSMSignerMessage));
+        objectToSign.set(MESSAGE.getFieldName(),
+            ((PowHSMSignerMessage) message).getMessageToSign(version));
 
         return objectToSign;
     }
@@ -39,17 +42,5 @@ public class PowHSMSigningClientBtc extends PowHSMSigningClient {
         }
         auth.set(RECEIPT_MERKLE_PROOF.getFieldName(), receiptMerkleProof);
         return auth;
-    }
-
-    private ObjectNode createMessageField(PowHSMSignerMessage message) {
-        ObjectNode messageToSend = new ObjectMapper().createObjectNode();
-        messageToSend.put(TX.getFieldName(), message.getBtcTransactionSerialized());
-        messageToSend.put(INPUT.getFieldName(), message.getInputIndex());
-        return messageToSend;
-    }
-
-    public boolean verifySigHash(Sha256Hash sigHash, String keyId, HSMSignature signatureReturned) throws HSMClientException {
-        ECKey eckey = ECKey.fromPublicOnly(getPublicKey(keyId));
-        return eckey.verify(sigHash.getBytes(), signatureReturned.toEthSignature());
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
@@ -1,5 +1,10 @@
 package co.rsk.federate.signing.hsm.client;
 
+import static co.rsk.federate.EventsTestUtils.createBatchPegoutCreatedLog;
+import static co.rsk.federate.EventsTestUtils.createPegoutTransactionCreatedLog;
+import static co.rsk.federate.EventsTestUtils.createReleaseRequestedLog;
+import static co.rsk.federate.EventsTestUtils.createUpdateCollectionsLog;
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.coinListOf;
 import static co.rsk.federate.signing.HSMCommand.GET_PUB_KEY;
 import static co.rsk.federate.signing.HSMCommand.SIGN;
 import static co.rsk.federate.signing.HSMField.AUTH;
@@ -16,7 +21,10 @@ import static co.rsk.federate.signing.HSMField.S;
 import static co.rsk.federate.signing.HSMField.SIGNATURE;
 import static co.rsk.federate.signing.HSMField.TX;
 import static co.rsk.federate.signing.HSMField.VERSION;
+import static co.rsk.federate.signing.utils.TestUtils.createBaseInputScriptThatSpendsFromTheFederation;
+import static co.rsk.federate.signing.utils.TestUtils.createBlock;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -24,33 +32,131 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.TransactionWitness;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import co.rsk.federate.bitcoin.BitcoinTestUtils;
 import co.rsk.federate.rpc.JsonRpcClient;
 import co.rsk.federate.rpc.JsonRpcClientProvider;
 import co.rsk.federate.rpc.JsonRpcException;
 import co.rsk.federate.signing.ECDSASignerFactory;
 import co.rsk.federate.signing.hsm.HSMClientException;
 import co.rsk.federate.signing.hsm.message.PowHSMSignerMessage;
+import co.rsk.federate.signing.hsm.message.PowHSMSignerMessageBuilder;
+import co.rsk.federate.signing.hsm.message.ReleaseCreationInformation;
+import co.rsk.federate.signing.hsm.message.SignerMessageBuilderException;
+import co.rsk.federate.signing.utils.TestUtils;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import co.rsk.peg.federation.Federation;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Block;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.db.ReceiptStore;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class PowHSMSigningClientBtcTest {
-    private JsonRpcClient jsonRpcClientMock;
-    private PowHSMSigningClientBtc client;
+
     private final static int HSM_VERSION = 2;
+    private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
+    private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
+
+    private static final Address userAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams,
+        "userAddress");
+    private static final Federation newFederation = TestUtils.createFederation(
+        bridgeMainnetConstants.getBtcParams(), 9);
+    private static final Federation oldFederation = TestUtils.createFederation(
+        bridgeMainnetConstants.getBtcParams(), 9);
+    private static final int FIRST_OUTPUT_INDEX = 0;
+    private final String keyId = "a-key-id";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    private JsonRpcClient jsonRpcClientMock;
+    private PowHSMSigningClientBtc client;
+    private HSMClientProtocol hsmClientProtocol;
+
+    private Transaction pegoutCreationRskTx;
+    private Block pegoutCreationBlock;
+    private TransactionReceipt pegoutCreationRskTxReceipt;
+
+    private Transaction pegoutConfirmationRskTx;
+    private ReceiptStore receiptStore;
+
+    private static List<Arguments> signArgProvider() {
+        List<Arguments> arguments = new ArrayList<>();
+
+        int[] hsmVersions = {2, 4, 5};
+        for (int hsmVersion : hsmVersions) {
+            // 50_000_000 = FE80F0FA02, 75_000_000 = FEC0687804, 100_000_000 = FE00E1F505
+            arguments.add(
+                Arguments.of(hsmVersion, Hex.decode("FE80F0FA02"), coinListOf(50_000_000)));
+            arguments.add(
+                Arguments.of(hsmVersion, Hex.decode("FEC0687804"), coinListOf(75_000_000)));
+            arguments.add(Arguments.of(hsmVersion, Hex.decode("FE80F0FA02FEC0687804FE00E1F505"),
+                coinListOf(50_000_000, 75_000_000, 100_000_000)));
+        }
+
+        return arguments;
+    }
+
     @BeforeEach
-    void createClient() throws JsonRpcException {
+    void setup() throws JsonRpcException {
+        Keccak256 pegoutCreationRskTxHash = TestUtils.createHash(2);
+        pegoutCreationRskTx = mock(Transaction.class);
+        when(pegoutCreationRskTx.getHash()).thenReturn(pegoutCreationRskTxHash);
+        when(pegoutCreationRskTx.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
+
+        Keccak256 pegoutConfirmationRskTxHash = TestUtils.createHash(3);
+        pegoutConfirmationRskTx = mock(Transaction.class);
+        when(pegoutConfirmationRskTx.getHash()).thenReturn(pegoutConfirmationRskTxHash);
+        when(pegoutConfirmationRskTx.getReceiveAddress()).thenReturn(
+            PrecompiledContracts.BRIDGE_ADDR);
+
+        pegoutCreationBlock = createBlock(1, Collections.singletonList(pegoutCreationRskTx));
+
+        pegoutCreationRskTxReceipt = new TransactionReceipt();
+        pegoutCreationRskTxReceipt.setLogInfoList(Collections.emptyList());
+
+        TransactionInfo pegoutCreationRskTxInfo = mock(TransactionInfo.class);
+        when(pegoutCreationRskTxInfo.getReceipt()).thenReturn(pegoutCreationRskTxReceipt);
+        when(pegoutCreationRskTxInfo.getBlockHash()).thenReturn(
+            pegoutCreationBlock.getHash().getBytes());
+
+        receiptStore = mock(ReceiptStore.class);
+        when(receiptStore.get(pegoutCreationRskTx.getHash().getBytes(),
+            pegoutCreationBlock.getHash().getBytes())).thenReturn(
+            Optional.of(pegoutCreationRskTxInfo));
+
         JsonRpcClientProvider jsonRpcClientProviderMock = mock(JsonRpcClientProvider.class);
         jsonRpcClientMock = mock(JsonRpcClient.class);
         when(jsonRpcClientProviderMock.acquire()).thenReturn(jsonRpcClientMock);
 
-        HSMClientProtocol hsmClientProtocol = new HSMClientProtocol(jsonRpcClientProviderMock, ECDSASignerFactory.DEFAULT_ATTEMPTS, ECDSASignerFactory.DEFAULT_INTERVAL);
+        hsmClientProtocol = new HSMClientProtocol(jsonRpcClientProviderMock,
+            ECDSASignerFactory.DEFAULT_ATTEMPTS, ECDSASignerFactory.DEFAULT_INTERVAL);
         client = new PowHSMSigningClientBtc(hsmClientProtocol, HSM_VERSION);
     }
 
@@ -75,6 +181,271 @@ class PowHSMSigningClientBtcTest {
         assertArrayEquals(Hex.decode("001122334455"), signature.getPublicKey());
         verify(jsonRpcClientMock, times(1)).send(expectedSignRequest);
         verify(jsonRpcClientMock, times(1)).send(expectedPublicKeyRequest);
+    }
+
+    private BtcTransaction createPegout(List<Coin> outpointValues, Address destinationAddress,
+        boolean segwit) {
+        BtcTransaction fundingTransaction = new BtcTransaction(btcMainnetParams);
+        fundingTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX,
+            new Script(new byte[]{}));
+
+        for (Coin outpointValue : outpointValues) {
+            fundingTransaction.addOutput(outpointValue, oldFederation.getAddress());
+        }
+
+        BtcTransaction pegoutBtcTx = new BtcTransaction(btcMainnetParams);
+
+        Script inputScriptThatSpendsFromTheFederation = createBaseInputScriptThatSpendsFromTheFederation(
+            oldFederation);
+
+        Coin fee = Coin.MILLICOIN;
+        for (int inputIndex = 0; inputIndex < outpointValues.size(); inputIndex++) {
+            TransactionInput addedInput = pegoutBtcTx.addInput(
+                fundingTransaction.getOutput(inputIndex));
+            addedInput.setScriptSig(inputScriptThatSpendsFromTheFederation);
+            if (segwit) {
+                addWitness(pegoutBtcTx, inputIndex);
+            }
+
+            Coin amountToSend = outpointValues.get(inputIndex).minus(fee);
+            pegoutBtcTx.addOutput(amountToSend, destinationAddress);
+        }
+
+        return pegoutBtcTx;
+    }
+
+    private void addWitness(BtcTransaction pegoutBtcTx, int inputIndex) {
+        TransactionWitness txWitness = new TransactionWitness(1);
+        txWitness.setPush(0, new byte[]{0x1});
+        pegoutBtcTx.setWitness(inputIndex, txWitness);
+    }
+
+    @ParameterizedTest
+    @MethodSource("signArgProvider")
+    void sign_whenBatchPegoutHasNotPegoutTransactionCreatedEvent_returnsOk(int hsmVersion,
+        byte[] serializedOutpointValues, List<Coin> expectedOutpointValues)
+        throws JsonRpcException, SignerMessageBuilderException, HSMClientException {
+        // arrange
+        BtcTransaction pegoutBtcTx = createPegout(expectedOutpointValues, userAddress, false);
+        List<LogInfo> logs = new ArrayList<>();
+
+        ECKey senderKey = new ECKey();
+        RskAddress senderAddress = new RskAddress(senderKey.getAddress());
+        LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
+        logs.add(updateCollectionsLog);
+
+        Coin pegoutAmount = mock(Coin.class);
+        LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
+            pegoutBtcTx.getHash(), pegoutAmount);
+        logs.add(releaseRequestedLog);
+
+        LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(
+            pegoutBtcTx.getHash(), serializedOutpointValues);
+        logs.add(pegoutTransactionCreatedLog);
+
+        pegoutCreationRskTxReceipt.setLogInfoList(logs);
+        pegoutCreationRskTxReceipt.setTransaction(pegoutCreationRskTx);
+
+        ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
+            pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
+
+        client = new PowHSMSigningClientBtc(hsmClientProtocol, hsmVersion);
+
+        PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
+            receiptStore, releaseCreationInformation);
+
+        final int numOfInputsToSign = expectedOutpointValues.size();
+
+        ObjectNode expectedPublicKeyRequest = buildGetPublicKeyCommand(hsmVersion, keyId);
+        ObjectNode publicKeyResponse = buildResponse(0);
+        String publicKey = "001122334455";
+        publicKeyResponse.put(PUB_KEY.getFieldName(), publicKey);
+        when(jsonRpcClientMock.send(expectedPublicKeyRequest)).thenReturn(publicKeyResponse);
+
+        for (int inputIndex = 0; inputIndex < numOfInputsToSign; inputIndex++) {
+            ObjectNode response = buildSignResponse("223344", "55667788", 0);
+
+            PowHSMSignerMessage powHSMSignerMessage = (PowHSMSignerMessage) powHSMSignerMessageBuilder.buildMessageForIndex(
+                inputIndex);
+
+            ObjectNode expectedSignCommand = buildSignCommand(hsmVersion, keyId,
+                powHSMSignerMessage);
+            when(jsonRpcClientMock.send(expectedSignCommand)).thenReturn(response);
+
+            HSMSignature signature = client.sign(keyId, powHSMSignerMessage);
+
+            assertNotNull(signature);
+
+            verify(jsonRpcClientMock, times(1)).send(expectedSignCommand);
+            verify(jsonRpcClientMock, times(1)).send(expectedPublicKeyRequest);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("signArgProvider")
+    void sign_whenSegwitBatchPegoutHasPegoutTransactionCreatedEvent_returnsOk(int hsmVersion,
+        byte[] serializedOutpointValues, List<Coin> expectedOutpointValues)
+        throws JsonRpcException, SignerMessageBuilderException, HSMClientException {
+        // arrange
+        BtcTransaction pegoutBtcTx = createPegout(expectedOutpointValues, userAddress, true);
+        List<LogInfo> logs = new ArrayList<>();
+
+        ECKey senderKey = new ECKey();
+        RskAddress senderAddress = new RskAddress(senderKey.getAddress());
+        LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
+        logs.add(updateCollectionsLog);
+
+        Coin pegoutAmount = mock(Coin.class);
+        LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
+            pegoutBtcTx.getHash(), pegoutAmount);
+        logs.add(releaseRequestedLog);
+
+        List<Keccak256> pegoutRequestRskTxHashes = Collections.singletonList(
+            TestUtils.createHash(10));
+        LogInfo batchPegoutCreatedLog = createBatchPegoutCreatedLog(pegoutBtcTx.getHash(),
+            pegoutRequestRskTxHashes);
+        logs.add(batchPegoutCreatedLog);
+
+        LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(
+            pegoutBtcTx.getHash(), serializedOutpointValues);
+        logs.add(pegoutTransactionCreatedLog);
+
+        pegoutCreationRskTxReceipt.setLogInfoList(logs);
+        pegoutCreationRskTxReceipt.setTransaction(pegoutCreationRskTx);
+
+        ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
+            pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
+
+        client = new PowHSMSigningClientBtc(hsmClientProtocol, hsmVersion);
+
+        PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
+            receiptStore, releaseCreationInformation);
+
+        final int numOfInputsToSign = expectedOutpointValues.size();
+
+        ObjectNode expectedPublicKeyRequest = buildGetPublicKeyCommand(hsmVersion, keyId);
+        ObjectNode publicKeyResponse = buildResponse(0);
+        String publicKey = "001122334455";
+        publicKeyResponse.put(PUB_KEY.getFieldName(), publicKey);
+        when(jsonRpcClientMock.send(expectedPublicKeyRequest)).thenReturn(publicKeyResponse);
+
+        for (int inputIndex = 0; inputIndex < numOfInputsToSign; inputIndex++) {
+            ObjectNode response = buildSignResponse("223344", "55667788", 0);
+
+            PowHSMSignerMessage powHSMSignerMessage = (PowHSMSignerMessage) powHSMSignerMessageBuilder.buildMessageForIndex(
+                inputIndex);
+
+            ObjectNode expectedSignCommand = buildSignCommand(hsmVersion, keyId,
+                powHSMSignerMessage);
+            when(jsonRpcClientMock.send(expectedSignCommand)).thenReturn(response);
+
+            HSMSignature signature = client.sign(keyId, powHSMSignerMessage);
+
+            assertNotNull(signature);
+
+            verify(jsonRpcClientMock, times(1)).send(expectedSignCommand);
+            verify(jsonRpcClientMock, times(1)).send(expectedPublicKeyRequest);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("signArgProvider")
+    void sign_whenSegwitMigrationPegoutHasPegoutTransactionCreatedEvent_returnsOk(int hsmVersion,
+        byte[] serializedOutpointValues, List<Coin> expectedOutpointValues)
+        throws JsonRpcException, SignerMessageBuilderException, HSMClientException {
+        // arrange
+        BtcTransaction pegoutBtcTx = createPegout(expectedOutpointValues,
+            newFederation.getAddress(), true);
+
+        List<LogInfo> logs = new ArrayList<>();
+
+        ECKey senderKey = new ECKey();
+        RskAddress senderAddress = new RskAddress(senderKey.getAddress());
+        LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
+        logs.add(updateCollectionsLog);
+
+        Coin pegoutAmount = mock(Coin.class);
+        LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
+            pegoutBtcTx.getHash(), pegoutAmount);
+        logs.add(releaseRequestedLog);
+
+        LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(
+            pegoutBtcTx.getHash(), serializedOutpointValues);
+        logs.add(pegoutTransactionCreatedLog);
+
+        pegoutCreationRskTxReceipt.setLogInfoList(logs);
+        pegoutCreationRskTxReceipt.setTransaction(pegoutCreationRskTx);
+
+        ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
+            pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
+
+        client = new PowHSMSigningClientBtc(hsmClientProtocol, hsmVersion);
+
+        PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
+            receiptStore, releaseCreationInformation);
+
+        final int numOfInputsToSign = expectedOutpointValues.size();
+
+        ObjectNode expectedPublicKeyRequest = buildGetPublicKeyCommand(hsmVersion, keyId);
+        ObjectNode publicKeyResponse = buildResponse(0);
+        String publicKey = "001122334455";
+        publicKeyResponse.put(PUB_KEY.getFieldName(), publicKey);
+        when(jsonRpcClientMock.send(expectedPublicKeyRequest)).thenReturn(publicKeyResponse);
+
+        for (int inputIndex = 0; inputIndex < numOfInputsToSign; inputIndex++) {
+            ObjectNode response = buildSignResponse("223344", "55667788", 0);
+
+            PowHSMSignerMessage powHSMSignerMessage = (PowHSMSignerMessage) powHSMSignerMessageBuilder.buildMessageForIndex(
+                inputIndex);
+
+            ObjectNode expectedSignCommand = buildSignCommand(hsmVersion, keyId,
+                powHSMSignerMessage);
+            when(jsonRpcClientMock.send(expectedSignCommand)).thenReturn(response);
+
+            HSMSignature signature = client.sign(keyId, powHSMSignerMessage);
+
+            assertNotNull(signature);
+
+            verify(jsonRpcClientMock, times(1)).send(expectedSignCommand);
+            verify(jsonRpcClientMock, times(1)).send(expectedPublicKeyRequest);
+        }
+    }
+
+    private ObjectNode buildGetPublicKeyCommand(int hsmVersion, String keyId) {
+        ObjectNode request = objectMapper.createObjectNode();
+        request.put(COMMAND.getFieldName(), GET_PUB_KEY.getCommand());
+        request.put(VERSION.getFieldName(), hsmVersion);
+        request.put(KEY_ID.getFieldName(), keyId);
+
+        return request;
+    }
+
+    private ObjectNode buildSignCommand(int hsmVersion, String key,
+        PowHSMSignerMessage powHSMSignerMessage) {
+        // Message child
+        JsonNode message = powHSMSignerMessage.getMessageToSign(hsmVersion);
+
+        // Auth child
+        ObjectNode auth = objectMapper.createObjectNode();
+        auth.put(RECEIPT.getFieldName(), powHSMSignerMessage.getTransactionReceipt());
+
+        ArrayNode receiptMerkleProof = new ObjectMapper().createArrayNode();
+        for (String receiptMerkleProofValue : powHSMSignerMessage.getReceiptMerkleProof()) {
+            receiptMerkleProof.add(receiptMerkleProofValue);
+        }
+        auth.set(RECEIPT_MERKLE_PROOF.getFieldName(), receiptMerkleProof);
+
+        ObjectNode request = objectMapper.createObjectNode();
+        request.put(COMMAND.getFieldName(), SIGN.getCommand());
+        request.put(VERSION.getFieldName(), hsmVersion);
+        request.put(KEY_ID.getFieldName(), key);
+        request.set(AUTH.getFieldName(), auth);
+        request.set(MESSAGE.getFieldName(), message);
+
+        return request;
     }
 
     @Test
@@ -226,6 +597,11 @@ class PowHSMSigningClientBtcTest {
         when(messageForSignature.getReceiptMerkleProof()).thenReturn(new String[]{"cccc"});
         Sha256Hash sigHash = Sha256Hash.of(Hex.decode("bbccddee"));
         when(messageForSignature.getSigHash()).thenReturn(sigHash);
+
+        ObjectNode message = objectMapper.createObjectNode();
+        message.put(TX.getFieldName(), messageForSignature.getBtcTransactionSerialized());
+        message.put(INPUT.getFieldName(), messageForSignature.getInputIndex());
+        when(messageForSignature.getMessageToSign(HSM_VERSION)).thenReturn(message);
         return messageForSignature;
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -275,8 +275,8 @@ class PowHSMSignerMessageBuilderTest {
         assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
         String expectedBtcTxSerialized = Hex.toHexString(pegoutBtcTx.bitcoinSerialize());
-        String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
-        assertEquals(expectedBtcTxSerialized, ActualBtcTxSerialized);
+        String actualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
+        assertEquals(expectedBtcTxSerialized, actualBtcTxSerialized);
 
         String[] expectedReceiptMerkleProof = getEncodedReceiptMerkleProof(receiptStore);
         assertArrayEquals(expectedReceiptMerkleProof,
@@ -349,8 +349,8 @@ class PowHSMSignerMessageBuilderTest {
                 oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
             assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
-            String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
-            assertEquals(expectedBtcTxSerialized, ActualBtcTxSerialized);
+            String actualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
+            assertEquals(expectedBtcTxSerialized, actualBtcTxSerialized);
 
             assertArrayEquals(expectedReceiptMerkleProof,
                 actualPowHSMSignerMessage.getReceiptMerkleProof());
@@ -419,8 +419,8 @@ class PowHSMSignerMessageBuilderTest {
                 oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
             assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
-            String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
-            assertEquals(expectedBtcTxSerialized, ActualBtcTxSerialized);
+            String actualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
+            assertEquals(expectedBtcTxSerialized, actualBtcTxSerialized);
 
             assertArrayEquals(expectedReceiptMerkleProof,
                 actualPowHSMSignerMessage.getReceiptMerkleProof());
@@ -487,8 +487,8 @@ class PowHSMSignerMessageBuilderTest {
                 oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
             assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
-            String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
-            assertEquals(expectedBtcTxSerialized, ActualBtcTxSerialized);
+            String actualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
+            assertEquals(expectedBtcTxSerialized, actualBtcTxSerialized);
 
             assertArrayEquals(expectedReceiptMerkleProof,
                 actualPowHSMSignerMessage.getReceiptMerkleProof());

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -6,6 +6,7 @@ import static co.rsk.federate.EventsTestUtils.createPegoutTransactionCreatedLog;
 import static co.rsk.federate.EventsTestUtils.createReleaseRequestedLog;
 import static co.rsk.federate.EventsTestUtils.createUpdateCollectionsLog;
 import static co.rsk.federate.bitcoin.BitcoinTestUtils.coinListOf;
+import static co.rsk.federate.signing.utils.TestUtils.createBaseInputScriptThatSpendsFromTheFederation;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -60,9 +61,12 @@ class PowHSMSignerMessageBuilderTest {
 
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
-    private static final Address userAddress = BitcoinTestUtils.createP2PKHAddress(
-        btcMainnetParams, "userAddress");
-    private static final Federation activeFederation = TestUtils.createFederation(
+
+    private static final Address userAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams,
+        "userAddress");
+    private static final Federation newFederation = TestUtils.createFederation(
+        bridgeMainnetConstants.getBtcParams(), 9);
+    private static final Federation oldFederation = TestUtils.createFederation(
         bridgeMainnetConstants.getBtcParams(), 9);
 
     private Transaction pegoutCreationRskTx;
@@ -73,10 +77,9 @@ class PowHSMSignerMessageBuilderTest {
 
     private static List<Arguments> serializedAndDeserializedOutpointValuesArgProvider() {
         List<Arguments> arguments = new ArrayList<>();
-
-        arguments.add(Arguments.of(Hex.decode("00"), Collections.singletonList(Coin.ZERO)));
-        arguments.add(Arguments.of(Hex.decode("01"), Collections.singletonList(Coin.SATOSHI)));
         // 50_000_000 = FE80F0FA02, 75_000_000 = FEC0687804, 100_000_000 = FE00E1F505
+        arguments.add(Arguments.of(Hex.decode("FE80F0FA02"), coinListOf(50_000_000)));
+        arguments.add(Arguments.of(Hex.decode("FEC0687804"), coinListOf(75_000_000)));
         arguments.add(Arguments.of(Hex.decode("FE80F0FA02FEC0687804FE00E1F505"),
             coinListOf(50_000_000, 75_000_000, 100_000_000)));
 
@@ -93,7 +96,8 @@ class PowHSMSignerMessageBuilderTest {
         Keccak256 pegoutConfirmationRskTxHash = TestUtils.createHash(3);
         pegoutConfirmationRskTx = mock(Transaction.class);
         when(pegoutConfirmationRskTx.getHash()).thenReturn(pegoutConfirmationRskTxHash);
-        when(pegoutConfirmationRskTx.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
+        when(pegoutConfirmationRskTx.getReceiveAddress()).thenReturn(
+            PrecompiledContracts.BRIDGE_ADDR);
 
         pegoutCreationBlock = createBlock(1, Collections.singletonList(pegoutCreationRskTx));
 
@@ -141,7 +145,8 @@ class PowHSMSignerMessageBuilderTest {
         when(receiptStore.get(rskTxHash.getBytes(), Keccak256.ZERO_HASH.getBytes())).thenReturn(
             Optional.of(txInfo));
 
-        BtcTransaction pegoutBtcTx = createPegout();
+        List<Coin> outpointValues = Collections.singletonList(Coin.COIN);
+        BtcTransaction pegoutBtcTx = createPegout(outpointValues, userAddress, false);
         int inputIndex = 0;
 
         //Act
@@ -161,7 +166,7 @@ class PowHSMSignerMessageBuilderTest {
         for (int i = 0; i < encodedReceipts.length; i++) {
             encodedReceipts[i] = Hex.toHexString(receiptMerkleProof.get(i).toMessage());
         }
-        Sha256Hash sigHash = pegoutBtcTx.hashForSignature(0, activeFederation.getRedeemScript(),
+        Sha256Hash sigHash = pegoutBtcTx.hashForSignature(0, oldFederation.getRedeemScript(),
             BtcTransaction.SigHash.ALL, false);
 
         assertEquals(Hex.toHexString(pegoutBtcTx.bitcoinSerialize()),
@@ -198,12 +203,10 @@ class PowHSMSignerMessageBuilderTest {
 
     private String[] getEncodedReceiptMerkleProof(ReceiptStore receiptStore) {
         List<Trie> receiptMerkleProof = BlockHashesHelper.calculateReceiptsTrieRootFor(
-            pegoutCreationBlock,
-            receiptStore, pegoutCreationRskTx.getHash());
+            pegoutCreationBlock, receiptStore, pegoutCreationRskTx.getHash());
         String[] encodedReceiptMerkleProof = new String[receiptMerkleProof.size()];
         for (int i = 0; i < encodedReceiptMerkleProof.length; i++) {
-            encodedReceiptMerkleProof[i] = Hex.toHexString(
-                receiptMerkleProof.get(i).toMessage());
+            encodedReceiptMerkleProof[i] = Hex.toHexString(receiptMerkleProof.get(i).toMessage());
         }
         return encodedReceiptMerkleProof;
     }
@@ -212,7 +215,8 @@ class PowHSMSignerMessageBuilderTest {
     void buildMessageForIndex_whenLegacyBatchPegoutHasTransactionCreatedEvent_ok()
         throws SignerMessageBuilderException {
         // arrange
-        BtcTransaction pegoutBtcTx = createPegout();
+        List<Coin> outpointValues = Collections.singletonList(Coin.COIN);
+        BtcTransaction pegoutBtcTx = createPegout(outpointValues, userAddress, false);
 
         List<LogInfo> logs = new ArrayList<>();
 
@@ -221,7 +225,7 @@ class PowHSMSignerMessageBuilderTest {
         LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
         logs.add(updateCollectionsLog);
 
-        Coin pegoutAmount = bridgeMainnetConstants.getMinimumPegoutTxValue();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);
@@ -245,8 +249,7 @@ class PowHSMSignerMessageBuilderTest {
 
         ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
             pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx,
-            pegoutConfirmationRskTx.getHash());
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
         PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
             receiptStore, releaseCreationInformation);
 
@@ -268,8 +271,7 @@ class PowHSMSignerMessageBuilderTest {
         assertEquals(inputIndex, actualInputIndex);
 
         Sha256Hash expectedSigHash = pegoutBtcTx.hashForSignature(inputIndex,
-            activeFederation.getRedeemScript(),
-            BtcTransaction.SigHash.ALL, false);
+            oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
         assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
         String expectedBtcTxSerialized = Hex.toHexString(pegoutBtcTx.bitcoinSerialize());
@@ -287,7 +289,7 @@ class PowHSMSignerMessageBuilderTest {
         byte[] serializedOutpointValues, List<Coin> expectedOutpointValues)
         throws SignerMessageBuilderException {
         // arrange
-        BtcTransaction pegoutBtcTx = createSegwitPegout(expectedOutpointValues);
+        BtcTransaction pegoutBtcTx = createPegout(expectedOutpointValues, userAddress, true);
 
         List<LogInfo> logs = new ArrayList<>();
 
@@ -296,7 +298,7 @@ class PowHSMSignerMessageBuilderTest {
         LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
         logs.add(updateCollectionsLog);
 
-        Coin pegoutAmount = bridgeMainnetConstants.getMinimumPegoutTxValue();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);
@@ -320,8 +322,7 @@ class PowHSMSignerMessageBuilderTest {
 
         ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
             pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx,
-            pegoutConfirmationRskTx.getHash());
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
         PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
             receiptStore, releaseCreationInformation);
 
@@ -345,8 +346,7 @@ class PowHSMSignerMessageBuilderTest {
             assertEquals(inputIndex, actualInputIndex);
 
             Sha256Hash expectedSigHash = pegoutBtcTx.hashForSignature(inputIndex,
-                activeFederation.getRedeemScript(),
-                BtcTransaction.SigHash.ALL, false);
+                oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
             assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
             String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
@@ -363,7 +363,8 @@ class PowHSMSignerMessageBuilderTest {
         byte[] serializedOutpointValues, List<Coin> expectedOutpointValues)
         throws SignerMessageBuilderException {
         // arrange
-        BtcTransaction pegoutBtcTx = createSegwitPegout(expectedOutpointValues);
+        BtcTransaction pegoutBtcTx = createPegout(expectedOutpointValues,
+            newFederation.getAddress(), true);
 
         List<LogInfo> logs = new ArrayList<>();
 
@@ -372,7 +373,7 @@ class PowHSMSignerMessageBuilderTest {
         LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
         logs.add(updateCollectionsLog);
 
-        Coin pegoutAmount = bridgeMainnetConstants.getMinimumPegoutTxValue();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);
@@ -390,8 +391,7 @@ class PowHSMSignerMessageBuilderTest {
 
         ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
             pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx,
-            pegoutConfirmationRskTx.getHash());
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
         PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
             receiptStore, releaseCreationInformation);
 
@@ -416,8 +416,7 @@ class PowHSMSignerMessageBuilderTest {
             assertEquals(inputIndex, actualInputIndex);
 
             Sha256Hash expectedSigHash = pegoutBtcTx.hashForSignature(inputIndex,
-                activeFederation.getRedeemScript(),
-                BtcTransaction.SigHash.ALL, false);
+                oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
             assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
             String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
@@ -434,7 +433,7 @@ class PowHSMSignerMessageBuilderTest {
         byte[] serializedOutpointValues, List<Coin> expectedOutpointValues)
         throws SignerMessageBuilderException {
         // arrange
-        BtcTransaction pegoutBtcTx = createSegwitPegout(expectedOutpointValues);
+        BtcTransaction pegoutBtcTx = createPegout(expectedOutpointValues, userAddress, true);
 
         List<LogInfo> logs = new ArrayList<>();
 
@@ -442,7 +441,7 @@ class PowHSMSignerMessageBuilderTest {
             RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
         logs.add(rejectedPeginLog);
 
-        Coin pegoutAmount = bridgeMainnetConstants.getMinimumPegoutTxValue();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);
@@ -460,8 +459,7 @@ class PowHSMSignerMessageBuilderTest {
 
         ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
             pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx,
-            pegoutConfirmationRskTx.getHash());
+            pegoutBtcTx, pegoutConfirmationRskTx.getHash());
         PowHSMSignerMessageBuilder powHSMSignerMessageBuilder = new PowHSMSignerMessageBuilder(
             receiptStore, releaseCreationInformation);
 
@@ -486,8 +484,7 @@ class PowHSMSignerMessageBuilderTest {
             assertEquals(inputIndex, actualInputIndex);
 
             Sha256Hash expectedSigHash = pegoutBtcTx.hashForSignature(inputIndex,
-                activeFederation.getRedeemScript(),
-                BtcTransaction.SigHash.ALL, false);
+                oldFederation.getRedeemScript(), BtcTransaction.SigHash.ALL, false);
             assertEquals(expectedSigHash, actualPowHSMSignerMessage.getSigHash());
 
             String ActualBtcTxSerialized = actualPowHSMSignerMessage.getBtcTransactionSerialized();
@@ -498,55 +495,40 @@ class PowHSMSignerMessageBuilderTest {
         }
     }
 
-    private Script createBaseInputScriptThatSpendsFromTheFederation() {
-        Script scriptPubKey = activeFederation.getP2SHScript();
-        return scriptPubKey.createEmptyInputScript(null, activeFederation.getRedeemScript());
-    }
-
-    private BtcTransaction createPegout() {
-        Coin fundingAmount = Coin.COIN;
-        Coin amountToSend = bridgeMainnetConstants.getMinimumPegoutTxValue();
+    private BtcTransaction createPegout(List<Coin> outpointValues, Address destinationAddress,
+        boolean segwit) {
         BtcTransaction fundingTransaction = new BtcTransaction(btcMainnetParams);
-        fundingTransaction.addInput(
-            BitcoinTestUtils.createHash(1),
-            FIRST_OUTPUT_INDEX,
-            new Script(new byte[]{})
-        );
-        fundingTransaction.addOutput(fundingAmount, activeFederation.getAddress());
+        fundingTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX,
+            new Script(new byte[]{}));
+
+        for (Coin outpointValue : outpointValues) {
+            fundingTransaction.addOutput(outpointValue, oldFederation.getAddress());
+        }
 
         BtcTransaction pegoutBtcTx = new BtcTransaction(btcMainnetParams);
-        TransactionInput addedInput = pegoutBtcTx.addInput(
-            fundingTransaction.getOutput(FIRST_OUTPUT_INDEX));
-        Script inputScriptThatSpendsFromTheFederation = createBaseInputScriptThatSpendsFromTheFederation();
-        addedInput.setScriptSig(inputScriptThatSpendsFromTheFederation);
-        pegoutBtcTx.addOutput(amountToSend, userAddress);
+
+        Script inputScriptThatSpendsFromTheFederation = createBaseInputScriptThatSpendsFromTheFederation(
+            oldFederation);
+
+        Coin fee = Coin.MILLICOIN;
+        for (int inputIndex = 0; inputIndex < outpointValues.size(); inputIndex++) {
+            TransactionInput addedInput = pegoutBtcTx.addInput(
+                fundingTransaction.getOutput(inputIndex));
+            addedInput.setScriptSig(inputScriptThatSpendsFromTheFederation);
+            if (segwit) {
+                addWitness(pegoutBtcTx, inputIndex);
+            }
+
+            Coin amountToSend = outpointValues.get(inputIndex).minus(fee);
+            pegoutBtcTx.addOutput(amountToSend, destinationAddress);
+        }
 
         return pegoutBtcTx;
     }
 
-    private BtcTransaction createSegwitPegout(List<Coin> outpointValues) {
-        BtcTransaction fundingTransaction = new BtcTransaction(btcMainnetParams);
-        fundingTransaction.addInput(
-            BitcoinTestUtils.createHash(1),
-            FIRST_OUTPUT_INDEX,
-            new Script(new byte[]{})
-        );
-
-        for (Coin outpointValue : outpointValues) {
-            fundingTransaction.addOutput(outpointValue, activeFederation.getAddress());
-        }
-
-        BtcTransaction segwitPegoutBtcTx = new BtcTransaction(btcMainnetParams);
-
-        Script inputScriptThatSpendsFromTheFederation = createBaseInputScriptThatSpendsFromTheFederation();
-        TransactionWitness txWitness = new TransactionWitness(outpointValues.size());
-        for (int i = 0; i < outpointValues.size(); i++) {
-            TransactionInput addedInput = segwitPegoutBtcTx.addInput(
-                fundingTransaction.getOutput(i));
-            addedInput.setScriptSig(inputScriptThatSpendsFromTheFederation);
-            txWitness.setPush(i, new byte[]{0x1});
-            segwitPegoutBtcTx.setWitness(i, txWitness);
-        }
-        return segwitPegoutBtcTx;
+    private void addWitness(BtcTransaction pegoutBtcTx, int inputIndex) {
+        TransactionWitness txWitness = new TransactionWitness(1);
+        txWitness.setPush(0, new byte[]{0x1});
+        pegoutBtcTx.setWitness(inputIndex, txWitness);
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -6,6 +6,7 @@ import static co.rsk.federate.EventsTestUtils.createPegoutTransactionCreatedLog;
 import static co.rsk.federate.EventsTestUtils.createReleaseRequestedLog;
 import static co.rsk.federate.EventsTestUtils.createUpdateCollectionsLog;
 import static co.rsk.federate.bitcoin.BitcoinTestUtils.coinListOf;
+import static co.rsk.federate.signing.utils.TestUtils.createBlock;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,18 +23,13 @@ import co.rsk.federate.bitcoin.BitcoinTestUtils;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.bitcoin.UtxoUtils;
-import co.rsk.peg.constants.BridgeConstants;
-import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
-import org.ethereum.core.BlockHeader;
-import org.ethereum.core.BlockHeaderBuilder;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
@@ -52,7 +48,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ReleaseCreationInformationGetterTest {
 
-    private final BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
     private BtcTransaction pegoutBtcTx;
     private Transaction pegoutCreationRskTx;
     private Block pegoutCreationBlock;
@@ -101,15 +96,6 @@ class ReleaseCreationInformationGetterTest {
             pegoutCreationBlock.getHash().getBytes());
     }
 
-    private Block createBlock(int blockNumber, List<Transaction> rskTxs) {
-
-        int parentBlockNumber = blockNumber > 0 ? blockNumber - 1 : 0;
-        BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
-            .setNumber(blockNumber)
-            .setParentHashFromKeccak256(TestUtils.createHash(parentBlockNumber))
-            .build();
-        return new Block(blockHeader, rskTxs, Collections.emptyList(), true, true);
-    }
 
     @Test
     void createGetTxInfoToSign_returnOK() throws HSMReleaseCreationInformationException {
@@ -473,7 +459,7 @@ class ReleaseCreationInformationGetterTest {
         LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
         logs.add(updateCollectionsLog);
 
-        Coin pegoutAmount = bridgeConstants.getMinimumPegoutTxValue();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);
@@ -542,7 +528,7 @@ class ReleaseCreationInformationGetterTest {
         LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
         logs.add(updateCollectionsLog);
 
-        Coin pegoutAmount = pegoutBtcTx.getInputSum();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);
@@ -604,7 +590,7 @@ class ReleaseCreationInformationGetterTest {
             RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
         logs.add(rejectedPeginLog);
 
-        Coin pegoutAmount = pegoutBtcTx.getInputSum();
+        Coin pegoutAmount = mock(Coin.class);
         LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
             pegoutBtcTx.getHash(), pegoutAmount);
         logs.add(releaseRequestedLog);

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -30,12 +30,25 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockHeader;
+import org.ethereum.core.BlockHeaderBuilder;
+import org.ethereum.core.Transaction;
 
 public final class TestUtils {
 
     private TestUtils() {
+    }
+
+    public static Block createBlock(int blockNumber, List<Transaction> rskTxs) {
+
+        int parentBlockNumber = blockNumber > 0 ? blockNumber - 1 : 0;
+        BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
+            .setNumber(blockNumber)
+            .setParentHashFromKeccak256(TestUtils.createHash(parentBlockNumber))
+            .build();
+        return new Block(blockHeader, rskTxs, Collections.emptyList(), true, true);
     }
 
     public static Keccak256 createHash(int nHash) {


### PR DESCRIPTION
Add use of PowHSMSignerMessage::getMessageToSign method from PowHSMSigningClientBtc class. It should be able to build the message for each different version.

## Description

- Use getMessageToSign method from PowHSMSigningClientBtc
- Get rid of unused methods createMessageField and verifySigHash
- Add tests to PowHSMSigningClientBtcTest
- Refactored and enhanced PowHSMSignerMessageBuilderTest

## Motivation and Context

Add use of PowHSMSignerMessage::getMessageToSign  method to enable HSM segwit support for the powpeg

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)