### PR TITLE
Fix refs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           POW_REF: ${{ github.ref_name }}
         run: |
-          IS_RSKJ_REF=$(git ls-remote --refs "$POW_REF")
+          IS_RSKJ_REF=$(git ls-remote --refs https://github.com/rsksmart/rskj "$POW_REF")
           if test -n "${IS_RSKJ_REF}"; then
             echo "Found matching ref in RSKj"
             CHECKOUT_REF="$POW_REF"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name != 'pull_request'
         working-directory: rskj
         env:
-          POW_REF: ${{ github.name }}
+          POW_REF: ${{ github.ref }}
         run: |
           IS_RSKJ_REF=$(git ls-remote --refs https://github.com/rsksmart/rskj "$POW_REF")
           if test -n "${IS_RSKJ_REF}"; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name != 'pull_request'
         working-directory: rskj
         env:
-          POW_REF: ${{ github.ref_name }}
+          POW_REF: ${{ github.name }}
         run: |
           IS_RSKJ_REF=$(git ls-remote --refs https://github.com/rsksmart/rskj "$POW_REF")
           if test -n "${IS_RSKJ_REF}"; then


### PR DESCRIPTION
As seen in the screenshots, there's no difference in using `refs/heads/master` or `master` for this command:

![Screenshot 2024-08-05 at 13 55 24](https://github.com/user-attachments/assets/b5fc53c1-2a97-4c0c-abc0-f66a28a8cba5)

![Screenshot 2024-08-05 at 13 55 50](https://github.com/user-attachments/assets/3aa0aed5-54b7-4961-b169-efa72912cd8b)

so I'm rolling back the variable `POW_REF` to it's previous value `github.ref` instead of `github.ref_name`.