### PR TITLE
Updating github ref

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           POW_REF: ${{ github.ref }}
         run: |
-          IS_RSKJ_REF=$(git ls-remote --refs "$POW_REF")
+          IS_RSKJ_REF=$(git ls-remote --refs ${{ github.ref_name }})
           if test -n "${IS_RSKJ_REF}"; then
             echo "Found matching ref in RSKj"
             CHECKOUT_REF="$POW_REF"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,9 +64,9 @@ jobs:
         if: github.event_name != 'pull_request'
         working-directory: rskj
         env:
-          POW_REF: ${{ github.ref }}
+          POW_REF: ${{ github.ref_name }}
         run: |
-          IS_RSKJ_REF=$(git ls-remote --refs ${{ github.ref_name }})
+          IS_RSKJ_REF=$(git ls-remote --refs "$POW_REF")
           if test -n "${IS_RSKJ_REF}"; then
             echo "Found matching ref in RSKj"
             CHECKOUT_REF="$POW_REF"


### PR DESCRIPTION
Fixing branch naming reference for push step.

The change [was tested](https://github.com/nagarev/test-gh-actions/actions/runs/10219302775/job/28277278864) using a (public) github repository.

![Screenshot 2024-08-02 at 15 36 24](https://github.com/user-attachments/assets/0fc04f2b-6df0-467a-9a13-2f685e8bf547)
_**Figure 1:** When using `${{ github.ref_name }}` on the Push Step the correct branch name was included (main). The string `naza` was used only to make the step fail, which it did due to more than one reference being issued to the command (`naza` and `main`)._