### PR TITLE
Update use of RedeemScriptParser interface to support new changes

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -6,6 +6,7 @@ import co.rsk.bitcoinj.core.TransactionInput;
 import co.rsk.bitcoinj.script.RedeemScriptParser;
 import co.rsk.bitcoinj.script.RedeemScriptParserFactory;
 import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.peg.constants.BridgeConstants;
@@ -479,8 +480,9 @@ public class BtcReleaseClient {
     }
 
     protected Script extractStandardRedeemScript(Script redeemScript) {
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
-        return parser.extractStandardRedeemScript();
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+        List<ScriptChunk> defaultRedeemScriptChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
+        return new ScriptBuilder().addChunks(defaultRedeemScriptChunks).build();
     }
 
     private Script extractDefaultRedeemScript(Federation federation) {
@@ -504,7 +506,6 @@ public class BtcReleaseClient {
 
         List<Federation> spendingFedFilter = observedFederations.stream()
                 .filter(f -> (extractDefaultRedeemScript(f)).equals(redeemScript)).collect(Collectors.toList());
-
 
         return spendingFedFilter.get(0);
     }


### PR DESCRIPTION
## Description

- Update use of RedeemScriptParser interface to support new changes after refactoring.
- Update test to use FlyoverRedeemScriptBuilderImpl and get rid of use of the removed FastBridgeRedeemScriptParser

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
