### PR TITLE
Refactor Federation Watcher Tests

### DIFF
--- a/src/main/java/co/rsk/federate/FederationWatcher.java
+++ b/src/main/java/co/rsk/federate/FederationWatcher.java
@@ -48,7 +48,7 @@ public class FederationWatcher {
         listeners.add(listener);
     }
 
-    public class FederationWatcherRskListener extends EthereumListenerAdapter {
+    class FederationWatcherRskListener extends EthereumListenerAdapter {
         @Override
         public void onBestBlock(org.ethereum.core.Block block, List<TransactionReceipt> receipts) {
             // Updating state only when the best block changes still "works",

--- a/src/main/java/co/rsk/federate/FederationWatcher.java
+++ b/src/main/java/co/rsk/federate/FederationWatcher.java
@@ -48,7 +48,7 @@ public class FederationWatcher {
         listeners.add(listener);
     }
 
-    private class FederationWatcherRskListener extends EthereumListenerAdapter {
+    public class FederationWatcherRskListener extends EthereumListenerAdapter {
         @Override
         public void onBestBlock(org.ethereum.core.Block block, List<TransactionReceipt> receipts) {
             // Updating state only when the best block changes still "works",


### PR DESCRIPTION
### Summary 

Refactor existing Federation Watcher Tests so that when we introduce the new logic for signing the svp spend transaction on proposed federation change we are ready.

### Motivation 

https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md