### PR TITLE
Implement getProposedFederationAddress in FederationProviderFromFederatorSupport

### DIFF
--- a/src/main/java/co/rsk/federate/FederationProvider.java
+++ b/src/main/java/co/rsk/federate/FederationProvider.java
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package co.rsk.federate;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.peg.federation.Federation;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -40,6 +38,9 @@ public interface FederationProvider {
     Optional<Federation> getRetiringFederation();
     // The currently "retiring" federation's address
     Optional<Address> getRetiringFederationAddress();
+
+    // The currently "proposed" federation's address
+    Optional<Address> getProposedFederationAddress();
 
     // The federations that are "live", that is, are still
     // operational. This should be the active federation

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -15,8 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package co.rsk.federate;
+
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -25,12 +26,10 @@ import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.constants.FederationConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.crypto.ECKey;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
 
 /**
  * Provides a federation using a FederatorSupport instance, which in turn
@@ -134,6 +133,11 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
     @Override
     public Optional<Address> getRetiringFederationAddress() {
         return federatorSupport.getRetiringFederationAddress();
+    }
+
+    @Override
+    public Optional<Address> getProposedFederationAddress() {
+        return federatorSupport.getProposedFederationAddress();
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -19,7 +19,6 @@ import org.ethereum.core.Blockchain;
 import org.ethereum.crypto.ECKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.time.Instant;
@@ -251,6 +250,15 @@ public class FederatorSupport {
         }
 
         return Instant.ofEpochMilli(creationTime.longValue());
+    }
+
+    public Optional<Address> getProposedFederationAddress() {
+        String proposedFederationAddress = bridgeTransactionSender.callTx(
+            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_ADDRESS);
+
+        return Optional.ofNullable(proposedFederationAddress)
+            .filter(addr -> !addr.isEmpty())
+            .map(addr -> Address.fromBase58(getBtcParams(), addr));
     }
 
     public int getBtcBlockchainBestChainHeight() {

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -5,6 +5,8 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizerTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizerTest.java
@@ -186,13 +186,10 @@ class BtcReleaseClientStorageSynchronizerTest {
         TransactionReceipt receipt = mock(TransactionReceipt.class);
         List<LogInfo> logs = new ArrayList<>();
 
-        SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
-
         BridgeEventLoggerImpl bridgeEventLogger = new BridgeEventLoggerImpl(
             new BridgeRegTestConstants(),
             activations,
-            logs,
-            signatureCache
+            logs
         );
 
         Keccak256 value = createHash(3);
@@ -282,13 +279,10 @@ class BtcReleaseClientStorageSynchronizerTest {
         TransactionReceipt receipt = mock(TransactionReceipt.class);
         List<LogInfo> logs = new ArrayList<>();
 
-        SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
-
         BridgeEventLoggerImpl bridgeEventLogger = new BridgeEventLoggerImpl(
             new BridgeRegTestConstants(),
             activations,
-            logs,
-            signatureCache
+            logs
         );
 
         Keccak256 releaseRequestTxHash = createHash(3);


### PR DESCRIPTION
### Summary

This PR implements the `getProposedFederationAdress` which will be used to check from the Federation Watcher if the proposed federation has changed per best block mined in the blockchain. 

This also includes a fix to remove the signatures cache dependency and add some bitcoin test util methods found in rskj-core. 

### Motivation and Context

https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md

`rskj:feat/bridge-constants`