### PR TITLE
Skipping SonarQube analysis on fork repos and adding POWPEG_REPO_OWNER input

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -305,7 +305,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           chmod +x gradlew
-          if [ "$GH_EVENT" = pull_request ]; then
+          if [ "$GH_EVENT" = pull_request ] && [ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]; then
             ./gradlew sonarqube --warning-mode all --no-daemon --stacktrace --info -x build -x test \
               -Dsonar.pullrequest.base="$GH_PR_BASE_REF" \
               -Dsonar.pullrequest.branch="$GH_PR_HEAD_REF" \

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -120,7 +120,7 @@ jobs:
           echo "SAFE_BRANCH_NAME=$SAFE_BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Run Rootstock Integration Tests
-        uses: rsksmart/rootstock-integration-tests@497172fd38dcfaf48c77f9bb1eeb6617eef5eed6 #v1
+        uses: rsksmart/rootstock-integration-tests@e86332474179a63f027d0fe969687d3d24f34c29 #v1
         with:
           rskj-branch: ${{ env.RSKJ_BRANCH }}
           powpeg-node-branch: ${{ env.POWPEG_BRANCH }}

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -97,9 +97,9 @@ jobs:
           fi
 
           # Set the Repo Owner
-          POWPEG_REPO_OWNER="${github_event_pull_request_head_repo_owner_login:-$github_repository_owner}"
+          REPO_OWNER="${github_event_pull_request_head_repo_owner_login:-$github_repository_owner}"
 
-          echo "POWPEG_REPO_OWNER=$POWPEG_REPO_OWNER" >> $GITHUB_ENV
+          echo "REPO_OWNER=$REPO_OWNER" >> $GITHUB_ENV
           echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
           echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
@@ -125,7 +125,7 @@ jobs:
           rskj-branch: ${{ env.RSKJ_BRANCH }}
           powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
           rit-branch: ${{ env.RIT_BRANCH }}
-          powpeg-repo-owner: ${{ env.POWPEG_REPO_OWNER }}
+          repo-owner: ${{ env.REPO_OWNER }}
 
       - name: Send Slack Notification on Success
         if: success() && github.event.pull_request.head.repo.owner.login == 'rsksmart'

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -34,6 +34,8 @@ jobs:
           github_event_pull_request_number: ${{ github.event.pull_request.number }}
           github_head_ref: ${{ github.head_ref }}
           github_ref_name: ${{ github.ref_name }}
+          github_event_pull_request_head_repo_owner_login: ${{ github.event.pull_request.head.repo.owner.login }}
+          github_repository_owner: ${{ github.repository_owner }}
         run: |
           PR_DESCRIPTION=pr-description.txt
 
@@ -94,6 +96,10 @@ jobs:
             exit 1
           fi
 
+          # Set the Repo Owner
+          POWPEG_REPO_OWNER="${github_event_pull_request_head_repo_owner_login:-$github_repository_owner}"
+
+          echo "POWPEG_REPO_OWNER=$POWPEG_REPO_OWNER" >> $GITHUB_ENV
           echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
           echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
@@ -119,6 +125,7 @@ jobs:
           rskj-branch: ${{ env.RSKJ_BRANCH }}
           powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
           rit-branch: ${{ env.RIT_BRANCH }}
+          powpeg-repo-owner: ${{ env.POWPEG_REPO_OWNER }}
 
       - name: Send Slack Notification on Success
         if: success() && github.event.pull_request.head.repo.owner.login == 'rsksmart'


### PR DESCRIPTION
## Description
Right now, checks for pull requests (PRs) from external contributors using forked repositories are not passing. The main issue is that the rootstock-integration-tests workflow is attempting to find the branch in the original rsksmart/powpeg repository instead of the contributor's fork. Here are the specific problems we've encountered:

`Git Checkout Error: error: pathspec 'vovchyk/status-badge' did not match any file(s) known to git
`
and 
```
SonarQube Execution Error: Execution failed for task '
'.Project not found. Please check the 'sonar.projectKey' and 'sonar.organization' properties, the 'SONAR_TOKEN' environment variable, or contact the project administrator to check the permissions of the user the token belongs to.

```
It appears that the SonarQube check is being triggered automatically for external PRs of branches from forked repos, which should not happen due to potential access issues

## Implementation
**Updated `rit.yml` Workflow:**
Added the repo-owner input to the Rootstock Integration Tests action to ensure it correctly clones the repository based on the PR's owner:
```
- name: Run Rootstock Integration Tests
  uses: rmoreliovlabs/rootstock-integration-tests@feature/add_repo_owner_input
  with:
    rskj-branch: ${{ env.RSKJ_BRANCH }}
    powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
    rit-branch: ${{ env.RIT_BRANCH }}
    powpeg-repo-owner: ${{ env.POWPEG_REPO_OWNER }}
```
**Conditionally Trigger SonarQube Check:**

Implemented logic to skip the SonarQube check for PRs from external contributors. This prevents unnecessary execution that could fail due to access issues.
`if [ "$GH_EVENT" = pull_request ] && [ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]; then`


For more context, check the rskj pr [here](https://github.com/rsksmart/rskj/pull/2774)