### PR TITLE
Implement getProposedFederation in FederationProviderFromFederatorSupport

### DIFF
--- a/src/main/java/co/rsk/federate/FederationProvider.java
+++ b/src/main/java/co/rsk/federate/FederationProvider.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 public interface FederationProvider {
 
     /**
-     * Retrieves the currently active federation, which is responsible for processing transactions.
+     * Retrieves the currently active federation.
      *
      * @return the active {@link Federation} instance
      */
@@ -58,7 +58,7 @@ public interface FederationProvider {
     Optional<Address> getRetiringFederationAddress();
 
     /**
-     * Retrieves the currently proposed federation, if one exists. This federation is awaiting activation.
+     * Retrieves the currently proposed federation, if one exists. This federation is awaiting validation.
      *
      * @return an {@link Optional} containing the proposed {@link Federation}, or {@link Optional#empty()} if none exists
      */

--- a/src/main/java/co/rsk/federate/FederationProvider.java
+++ b/src/main/java/co/rsk/federate/FederationProvider.java
@@ -22,24 +22,52 @@ import co.rsk.peg.federation.Federation;
 import java.util.Optional;
 
 /**
- * Implementors of this interface must be able to provide
- * federation instances.
- *
- * @author Ariel Mendelzon
+ * Provides access to various federation instances, including the active, retiring, and proposed federations.
+ * Implementations of this interface must define how to retrieve the federations and their respective addresses.
+ * These methods allow clients to manage and monitor federations in different lifecycle stages within the bridge.
  */
 public interface FederationProvider {
-    // The currently "active" federation
+
+    /**
+     * Retrieves the currently active federation, which is responsible for processing transactions.
+     *
+     * @return the active {@link Federation} instance
+     */
     Federation getActiveFederation();
-    // The currently "active" federation's address
+
+    /**
+     * Retrieves the address of the currently active federation.
+     *
+     * @return the {@link Address} of the active federation
+     */
     Address getActiveFederationAddress();
 
-    // The currently "retiring" federation
+    /**
+     * Retrieves the currently retiring federation, if one exists. This federation is in transition 
+     * and will soon be replaced by a new active federation.
+     *
+     * @return an {@link Optional} containing the retiring {@link Federation}, or {@link Optional#empty()} if none exists
+     */
     Optional<Federation> getRetiringFederation();
-    // The currently "retiring" federation's address
+
+    /**
+     * Retrieves the address of the currently retiring federation, if one exists.
+     *
+     * @return an {@link Optional} containing the {@link Address} of the retiring federation, or {@link Optional#empty()} if none exists
+     */
     Optional<Address> getRetiringFederationAddress();
 
-    // The currently "proposed" federation
+    /**
+     * Retrieves the currently proposed federation, if one exists. This federation is awaiting activation.
+     *
+     * @return an {@link Optional} containing the proposed {@link Federation}, or {@link Optional#empty()} if none exists
+     */
     Optional<Federation> getProposedFederation();
-    // The currently "proposed" federation's address
+
+    /**
+     * Retrieves the address of the currently proposed federation, if one exists.
+     *
+     * @return an {@link Optional} containing the {@link Address} of the proposed federation, or {@link Optional#empty()} if none exists
+     */
     Optional<Address> getProposedFederationAddress();
 }

--- a/src/main/java/co/rsk/federate/FederationProvider.java
+++ b/src/main/java/co/rsk/federate/FederationProvider.java
@@ -38,6 +38,8 @@ public interface FederationProvider {
     // The currently "retiring" federation's address
     Optional<Address> getRetiringFederationAddress();
 
+    // The currently "proposed" federation
+    Optional<Federation> getProposedFederation();
     // The currently "proposed" federation's address
     Optional<Address> getProposedFederationAddress();
 }

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -157,20 +157,20 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.BTC)
                     .map(ECKey::getPubKey)
                     .map(BtcECKey::fromPublicOnly)
-                    .orElseThrow(() -> new IllegalStateException()),
+                    .orElseThrow(IllegalStateException::new),
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.RSK)
-                    .orElseThrow(() -> new IllegalStateException()),
+                    .orElseThrow(IllegalStateException::new),
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.MST)
-                    .orElseThrow(() -> new IllegalStateException())
+                    .orElseThrow(IllegalStateException::new)
             ))
             .toList();
 
         FederationArgs federationArgs = new FederationArgs(
             federationMembers,
             federatorSupport.getProposedFederationCreationTime()
-                .orElseThrow(() -> new IllegalStateException()),
+                .orElseThrow(IllegalStateException::new),
             federatorSupport.getProposedFederationCreationBlockNumber()
-                .orElseThrow(() -> new IllegalStateException()),
+                .orElseThrow(IllegalStateException::new),
             federatorSupport.getBtcParams()
         );
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -152,7 +152,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
             return Optional.empty();
         }
 
-        List<FederationMember> members = IntStream.range(0, federationSize)
+        List<FederationMember> federationMembers = IntStream.range(0, federationSize)
             .mapToObj(i -> new FederationMember(
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.BTC)
                     .map(ECKey::getPubKey)
@@ -166,7 +166,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
             .toList();
 
         FederationArgs federationArgs = new FederationArgs(
-            members,
+            federationMembers,
             federatorSupport.getProposedFederationCreationTime()
                 .orElseThrow(() -> new IllegalStateException()),
             federatorSupport.getProposedFederationCreationBlockNumber()
@@ -174,10 +174,12 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
             federatorSupport.getBtcParams()
         );
 
-        Federation initialFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-        Federation expectedFederation = getExpectedFederation(initialFederation, proposedFederationAddress.get());
+        Federation federation = FederationFactory.buildP2shErpFederation(
+            federationArgs,
+            federationConstants.getErpFedPubKeysList(),
+            federationConstants.getErpFedActivationDelay());
 
-        return Optional.of(expectedFederation);
+        return Optional.of(federation);
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -184,8 +184,9 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
                 federationConstants.getErpFedActivationDelay());
 
             return Optional.of(federation);
-        } catch (IllegalStateException e) {
+        } catch (Exception e) {
             logger.error("[getProposedFederation] Unable to build the proposed federation", e);
+
             return Optional.empty();
         }
     }

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -185,7 +185,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
     @Override
     public Optional<Address> getProposedFederationAddress() {
         return Optional.of(federatorSupport)
-            .filter(federatorSupport -> federatorSupport.getConfigForBestBlock().isActive(RSKIP419))
+            .filter(fedSupport -> fedSupport.getConfigForBestBlock().isActive(RSKIP419))
             .flatMap(FederatorSupport::getProposedFederationAddress);
     }
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -145,10 +145,9 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
             return Optional.empty();
         }
        
-        Optional<Address> proposedFederationAddress = getProposedFederationAddress();
         Integer federationSize = federatorSupport.getProposedFederationSize()
             .orElse(FEDERATION_NON_EXISTENT.getCode());
-        if (federationSize == FEDERATION_NON_EXISTENT.getCode() || proposedFederationAddress.isEmpty()) {
+        if (federationSize == FEDERATION_NON_EXISTENT.getCode()) {
             return Optional.empty();
         }
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -157,18 +157,20 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.BTC)
                     .map(ECKey::getPubKey)
                     .map(BtcECKey::fromPublicOnly)
-                    .orElse(null),
+                    .orElseThrow(() -> new IllegalStateException()),
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.RSK)
-                    .orElse(null),
+                    .orElseThrow(() -> new IllegalStateException()),
                 federatorSupport.getProposedFederatorPublicKeyOfType(i, KeyType.MST)
-                    .orElse(null)
+                    .orElseThrow(() -> new IllegalStateException())
             ))
             .toList();
 
         FederationArgs federationArgs = new FederationArgs(
             members,
-            federatorSupport.getProposedFederationCreationTime().orElse(null),
-            federatorSupport.getProposedFederationCreationBlockNumber().orElse(null),
+            federatorSupport.getProposedFederationCreationTime()
+                .orElseThrow(() -> new IllegalStateException()),
+            federatorSupport.getProposedFederationCreationBlockNumber()
+                .orElseThrow(() -> new IllegalStateException()),
             federatorSupport.getBtcParams()
         );
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -37,11 +37,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides a federation using a FederatorSupport instance, which in turn
- * gathers the federation from the bridge contract of the ethereum
- * network it is attached to.
+ * A provider that supplies the current active, retiring, and proposed federations by
+ * using a {@link FederatorSupport} instance, which interacts with the Bridge contract.
  *
- * @author Ariel Mendelzon
+ * <p>The {@code FederationProviderFromFederatorSupport} enables access to:
+ * <ul>
+ *     <li><strong>Active Federation</strong>
+ *     <li><strong>Retiring Federation</strong>
+ *     <li><strong>Proposed Federation</strong>
+ * </ul>
  */
 public class FederationProviderFromFederatorSupport implements FederationProvider {
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -97,7 +97,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
         Integer federationSize = federatorSupport.getRetiringFederationSize();
         Optional<Address> optionalRetiringFederationAddress = getRetiringFederationAddress();
 
-        if (federationSize == FEDERATION_NON_EXISTENT.getCode() || !optionalRetiringFederationAddress.isPresent()) {
+        if (federationSize == FEDERATION_NON_EXISTENT.getCode() || optionalRetiringFederationAddress.isEmpty()) {
             return Optional.empty();
         }
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -188,8 +188,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
 
     @Override
     public Optional<Address> getProposedFederationAddress() {
-        return Optional.of(federatorSupport)
-            .flatMap(FederatorSupport::getProposedFederationAddress);
+        return federatorSupport.getProposedFederationAddress();
     }
 
     private Federation getExpectedFederation(Federation initialFederation, Address expectedFederationAddress) {

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -146,13 +146,9 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
         }
        
         Optional<Address> proposedFederationAddress = getProposedFederationAddress();
-        if (proposedFederationAddress.isEmpty()) {
-            return Optional.empty();
-        }
-
         Integer federationSize = federatorSupport.getProposedFederationSize()
             .orElse(FEDERATION_NON_EXISTENT.getCode());
-        if (federationSize == FEDERATION_NON_EXISTENT.getCode()) {
+        if (federationSize == FEDERATION_NON_EXISTENT.getCode() || proposedFederationAddress.isEmpty()) {
             return Optional.empty();
         }
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -20,7 +20,6 @@ package co.rsk.federate;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static co.rsk.peg.federation.FederationMember.KeyType;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
-import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP419;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -145,10 +144,6 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
 
     @Override
     public Optional<Federation> getProposedFederation() {
-        if (!federatorSupport.getConfigForBestBlock().isActive(RSKIP419)) {
-            return Optional.empty();
-        }
-       
         Integer federationSize = federatorSupport.getProposedFederationSize()
             .orElse(FEDERATION_NON_EXISTENT.getCode());
         if (federationSize == FEDERATION_NON_EXISTENT.getCode()) {
@@ -194,7 +189,6 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
     @Override
     public Optional<Address> getProposedFederationAddress() {
         return Optional.of(federatorSupport)
-            .filter(fedSupport -> fedSupport.getConfigForBestBlock().isActive(RSKIP419))
             .flatMap(FederatorSupport::getProposedFederationAddress);
     }
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -43,13 +43,13 @@ import java.util.stream.IntStream;
  * @author Ariel Mendelzon
  */
 public class FederationProviderFromFederatorSupport implements FederationProvider {
+
     private final FederatorSupport federatorSupport;
     private final FederationConstants federationConstants;
 
     public FederationProviderFromFederatorSupport(
         FederatorSupport federatorSupport,
         FederationConstants federationConstants) {
-
         this.federatorSupport = federatorSupport;
         this.federationConstants = federationConstants;
     }
@@ -97,7 +97,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
         Integer federationSize = federatorSupport.getRetiringFederationSize();
         Optional<Address> optionalRetiringFederationAddress = getRetiringFederationAddress();
 
-        if (federationSize == -1 || !optionalRetiringFederationAddress.isPresent()) {
+        if (federationSize == FEDERATION_NON_EXISTENT.getCode() || !optionalRetiringFederationAddress.isPresent()) {
             return Optional.empty();
         }
 

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -98,13 +98,12 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
     @Override
     public Optional<Federation> getRetiringFederation() {
         Integer federationSize = federatorSupport.getRetiringFederationSize();
-        Optional<Address> optionalRetiringFederationAddress = getRetiringFederationAddress();
 
-        if (federationSize == FEDERATION_NON_EXISTENT.getCode() || optionalRetiringFederationAddress.isEmpty()) {
+        if (federationSize == FEDERATION_NON_EXISTENT.getCode()) {
             return Optional.empty();
         }
 
-        Address retiringFederationAddress = optionalRetiringFederationAddress.get();
+        Address retiringFederationAddress = getRetiringFederationAddress().orElse(null);
         boolean useTypedPublicKeyGetter = federatorSupport.getConfigForBestBlock().isActive(RSKIP123);
         List<FederationMember> members = new ArrayList<>();
         for (int i = 0; i < federationSize; i++) {

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -20,7 +20,7 @@ package co.rsk.federate;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static co.rsk.peg.federation.FederationMember.KeyType;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
-import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP417;
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP419;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -141,7 +141,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
 
     @Override
     public Optional<Federation> getProposedFederation() {
-        if (!federatorSupport.getConfigForBestBlock().isActive(RSKIP417)) {
+        if (!federatorSupport.getConfigForBestBlock().isActive(RSKIP419)) {
             return Optional.empty();
         }
        
@@ -181,7 +181,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
     @Override
     public Optional<Address> getProposedFederationAddress() {
         return Optional.of(federatorSupport)
-            .filter(federatorSupport -> federatorSupport.getConfigForBestBlock().isActive(RSKIP417))
+            .filter(federatorSupport -> federatorSupport.getConfigForBestBlock().isActive(RSKIP419))
             .flatMap(FederatorSupport::getProposedFederationAddress);
     }
 

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -295,8 +295,8 @@ public class FederatorSupport {
     }
 
     public Optional<Long> getProposedFederationCreationBlockNumber() {
-        BigInteger creationBlockNumber = 
-            bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER);
+        BigInteger creationBlockNumber = bridgeTransactionSender.callTx(
+            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER);
 
         return Optional.ofNullable(creationBlockNumber)
             .map(BigInteger::longValue);

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -291,7 +291,7 @@ public class FederatorSupport {
 
         return Optional.ofNullable(creationTime)
             .map(BigInteger::longValue)
-            .map(Instant::ofEpochMilli);
+            .map(Instant::ofEpochSecond);
     }
 
     public Optional<Long> getProposedFederationCreationBlockNumber() {

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -273,6 +273,18 @@ public class FederatorSupport {
             .map(BigInteger::intValue);
     }
 
+    public Optional<ECKey> getProposedFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        Objects.requireNonNull(keyType);
+
+        byte[] publicKeyBytes = bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_PROPOSED_FEDERATOR_PUBLIC_KEY_OF_TYPE,
+            new Object[]{ index, keyType.getValue() });
+       
+        return Optional.ofNullable(publicKeyBytes)
+            .map(ECKey::fromPublicOnly);
+    }
+
     public int getBtcBlockchainBestChainHeight() {
         BigInteger btcBlockchainBestChainHeight = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT);
         return btcBlockchainBestChainHeight.intValue();

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -294,6 +294,14 @@ public class FederatorSupport {
             .map(Instant::ofEpochMilli);
     }
 
+    public Optional<Long> getProposedFederationCreationBlockNumber() {
+        BigInteger creationBlockNumber = 
+            bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER);
+
+        return Optional.ofNullable(creationBlockNumber)
+            .map(BigInteger::longValue);
+    }
+
     public int getBtcBlockchainBestChainHeight() {
         BigInteger btcBlockchainBestChainHeight = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT);
         return btcBlockchainBestChainHeight.intValue();

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -285,6 +285,15 @@ public class FederatorSupport {
             .map(ECKey::fromPublicOnly);
     }
 
+    public Optional<Instant> getProposedFederationCreationTime() {
+        BigInteger creationTime = bridgeTransactionSender.callTx(
+            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_CREATION_TIME);
+
+        return Optional.ofNullable(creationTime)
+            .map(BigInteger::longValue)
+            .map(Instant::ofEpochMilli);
+    }
+
     public int getBtcBlockchainBestChainHeight() {
         BigInteger btcBlockchainBestChainHeight = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT);
         return btcBlockchainBestChainHeight.intValue();

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  */
 public class FederatorSupport {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FederatorSupport.class);
+    private static final Logger logger = LoggerFactory.getLogger(FederatorSupport.class);
 
     private final Blockchain blockchain;
     private final PowpegNodeSystemProperties config;
@@ -95,7 +95,7 @@ public class FederatorSupport {
     }
 
     public void sendReceiveHeaders(org.bitcoinj.core.Block[] headers) {
-        LOGGER.debug("About to send to the bridge headers from {} to {}", headers[0].getHash(), headers[headers.length - 1].getHash());
+        logger.debug("About to send to the bridge headers from {} to {}", headers[0].getHash(), headers[headers.length - 1].getHash());
 
         Object[] objectArray = new Object[headers.length];
 
@@ -115,7 +115,7 @@ public class FederatorSupport {
     }
 
     public void sendRegisterBtcTransaction(org.bitcoinj.core.Transaction tx, int blockHeight, PartialMerkleTree pmt) {
-        LOGGER.debug("About to send to the bridge btc tx hash {}. Block height {}", tx.getWTxId(), blockHeight);
+        logger.debug("About to send to the bridge btc tx hash {}. Block height {}", tx.getWTxId(), blockHeight);
 
         byte[] txSerialized = tx.bitcoinSerialize();
         byte[] pmtSerialized = pmt.bitcoinSerialize();
@@ -123,7 +123,7 @@ public class FederatorSupport {
     }
 
     public void sendRegisterCoinbaseTransaction(CoinbaseInformation coinbaseInformation) {
-        LOGGER.debug("About to send to the bridge btc coinbase tx hash {}. Block hash {}", coinbaseInformation.getCoinbaseTransaction().getTxId(), coinbaseInformation.getBlockHash());
+        logger.debug("About to send to the bridge btc coinbase tx hash {}. Block hash {}", coinbaseInformation.getCoinbaseTransaction().getTxId(), coinbaseInformation.getBlockHash());
 
         byte[] txSerialized = coinbaseInformation.getSerializedCoinbaseTransactionWithoutWitness();
         byte[] pmtSerialized = coinbaseInformation.getPmt().bitcoinSerialize();
@@ -201,7 +201,7 @@ public class FederatorSupport {
     public Optional<Address> getRetiringFederationAddress() {
         String addressString = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_RETIRING_FEDERATION_ADDRESS);
 
-        if (addressString.equals("")) {
+        if (addressString.isEmpty()) {
             return Optional.empty();
         }
 

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -24,6 +24,7 @@ import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -262,6 +263,14 @@ public class FederatorSupport {
         return Optional.ofNullable(proposedFederationAddress)
             .filter(addr -> !addr.isEmpty())
             .map(addr -> Address.fromBase58(getBtcParams(), addr));
+    }
+
+    public Optional<Integer> getProposedFederationSize() {
+        BigInteger size = bridgeTransactionSender.callTx(
+            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_SIZE);
+
+        return Optional.ofNullable(size)
+            .map(BigInteger::intValue);
     }
 
     public int getBtcBlockchainBestChainHeight() {

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -371,16 +371,6 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @Test
-    void getProposedFederation_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
-        // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-
-        // Act & Assert
-        assertEquals(Optional.empty(), federationProvider.getProposedFederation());
-    }
-
-    @Test
     void getProposedFederation_whenProposedFederationSizeIsNonExistent_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -3,7 +3,7 @@ package co.rsk.federate;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP284;
-import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP417;
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP419;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -375,7 +375,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenRSKIP417IsNotActivated_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(false);
+        when(configMock.isActive(RSKIP419)).thenReturn(false);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         // Act & Assert
@@ -386,7 +386,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenProposedFederationSizeIsNonExistent_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationSize())
             .thenReturn(Optional.of(FEDERATION_NON_EXISTENT.getCode()));
@@ -401,7 +401,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenProposedFederationAddressDoesNotExist_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationSize())
             .thenReturn(Optional.of(9));
@@ -416,7 +416,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenExistsAndIsStandardMultisigFederation_shouldReturnProposedFederation() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         Federation expectedFederation = createFederation(
@@ -451,7 +451,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenExistsAndIsNonStandardErpFederation_shouldReturnProposedFederation() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         Federation expectedFederation = createNonStandardErpFederation(
@@ -487,7 +487,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenExistsAndIsP2shErpFederation_shouldReturnProposedFederation() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         Federation expectedFederation = createP2shErpFederation(
@@ -522,7 +522,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederationAddress_whenAddressExists_shouldReturnAddress() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(DEFAULT_ADDRESS));
 
@@ -538,7 +538,7 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederationAddress_whenNoAddressExists_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP417)).thenReturn(true);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.empty());
 

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -3,7 +3,6 @@ package co.rsk.federate;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP284;
-import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP419;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -375,7 +374,6 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(false);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         // Act & Assert
@@ -386,7 +384,6 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenProposedFederationSizeIsNonExistent_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationSize())
             .thenReturn(Optional.of(FEDERATION_NON_EXISTENT.getCode()));
@@ -400,7 +397,6 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenSomeDataDoesNotExists_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         Federation expectedFederation = createP2shErpFederation(
@@ -426,7 +422,6 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederation_whenExistsAndIsP2shErpFederation_shouldReturnProposedFederation() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         Federation expectedFederation = createP2shErpFederation(
@@ -461,7 +456,6 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederationAddress_whenAddressExists_shouldReturnAddress() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(DEFAULT_ADDRESS));
 
@@ -477,7 +471,6 @@ class FederationProviderFromFederatorSupportTest {
     void getProposedFederationAddress_whenNoAddressExists_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.empty());
 

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -397,6 +397,32 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @Test
+    void getProposedFederation_whenSomeDataDoesNotExists_shouldReturnEmptyOptional() {
+        // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+
+        Federation expectedFederation = createP2shErpFederation(
+            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000));
+        Address expectedFederationAddress = expectedFederation.getAddress();
+        Integer federationSize = 5;
+        when(federatorSupportMock.getProposedFederationSize()).thenReturn(Optional.of(federationSize));
+        when(federatorSupportMock.getProposedFederationCreationTime()).thenReturn(Optional.of(creationTime));
+        when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(expectedFederationAddress));
+        when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
+        when(federatorSupportMock.getProposedFederationCreationBlockNumber()).thenReturn(Optional.of(0L));
+        when(federatorSupportMock.getProposedFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC))
+            .thenThrow(new IllegalStateException());
+
+        // Act
+        Optional<Federation> proposedFederation = federationProvider.getProposedFederation();
+
+        // Assert
+        assertFalse(proposedFederation.isPresent());
+    }
+
+    @Test
     void getProposedFederation_whenExistsAndIsP2shErpFederation_shouldReturnProposedFederation() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -373,8 +373,6 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenProposedFederationSizeIsNonExistent_shouldReturnEmptyOptional() {
         // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationSize())
             .thenReturn(Optional.of(FEDERATION_NON_EXISTENT.getCode()));
 
@@ -386,9 +384,6 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenSomeDataDoesNotExists_shouldReturnEmptyOptional() {
         // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-
         Federation expectedFederation = createP2shErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000));
         Address expectedFederationAddress = expectedFederation.getAddress();
@@ -411,9 +406,6 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenExistsAndIsP2shErpFederation_shouldReturnProposedFederation() {
         // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-
         Federation expectedFederation = createP2shErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000));
         Address expectedFederationAddress = expectedFederation.getAddress();
@@ -445,8 +437,6 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederationAddress_whenAddressExists_shouldReturnAddress() {
         // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(DEFAULT_ADDRESS));
 
         // Act
@@ -460,8 +450,6 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederationAddress_whenNoAddressExists_shouldReturnEmptyOptional() {
         // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.empty());
 
         // Act

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -234,6 +234,19 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @Test
+    void getRetiringFederation_whenAddressNotPresent_shouldThrowIllegalStateException() {
+        // Arrange
+        when(federatorSupportMock.getRetiringFederationSize()).thenReturn(3);
+        when(federatorSupportMock.getRetiringFederationAddress()).thenReturn(Optional.empty()); // Address is missing
+    
+        // Act
+        Optional<Federation> retiringFederation = federationProvider.getRetiringFederation();
+
+        // Assert
+        assertTrue(retiringFederation.isEmpty());
+    }
+
+    @Test
     void getRetiringFederation_present_beforeMultikey() {
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP123)).thenReturn(false);

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -5,6 +5,7 @@ import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP284;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -239,11 +240,8 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getRetiringFederationSize()).thenReturn(3);
         when(federatorSupportMock.getRetiringFederationAddress()).thenReturn(Optional.empty()); // Address is missing
     
-        // Act
-        Optional<Federation> retiringFederation = federationProvider.getRetiringFederation();
-
-        // Assert
-        assertTrue(retiringFederation.isEmpty());
+        // Act & Assert
+        assertThrows(IllegalStateException.class, () -> federationProvider.getRetiringFederation());
     }
 
     @Test
@@ -385,7 +383,7 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @Test
-    void getProposedFederation_whenSomeDataDoesNotExists_shouldReturnEmptyOptional() {
+    void getProposedFederation_whenSomeDataDoesNotExists_shouldThrowIllegalStateException() {
         // Arrange
         Federation expectedFederation = createP2shErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000));
@@ -397,13 +395,10 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
         when(federatorSupportMock.getProposedFederationCreationBlockNumber()).thenReturn(Optional.of(0L));
         when(federatorSupportMock.getProposedFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC))
-            .thenThrow(new IllegalStateException());
+            .thenReturn(Optional.empty());
 
-        // Act
-        Optional<Federation> proposedFederation = federationProvider.getProposedFederation();
-
-        // Assert
-        assertFalse(proposedFederation.isPresent());
+        // Act & Assert
+        assertThrows(IllegalStateException.class, () -> federationProvider.getProposedFederation());
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -231,16 +231,6 @@ class FederationProviderFromFederatorSupportTest {
 
         assertEquals(Optional.empty(), federationProvider.getRetiringFederation());
         verify(federatorSupportMock).getRetiringFederationSize();
-        verify(federatorSupportMock).getRetiringFederationAddress();
-    }
-
-    @Test
-    void getRetiringFederation_no_address() {
-        when(federatorSupportMock.getRetiringFederationSize()).thenReturn(5);
-
-        assertEquals(Optional.empty(), federationProvider.getRetiringFederation());
-        verify(federatorSupportMock).getRetiringFederationSize();
-        verify(federatorSupportMock).getRetiringFederationAddress();
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -372,7 +372,7 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @Test
-    void getProposedFederation_whenRSKIP417IsNotActivated_shouldReturnEmptyOptional() {
+    void getProposedFederation_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
         // Arrange
         ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
         when(configMock.isActive(RSKIP419)).thenReturn(false);
@@ -410,77 +410,6 @@ class FederationProviderFromFederatorSupportTest {
         assertEquals(Optional.empty(), federationProvider.getProposedFederation());
         verify(federatorSupportMock).getProposedFederationSize();
         verify(federatorSupportMock).getProposedFederationAddress();
-    }
-
-    @Test
-    void getProposedFederation_whenExistsAndIsStandardMultisigFederation_shouldReturnProposedFederation() {
-        // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-
-        Federation expectedFederation = createFederation(
-            getFederationMembersFromPks(0, 2000, 4000, 6000, 8000, 10000, 12000));
-        Address expectedFederationAddress = expectedFederation.getAddress();
-        Integer federationSize = 6;
-        when(federatorSupportMock.getProposedFederationSize()).thenReturn(Optional.of(federationSize));
-        when(federatorSupportMock.getProposedFederationCreationTime()).thenReturn(Optional.of(creationTime));
-        when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(expectedFederationAddress));
-        when(federatorSupportMock.getProposedFederationCreationBlockNumber()).thenReturn(Optional.of(0L));
-        when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        for (int i = 0; i < federationSize; i++) {
-            when(federatorSupportMock.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC))
-                .thenReturn(Optional.of(ECKey.fromPrivate(BigInteger.valueOf((i+1)*2000))));
-            when(federatorSupportMock.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK))
-                .thenReturn(Optional.of(ECKey.fromPrivate(BigInteger.valueOf((i+1)*2000+1))));
-            when(federatorSupportMock.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.MST))
-                .thenReturn(Optional.of(ECKey.fromPrivate(BigInteger.valueOf((i+1)*2000+2))));
-        }
-
-        // Act
-        Optional<Federation> proposedFederation = federationProvider.getProposedFederation();
-
-        // Assert
-        assertTrue(proposedFederation.isPresent());
-        assertEquals(STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION, proposedFederation.get().getFormatVersion());
-        assertEquals(expectedFederation, proposedFederation.get());
-        assertEquals(expectedFederationAddress, proposedFederation.get().getAddress());
-    }
-
-    @Test
-    void getProposedFederation_whenExistsAndIsNonStandardErpFederation_shouldReturnProposedFederation() {
-        // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-
-        Federation expectedFederation = createNonStandardErpFederation(
-            getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000),
-            configMock);
-        Address expectedFederationAddress = expectedFederation.getAddress();
-        Integer federationSize = 5;
-        when(federatorSupportMock.getProposedFederationSize()).thenReturn(Optional.of(federationSize));
-        when(federatorSupportMock.getProposedFederationCreationTime()).thenReturn(Optional.of(creationTime));
-        when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(expectedFederationAddress));
-        when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        when(federatorSupportMock.getProposedFederationCreationBlockNumber()).thenReturn(Optional.of(0L));
-        for (int i = 0; i < federationSize; i++) {
-            when(federatorSupportMock.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC))
-                .thenReturn(Optional.of(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000))));
-            when(federatorSupportMock.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK))
-                .thenReturn(Optional.of(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+1))));
-            when(federatorSupportMock.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.MST))
-                .thenReturn(Optional.of(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+2))));
-        }
-
-        // Act
-        Optional<Federation> proposedFederation = federationProvider.getProposedFederation();
-
-        // Assert
-        assertTrue(proposedFederation.isPresent());
-        assertEquals(NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, proposedFederation.get().getFormatVersion());
-        assertEquals(expectedFederation, proposedFederation.get());
-        assertEquals(expectedFederationAddress, proposedFederation.get().getAddress());
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -394,22 +394,6 @@ class FederationProviderFromFederatorSupportTest {
         // Act & Assert
         assertEquals(Optional.empty(), federationProvider.getProposedFederation());
         verify(federatorSupportMock).getProposedFederationSize();
-        verify(federatorSupportMock).getProposedFederationAddress();
-    }
-
-    @Test
-    void getProposedFederation_whenProposedFederationAddressDoesNotExist_shouldReturnEmptyOptional() {
-        // Arrange
-        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getProposedFederationSize())
-            .thenReturn(Optional.of(9));
-
-        // Act & Assert
-        assertEquals(Optional.empty(), federationProvider.getProposedFederation());
-        verify(federatorSupportMock).getProposedFederationSize();
-        verify(federatorSupportMock).getProposedFederationAddress();
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -55,7 +55,7 @@ class FederatorSupportTest {
     private static final NetworkParameters NETWORK_PARAMETERS = BridgeMainNetConstants.getInstance().getBtcParams();
     private static final List<BtcECKey> KEYS = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"k1", "k2", "k3"}, true);
     private static final Address DEFAULT_ADDRESS = BitcoinTestUtils.createP2SHMultisigAddress(NETWORK_PARAMETERS, KEYS);
-    private static final byte[] PUBLIC_KEY = Hex.decode("0497466f2b32bc3bb76d4741ae51cd1d8578b48d3f1e68da206d47321aec267ce78549b514e4453d74ef11b0cd5e4e4c364effddac8b51bcfc8de80682f952896f");
+    private static final byte[] PUBLIC_KEY = ECKey.fromPrivate(BigInteger.valueOf(100)).getPubKey();
 
     private BridgeTransactionSender bridgeTransactionSender;
     private FederatorSupport federatorSupport;

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -30,6 +30,7 @@ import co.rsk.peg.StateForProposedFederator;
 import java.util.AbstractMap;
 import co.rsk.federate.bitcoin.BitcoinTestUtils;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -303,6 +304,34 @@ class FederatorSupportTest {
         assertThrows(NullPointerException.class, () -> {
             federatorSupport.getProposedFederatorPublicKeyOfType(index, null);
         });
+    }
+
+    @Test
+    void getProposedFederationCreationTime_whenCreationTimeIsNull_shouldReturnEmptyOptional() {
+        // Arrange
+        when(bridgeTransactionSender.callTx(any(), eq(Bridge.GET_PROPOSED_FEDERATION_CREATION_TIME)))
+            .thenReturn(null);
+
+        // Act
+        Optional<Instant> result = federatorSupport.getProposedFederationCreationTime();
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getProposedFederationCreationTime_whenCreationTimeIsValid_shouldReturnInstant() {
+        // Arrange
+        BigInteger expectedCreationTime = BigInteger.valueOf(System.currentTimeMillis());
+        when(bridgeTransactionSender.callTx(any(), eq(Bridge.GET_PROPOSED_FEDERATION_CREATION_TIME)))
+            .thenReturn(expectedCreationTime);
+
+        // Act
+        Optional<Instant> result = federatorSupport.getProposedFederationCreationTime();
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(expectedCreationTime.longValue(), result.get().toEpochMilli());
     }
 
 

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -334,6 +334,33 @@ class FederatorSupportTest {
         assertEquals(expectedCreationTime.longValue(), result.get().toEpochMilli());
     }
 
+    @Test
+    void getProposedFederationCreationBlockNumber_whenBlockNumberIsNull_shouldReturnEmptyOptional() {
+        // Arrange
+        when(bridgeTransactionSender.callTx(any(), eq(Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER)))
+            .thenReturn(null);
+
+        // Act
+        Optional<Long> result = federatorSupport.getProposedFederationCreationBlockNumber();
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getProposedFederationCreationBlockNumber_whenBlockNumberIsValid_shouldReturnLong() {
+        // Arrange
+        BigInteger expectedBlockNumber = BigInteger.valueOf(123456);
+        when(bridgeTransactionSender.callTx(any(), eq(Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER)))
+            .thenReturn(expectedBlockNumber);
+
+        // Act
+        Optional<Long> result = federatorSupport.getProposedFederationCreationBlockNumber();
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(expectedBlockNumber.longValue(), result.get());
+    }
 
     private Sha256Hash createHash() {
         byte[] bytes = new byte[32];

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -331,7 +331,7 @@ class FederatorSupportTest {
 
         // Assert
         assertTrue(result.isPresent());
-        assertEquals(expectedCreationTime.longValue(), result.get().toEpochMilli());
+        assertEquals(expectedCreationTime.longValue(), result.get().getEpochSecond());
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -26,6 +26,8 @@ import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeMethods;
 import co.rsk.peg.StateForProposedFederator;
 import java.util.AbstractMap;
+import co.rsk.federate.bitcoin.BitcoinTestUtils;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -220,6 +222,34 @@ class FederatorSupportTest {
         // Assert
         assertTrue(result.isPresent());
         assertEquals(DEFAULT_ADDRESS.toString(), result.get().toString());
+    }
+
+    @Test
+    void getProposedFederationSize_whenSizeIsNull_shouldReturnEmptyOptional() {
+        // Arrange
+        when(bridgeTransactionSender.callTx(any(), eq(Bridge.GET_PROPOSED_FEDERATION_SIZE)))
+            .thenReturn(null);
+
+        // Act
+        Optional<Integer> result = federatorSupport.getProposedFederationSize();
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getProposedFederationSize_whenSizeIsPresent_shouldReturnInteger() {
+        // Arrange
+        BigInteger expectedSize = BigInteger.valueOf(9);
+        when(bridgeTransactionSender.callTx(any(), eq(Bridge.GET_PROPOSED_FEDERATION_SIZE)))
+            .thenReturn(expectedSize);
+
+        // Act
+        Optional<Integer> result = federatorSupport.getProposedFederationSize();
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(expectedSize.intValue(), result.get());
     }
 
     private Sha256Hash createHash() {

--- a/src/test/java/co/rsk/federate/FederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederatorSupportTest.java
@@ -258,7 +258,7 @@ class FederatorSupportTest {
     }
 
     @Test
-    void getProposedFederatorPublicKeyOfType_whenPublicKeyBytesIsNull_shouldReturnEmptyOptional() {
+    void getProposedFederatorPublicKeyOfType_whenPublicKeyIsNull_shouldReturnEmptyOptional() {
         // Arrange
         int index = 0;
         FederationMember.KeyType keyType = FederationMember.KeyType.BTC;
@@ -276,7 +276,7 @@ class FederatorSupportTest {
     }
 
     @Test
-    void getProposedFederatorPublicKeyOfType_whenPublicKeyBytesArePresent_shouldReturnECKey() {
+    void getProposedFederatorPublicKeyOfType_whenPublicKeyIsPresent_shouldReturnECKey() {
         // Arrange
         int index = 0; 
         FederationMember.KeyType keyType = FederationMember.KeyType.BTC;


### PR DESCRIPTION
### Summary

This PR includes the implementation of `getProposedFederation`. As well as bridge RPC methods for specific proposed federation implementations for `getFederationSize`, `getFederatorPublicKeyOfType`,`getFederationCreationTime`, and `getFederationCreationBlockNumber`.

### Motivation and Context

https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md
