### PR TITLE
Fixing some issues on RIT workflow

### DIFF
--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -1,8 +1,6 @@
 name: Rootstock Integration Tests
 
 on:
-  push:
-    branches: ["master", "*-rc"]
   pull_request:
     types: [ opened, synchronize, reopened ]
     branches: [ "master", "*-rc" ]
@@ -17,31 +15,91 @@ on:
         required: false
         default: 'master'
 
+env:
+  REGEX_PARSE_BRANCH: '([a-zA-Z0-9/_-]+)'
+  VALID_BRANCH_REGEX: '^[a-zA-Z0-9._/-]+$'
+
 jobs:
   rootstock-integration-tests:
     name: Rootstock Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: Fetch Pull Request Description
+        id: fetch-pr-description
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo 'pr_description<<EOF'
+            gh pr view ${{ github.event.pull_request.number }} --json body -q .body
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - name: Set Branch Variables
         id: set-branch-variables
+        env:
+          PR_DESCRIPTION: ${{ env.pr_description }}
         run: |
           # Default values
           POWPEG_BRANCH="master"
-          RIT_BRANCH="${{ github.event.inputs.rit-branch || 'main' }}"
-          RSKJ_BRANCH="${{ github.event.inputs.rskj-branch || 'master' }}"
-
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/*-rc" ]]; then
-            POWPEG_BRANCH="${{ github.ref }}"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          
+          # Set the POWPEG_BRANCH branch
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             POWPEG_BRANCH="${{ github.ref_name }}"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            POWPEG_BRANCH="${{ github.head_ref }}"
+            if [[  "$PR_DESCRIPTION" =~ '`'fed:${{ env.REGEX_PARSE_BRANCH }}'`' ]]; then
+              POWPEG_BRANCH="${BASH_REMATCH[1]}"
+            else
+              POWPEG_BRANCH="${{ github.head_ref }}"
+            fi
+          fi
+          
+          # Set the RSKj branch
+          if [[ -n "${{ github.event.inputs.rskj-branch }}" ]]; then
+            RSKJ_BRANCH="${{ github.event.inputs.rskj-branch }}"
+          elif [[ "$PR_DESCRIPTION" =~ '`'rskj:${{ env.REGEX_PARSE_BRANCH }}'`' ]]; then
+            RSKJ_BRANCH="${BASH_REMATCH[1]}"
+          else
+            RSKJ_BRANCH="master"
+          fi
+          
+          # Set the RIT branch
+          if [[ -n "${{ github.event.inputs.rit-branch }}" ]]; then
+            RIT_BRANCH="${{ github.event.inputs.rit-branch }}"
+          elif [[ "$PR_DESCRIPTION" =~ '`'rit:${{ env.REGEX_PARSE_BRANCH }}'`' ]]; then
+            RIT_BRANCH="${BASH_REMATCH[1]}"
+          else
+            RIT_BRANCH="main"
+          fi
+          
+          if ! [[ "$RIT_BRANCH" =~ ${{ env.VALID_BRANCH_REGEX }}  ]]; then
+            echo "Error: Invalid RIT branch name: $RIT_BRANCH"
+            exit 1
+          fi
+    
+          if ! [[ "$POWPEG_BRANCH" =~ ${{ env.VALID_BRANCH_REGEX }}  ]]; then
+            echo "Error: Invalid PowPeg branch name: $POWPEG_BRANCH"
+            exit 1
+          fi
+    
+          if ! [[ "$RSKJ_BRANCH" =~ ${{ env.VALID_BRANCH_REGEX }}  ]]; then
+            echo "Error: Invalid RSKJ branch name: $RSKJ_BRANCH"
+            exit 1
           fi
 
+          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
           echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
-          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
+
+      - name: Set Build URL
+        id: set-build-url
+        run: |
+          BUILD_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "BUILD_URL=$BUILD_URL" >> $GITHUB_ENV
 
       - name: Run Rootstock Integration Tests
         uses: rsksmart/rootstock-integration-tests@497172fd38dcfaf48c77f9bb1eeb6617eef5eed6 #v1
@@ -49,3 +107,37 @@ jobs:
           rskj-branch: ${{ env.RSKJ_BRANCH }}
           powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
           rit-branch: ${{ env. RIT_BRANCH }}
+
+      - name: Send Slack Notification on Success
+        if: success() && github.event.pull_request.head.repo.owner.login == 'rsksmart'
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: 'C8X9Q4PBM' # integration-tests channel
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "good",
+                  "text": "OK: :+1: Pull request: ${{ github.head_ref }}  - [#${{ github.run_number }}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
+
+      - name: Send Slack Notification on Failure
+        if: failure() && github.event.pull_request.head.repo.owner.login == 'rsksmart'
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          channel-id: 'C8X9Q4PBM' # integration-tests channel
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "danger",
+                  "text": "FAILED: :robot_face: *Pull request*: ${{ github.head_ref }}  - [#${{ github.run_number }}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -104,6 +104,15 @@ jobs:
           BUILD_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "BUILD_URL=$BUILD_URL" >> $GITHUB_ENV
 
+      - name: Sanitize Branch Name
+        id: sanitize-branch-name
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # Delete non-alphanumeric characters and limit to 255 chars which is the branch limit in GitHub
+          SAFE_BRANCH_NAME=$(echo "${GITHUB_HEAD_REF}" | tr -cd '[:alnum:]_-' | cut -c1-255)
+          echo "SAFE_BRANCH_NAME=$SAFE_BRANCH_NAME" >> $GITHUB_ENV
+
       - name: Run Rootstock Integration Tests
         uses: rsksmart/rootstock-integration-tests@497172fd38dcfaf48c77f9bb1eeb6617eef5eed6 #v1
         with:
@@ -116,8 +125,6 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
-          github_head_ref: ${{ github.head_ref }}
-          github_run_number: ${{ github.run_number }}
         with:
           channel-id: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
           payload: |
@@ -125,7 +132,7 @@ jobs:
               "attachments": [
                 {
                   "color": "good",
-                  "text": "OK: :+1: Pull request: ${github_head_ref}  - [#${github_run_number}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
+                  "text": "OK: :+1:  *Pull request*: ${{ env.SAFE_BRANCH_NAME }} - [#${{ github.run_number }}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
                 }
               ]
             }
@@ -135,8 +142,6 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
-          github_head_ref: ${{ github.head_ref }}
-          github_run_number: ${{ github.run_number }}
         with:
           channel-id: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
           payload: |
@@ -144,7 +149,7 @@ jobs:
               "attachments": [
                 {
                   "color": "danger",
-                  "text": "FAILED: :robot_face: *Pull request*: ${github_head_ref}  - [#${github_run_number}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
+                  "text": "FAILED: :robot_face: *Pull request*: ${{ env.SAFE_BRANCH_NAME }} - [#${{ github.run_number }}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
                 }
               ]
             }

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -15,86 +15,88 @@ on:
         required: false
         default: 'master'
 
-env:
-  REGEX_PARSE_BRANCH: '([a-zA-Z0-9/_-]+)'
-  VALID_BRANCH_REGEX: '^[a-zA-Z0-9._/-]+$'
-
 jobs:
   rootstock-integration-tests:
     name: Rootstock Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Checkout Repository
+      - name: Checkout Repository # Step needed to access the PR description using github CLI
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: Fetch Pull Request Description
-        id: fetch-pr-description
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          {
-            echo 'pr_description<<EOF'
-            gh pr view ${{ github.event.pull_request.number }} --json body -q .body
-            echo EOF
-          } >> "$GITHUB_ENV"
 
       - name: Set Branch Variables
         id: set-branch-variables
         env:
-          PR_DESCRIPTION: ${{ env.pr_description }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_event_input_rskj_branch: ${{ github.event.inputs.rskj-branch }}
+          github_event_input_rit_branch: ${{ github.event.inputs.rit-branch }}
+          github_event_name: ${{ github.event_name }}
+          github_event_pull_request_number: ${{ github.event.pull_request.number }}
+          github_head_ref: ${{ github.head_ref }}
+          github_ref_name: ${{ github.ref_name }}
         run: |
-          # Default values
-          POWPEG_BRANCH="master"
-          
-          # Set the POWPEG_BRANCH branch
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            POWPEG_BRANCH="${{ github.ref_name }}"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            if [[  "$PR_DESCRIPTION" =~ '`'fed:${{ env.REGEX_PARSE_BRANCH }}'`' ]]; then
-              POWPEG_BRANCH="${BASH_REMATCH[1]}"
-            else
-              POWPEG_BRANCH="${{ github.head_ref }}"
-            fi
-          fi
-          
-          # Set the RSKj branch
-          if [[ -n "${{ github.event.inputs.rskj-branch }}" ]]; then
-            RSKJ_BRANCH="${{ github.event.inputs.rskj-branch }}"
-          elif [[ "$PR_DESCRIPTION" =~ '`'rskj:${{ env.REGEX_PARSE_BRANCH }}'`' ]]; then
-            RSKJ_BRANCH="${BASH_REMATCH[1]}"
+          PR_DESCRIPTION=pr-description.txt
+
+          ALLOWED_BRANCH_CHARACTERS='[-./0-9A-Z_a-z]'
+
+          default_rskj_branch=master
+          default_powpeg_branch=master
+          default_rit_branch=main
+
+          get_branch_from_description()
+          {
+            _prefix=$1
+
+            # On lines matching "`$_prefix:...`", replace the lines with the
+            # thing in ... and print the result.
+            _search_re='\@`'$_prefix:$ALLOWED_BRANCH_CHARACTERS'\{1,\}`@'
+            _replace_re='s@.*`'$_prefix:'\('$ALLOWED_BRANCH_CHARACTERS'\{1,\}\)`.*@\1@p'
+            _branch=$(sed -n "$_search_re $_replace_re" "$PR_DESCRIPTION")
+            echo "$_branch"
+          }
+
+          is_valid_branch_name()
+          {
+            echo "$1" | grep -qx "$ALLOWED_BRANCH_CHARACTERS\\{1,\\}"
+          }
+
+          if [ "$github_event_name" = workflow_dispatch ]; then
+            POWPEG_BRANCH=$github_ref_name
+            RSKJ_BRANCH=${github_event_inputs_rskj_branch:-$default_rskj_branch}
+            RIT_BRANCH=${github_event_inputs_rit_branch:-$default_rit_branch}
+          elif [ "$github_event_name" = pull_request ]; then
+            gh pr view "$github_event_pull_request_number" --json body -q .body >"$PR_DESCRIPTION"
+
+            POWPEG_BRANCH=$(get_branch_from_description fed)
+            : ${POWPEG_BRANCH:=${github_head_ref:-$default_powpeg_branch}}
+
+            RSKJ_BRANCH=$(get_branch_from_description rskj)
+            : ${RSKJ_BRANCH:=$default_rskj_branch}
+
+            RIT_BRANCH=$(get_branch_from_description rit)
+            : ${RIT_BRANCH:=$default_rit_branch}
           else
-            RSKJ_BRANCH="master"
+            RSKJ_BRANCH=$default_rskj_branch
+            POWPEG_BRANCH=$default_powpeg_branch
+            RIT_BRANCH=$default_rit_branch
           fi
-          
-          # Set the RIT branch
-          if [[ -n "${{ github.event.inputs.rit-branch }}" ]]; then
-            RIT_BRANCH="${{ github.event.inputs.rit-branch }}"
-          elif [[ "$PR_DESCRIPTION" =~ '`'rit:${{ env.REGEX_PARSE_BRANCH }}'`' ]]; then
-            RIT_BRANCH="${BASH_REMATCH[1]}"
-          else
-            RIT_BRANCH="main"
-          fi
-          
-          if ! [[ "$RIT_BRANCH" =~ ${{ env.VALID_BRANCH_REGEX }}  ]]; then
-            echo "Error: Invalid RIT branch name: $RIT_BRANCH"
+
+          if ! is_valid_branch_name "$RSKJ_BRANCH"; then
+            echo "rskj: invalid branch name: $RSKJ_BRANCH" >&2
             exit 1
           fi
-    
-          if ! [[ "$POWPEG_BRANCH" =~ ${{ env.VALID_BRANCH_REGEX }}  ]]; then
-            echo "Error: Invalid PowPeg branch name: $POWPEG_BRANCH"
+          if ! is_valid_branch_name "$POWPEG_BRANCH"; then
+            echo "fed: invalid branch name: $POWPEG_BRANCH" >&2
             exit 1
           fi
-    
-          if ! [[ "$RSKJ_BRANCH" =~ ${{ env.VALID_BRANCH_REGEX }}  ]]; then
-            echo "Error: Invalid RSKJ branch name: $RSKJ_BRANCH"
+          if ! is_valid_branch_name "$RIT_BRANCH"; then
+            echo "rit: invalid branch name: $RIT_BRANCH" >&2
             exit 1
           fi
 
-          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
           echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
-
+          echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
       - name: Set Build URL
         id: set-build-url
         run: |
@@ -112,7 +114,7 @@ jobs:
         if: success() && github.event.pull_request.head.repo.owner.login == 'rsksmart'
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
-          channel-id: 'C8X9Q4PBM' # integration-tests channel
+          channel-id: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
           payload: |
             {
               "attachments": [
@@ -129,7 +131,7 @@ jobs:
         if: failure() && github.event.pull_request.head.repo.owner.login == 'rsksmart'
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
-          channel-id: 'C8X9Q4PBM' # integration-tests channel
+          channel-id: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
           payload: |
             {
               "attachments": [

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -114,6 +114,10 @@ jobs:
       - name: Send Slack Notification on Success
         if: success() && github.event.pull_request.head.repo.owner.login == 'rsksmart'
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
+          github_head_ref: ${{ github.head_ref }}
+          github_run_number: ${{ github.run_number }}
         with:
           channel-id: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
           payload: |
@@ -121,16 +125,18 @@ jobs:
               "attachments": [
                 {
                   "color": "good",
-                  "text": "OK: :+1: Pull request: ${{ github.head_ref }}  - [#${{ github.run_number }}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
+                  "text": "OK: :+1: Pull request: ${github_head_ref}  - [#${github_run_number}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
                 }
               ]
             }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
 
       - name: Send Slack Notification on Failure
         if: failure() && github.event.pull_request.head.repo.owner.login == 'rsksmart'
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
+          github_head_ref: ${{ github.head_ref }}
+          github_run_number: ${{ github.run_number }}
         with:
           channel-id: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
           payload: |
@@ -138,9 +144,7 @@ jobs:
               "attachments": [
                 {
                   "color": "danger",
-                  "text": "FAILED: :robot_face: *Pull request*: ${{ github.head_ref }}  - [#${{ github.run_number }}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
+                  "text": "FAILED: :robot_face: *Pull request*: ${github_head_ref}  - [#${github_run_number}] - (${{ env.BUILD_URL }}) - *Branches used* [rskj:`rsksmart#${{ env.RSKJ_BRANCH }}`] [fed:`${{ env.POWPEG_BRANCH }}`] [rootstock-integration-tests:`${{ env.RIT_BRANCH }}`]"
                 }
               ]
             }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -97,6 +97,7 @@ jobs:
           echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
           echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
+
       - name: Set Build URL
         id: set-build-url
         run: |

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           rskj-branch: ${{ env.RSKJ_BRANCH }}
           powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
-          rit-branch: ${{ env. RIT_BRANCH }}
+          rit-branch: ${{ env.RIT_BRANCH }}
 
       - name: Send Slack Notification on Success
         if: success() && github.event.pull_request.head.repo.owner.login == 'rsksmart'


### PR DESCRIPTION
Issues fixed:
1 - Remove the trigger on push for master and *-rc -> we don't need that anymore since we are running it for every commit on PRs against these branches. 2 - Send the status of the execution to slack
3 - Solve the issue that the status of an execution triggered via workflow doesn't update the PR status. And if we need to use a different branch for RIT, Powpeg and RIT in the PR, it won't change the status to green after the workflow_dispatch execution -> We will do that adding a parsing on the description, looking for the branch that need to be used for that PR. If there is no branch configured on the description, we will try to use the default one.

Branches to be used by RIT:
`fed:vovchyk/jackson-ver-bump`
`rskj:vovchyk/jackson-ver-bump`