### PR TITLE
build: allow plus symbol in branch names

### DIFF
--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           PR_DESCRIPTION=pr-description.txt
 
-          ALLOWED_BRANCH_CHARACTERS='[-./0-9A-Z_a-z]'
+          ALLOWED_BRANCH_CHARACTERS='[-+./0-9A-Z_a-z]'
 
           default_rskj_branch=master
           default_powpeg_branch=master


### PR DESCRIPTION
`rskj:vovchyk/rit+fixes`