### PR TITLE
Modify BtcReleaseClient onBestBlock such that it process svpSpendTxWaitingForSignatures 

### DIFF
--- a/src/main/java/co/rsk/federate/FedNodeContext.java
+++ b/src/main/java/co/rsk/federate/FedNodeContext.java
@@ -59,8 +59,6 @@ public class FedNodeContext extends RskContext {
             getBtcToRskClientRetiring(),
             new BtcReleaseClient(
                 getRsk(),
-                getBlockStore(),
-                getReceiptStore(),
                 getFederatorSupport(),
                 getPowpegNodeSystemProperties(),
                 getNodeBlockProcessor()

--- a/src/main/java/co/rsk/federate/FedNodeContext.java
+++ b/src/main/java/co/rsk/federate/FedNodeContext.java
@@ -60,6 +60,7 @@ public class FedNodeContext extends RskContext {
             new BtcReleaseClient(
                 getRsk(),
                 getBlockStore(),
+                getReceiptStore(),
                 getFederatorSupport(),
                 getPowpegNodeSystemProperties(),
                 getNodeBlockProcessor()

--- a/src/main/java/co/rsk/federate/FedNodeContext.java
+++ b/src/main/java/co/rsk/federate/FedNodeContext.java
@@ -59,6 +59,7 @@ public class FedNodeContext extends RskContext {
             getBtcToRskClientRetiring(),
             new BtcReleaseClient(
                 getRsk(),
+                getBlockStore(),
                 getFederatorSupport(),
                 getPowpegNodeSystemProperties(),
                 getNodeBlockProcessor()

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -36,13 +36,10 @@ public class FederatorSupport {
 
     private final Blockchain blockchain;
     private final PowpegNodeSystemProperties config;
-
     private final NetworkParameters parameters;
-
     private final BridgeTransactionSender bridgeTransactionSender;
 
     private ECDSASigner signer;
-
     private FederationMember federationMember;
     private RskAddress federatorAddress;
 
@@ -52,9 +49,7 @@ public class FederatorSupport {
             BridgeTransactionSender bridgeTransactionSender) {
         this.blockchain = blockchain;
         this.config = config;
-
         this.parameters = config.getNetworkConstants().getBridgeConstants().getBtcParams();
-
         this.bridgeTransactionSender = bridgeTransactionSender;
     }
 

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -11,6 +11,7 @@ import co.rsk.federate.signing.ECDSASigner;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.StateForFederator;
+import co.rsk.peg.StateForProposedFederator;
 import org.bitcoinj.core.PartialMerkleTree;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.Sha256Hash;
@@ -150,6 +151,13 @@ public class FederatorSupport {
         return new StateForFederator(result, this.parameters);
     }
 
+    public Optional<StateForProposedFederator> getStateForProposedFederator() {
+        byte[] result = bridgeTransactionSender.callTx(
+            federatorAddress, Bridge.GET_STATE_FOR_SVP_CLIENT);
+
+        return Optional.ofNullable(result)
+            .map(rlpData -> new StateForProposedFederator(rlpData, parameters));
+    }
 
     public void addSignature(List<byte[]> signatures, byte[] rskTxHash) {
         byte[] federatorPublicKeyBytes = federationMember.getBtcPublicKey().getPubKey();

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -307,7 +307,7 @@ public class BtcReleaseClient {
                 .filter(confirmationDifference -> confirmationDifference >= bridgeConstants.getRsk2BtcMinimumAcceptableConfirmations())
                 .isPresent();
 
-            logger.info("[isReadyToSign] SVP spend tx readiness check for signing: tx hash [{}], Current block [{}], Ready to sign? [{}]",
+            logger.info("[isSvpSpendTxReadyToSign] SVP spend tx readiness check for signing: tx hash [{}], Current block [{}], Ready to sign? [{}]",
                 svpTxHash,
                 currentBlockNumber,
                 isReadyToSign ? "YES" : "NO");

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -1,5 +1,7 @@
 package co.rsk.federate.btcreleaseclient;
 
+import static co.rsk.federate.signing.PowPegNodeKeyId.BTC;
+
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.TransactionInput;
@@ -72,11 +74,18 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static co.rsk.federate.signing.PowPegNodeKeyId.BTC;
-
 /**
- * Manages signing and broadcasting pegouts
- * @author Oscar Guindzberg
+ * Responsible for managing the signing and broadcasting of pegout transactions
+ * to the Bitcoin network in a federated bridge environment. The BtcReleaseClient
+ * coordinates the execution of pegout operations, ensuring transactions are 
+ * correctly signed and propagated.
+ *
+ * <p>Key responsibilities include:</p>
+ * <ul>
+ *   <li>Assembling transaction data and managing signing processes</li>
+ *   <li>Validating transaction information before broadcast</li>
+ *   <li>Ensuring successful pegout transaction broadcast to the Bitcoin network</li>
+ * </ul>
  */
 public class BtcReleaseClient {
     private static final Logger logger = LoggerFactory.getLogger(BtcReleaseClient.class);

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -249,7 +249,9 @@ public class BtcReleaseClient {
             // since it all lies within RSK's blockchain and normal rules apply. I.e., this
             // process works on a block-by-block basis.
             StateForFederator stateForFederator = federatorSupport.getStateForFederator();
-            Set<Map.Entry<Keccak256, BtcTransaction>> rskTxsReadyToBeSigned = stateForFederator.getRskTxsWaitingForSignatures().entrySet().stream()
+            Set<Map.Entry<Keccak256, BtcTransaction>> rskTxsReadyToBeSigned = stateForFederator.getRskTxsWaitingForSignatures()
+                .entrySet()
+                .stream()
                 .filter(rskTxWaitingForSignatures -> isReadyToSign(block.getNumber(), rskTxWaitingForSignatures.getKey()))
                 .collect(Collectors.toUnmodifiableSet());
             processReleases(rskTxsReadyToBeSigned);

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -238,7 +238,7 @@ public class BtcReleaseClient {
             }
             storageSynchronizer.processBlock(block, receipts);
           
-            // Check if svp spend tx waiting for signatures is available to be signed
+            // Sign svp spend tx waiting for signatures, if it exists,
             // before attempting to sign any pegouts.
             federatorSupport.getStateForProposedFederator()
                 .map(StateForProposedFederator::getSvpSpendTxWaitingForSignatures)

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -314,14 +314,14 @@ public class BtcReleaseClient {
         }
 
         private BtcTransaction convertToBtcTxFromRLPData(byte[] dataFromBtcReleaseTopic) {
-            RLPList dataElements = (RLPList)RLP.decode2(dataFromBtcReleaseTopic).get(0);
+            RLPList dataElements = (RLPList) RLP.decode2(dataFromBtcReleaseTopic).get(0);
 
             return new BtcTransaction(bridgeConstants.getBtcParams(), dataElements.get(1).getRLPData());
         }
 
         private BtcTransaction convertToBtcTxFromSolidityData(byte[] dataFromBtcReleaseTopic) {
             return new BtcTransaction(bridgeConstants.getBtcParams(),
-                (byte[])BridgeEvents.RELEASE_BTC.getEvent().decodeEventData(dataFromBtcReleaseTopic)[0]);
+                (byte[]) BridgeEvents.RELEASE_BTC.getEvent().decodeEventData(dataFromBtcReleaseTopic)[0]);
         }
     }
 

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -228,6 +228,7 @@ public class BtcReleaseClient {
         @Override
         public void onBestBlock(org.ethereum.core.Block block, List<TransactionReceipt> receipts) {
             if (!isPegoutEnabled) {
+                logger.warn("[onBestBlock] Processing of RSK transactions waiting for signatures is disabled");
                 return;
             }
 

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -88,13 +88,11 @@ import org.slf4j.LoggerFactory;
  * </ul>
  */
 public class BtcReleaseClient {
+
     private static final Logger logger = LoggerFactory.getLogger(BtcReleaseClient.class);
     private static final PanicProcessor panicProcessor = new PanicProcessor();
     private static final List<DataWord> SINGLE_RELEASE_BTC_TOPIC_RLP = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
     private static final DataWord SINGLE_RELEASE_BTC_TOPIC_SOLIDITY = DataWord.valueOf(BridgeEvents.RELEASE_BTC.getEvent().encodeSignatureLong());
-
-    private ActivationConfig activationConfig;
-    private PeerGroup peerGroup;
 
     private final Ethereum ethereum;
     private final FederatorSupport federatorSupport;
@@ -104,13 +102,13 @@ public class BtcReleaseClient {
     private final boolean isPegoutEnabled;
     private final PegoutSignedCache pegoutSignedCache;
 
+    private ActivationConfig activationConfig;
+    private PeerGroup peerGroup;
     private ECDSASigner signer;
     private BtcReleaseEthereumListener blockListener;
     private SignerMessageBuilderFactory signerMessageBuilderFactory;
-
     private ReleaseCreationInformationGetter releaseCreationInformationGetter;
     private ReleaseRequirementsEnforcer releaseRequirementsEnforcer;
-
     private BtcReleaseClientStorageAccessor storageAccessor;
     private BtcReleaseClientStorageSynchronizer storageSynchronizer;
 
@@ -144,7 +142,8 @@ public class BtcReleaseClient {
         this.activationConfig = activationConfig;
         logger.debug("[setup] Signer: {}", signer.getClass());
 
-        org.bitcoinj.core.Context btcContext = new org.bitcoinj.core.Context(ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString()));
+        org.bitcoinj.core.Context btcContext = new org.bitcoinj.core.Context(
+            ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString()));
         peerGroup = new PeerGroup(btcContext);
         try {
             if (!federatorSupport.getBitcoinPeerAddresses().isEmpty()) {
@@ -153,7 +152,7 @@ public class BtcReleaseClient {
                 }
                 peerGroup.setMaxConnections(federatorSupport.getBitcoinPeerAddresses().size());
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new BtcReleaseClientException("Error configuring peerSupport", e);
         }
         peerGroup.start();
@@ -207,7 +206,9 @@ public class BtcReleaseClient {
 
     @PreDestroy
     public void tearDown() {
-        org.bitcoinj.core.Context.propagate(new org.bitcoinj.core.Context(ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString())));
+        org.bitcoinj.core.Context.propagate(
+            new org.bitcoinj.core.Context(
+                ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString())));
         peerGroup.stop();
         peerGroup = null;
     }
@@ -225,6 +226,7 @@ public class BtcReleaseClient {
                 );
                 return;
             }
+
             // Processing transactions waiting for signatures on best block only still "works",
             // since it all lies within RSK's blockchain and normal rules apply. I.e., this
             // process works on a block-by-block basis.
@@ -243,6 +245,7 @@ public class BtcReleaseClient {
             if (!isPegoutEnabled || nodeBlockProcessor.hasBetterBlockToSync()) {
                 return;
             }
+
             /* Pegout events must be processed on an every-single-block basis,
              since otherwise we could be missing pegouts potentially mined
              on what originally were side-chains and then turned into best-chains.*/

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -741,8 +741,6 @@ class BtcReleaseClientTest {
             mock(ReceiptStore.class)
         );
 
-        ReceiptStore receiptStore = mock(ReceiptStore.class);
-
         Keccak256 blockHash = createHash(2);
         Block block = mock(Block.class);
         TransactionReceipt txReceipt = mock(TransactionReceipt.class);
@@ -833,8 +831,6 @@ class BtcReleaseClientTest {
         SignerMessageBuilderFactory signerMessageBuilderFactory = new SignerMessageBuilderFactory(
             mock(ReceiptStore.class)
         );
-
-        ReceiptStore receiptStore = mock(ReceiptStore.class);
 
         Keccak256 blockHash = createHash(2);
         Block block = mock(Block.class);

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -28,6 +28,7 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.TransactionInput;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
+import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
@@ -103,8 +104,8 @@ class BtcReleaseClientTest {
     private final BlockStore blockStore = mock(BlockStore.class);
     private final ReceiptStore receiptStore = mock(ReceiptStore.class);
     private final Block bestBlock = mock(Block.class);
-    private final NetworkParameters params = RegTestParams.get();
-    private final BridgeConstants bridgeConstants = Constants.regtest().bridgeConstants;
+    private final NetworkParameters params = MainNetParams.get();
+    private final BridgeConstants bridgeConstants = Constants.mainnet().bridgeConstants;
 
     private static final List<BtcECKey> erpFedKeys = Arrays.stream(new String[]{
         "03b9fc46657cf72a1afa007ecf431de1cd27ff5cc8829fa625b66ca47b967e6b24",

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -713,8 +713,7 @@ class BtcReleaseClientTest {
         doReturn(mock(StateForFederator.class)).when(federatorSupport).getStateForFederator();
 
         ECKey ecKey = new ECKey();
-        BtcECKey fedKey = new BtcECKey();
-        ECPublicKey signerPublicKey = new ECPublicKey(fedKey.getPubKey());
+        ECPublicKey signerPublicKey = new ECPublicKey(federationMember.getBtcPublicKey().getPubKey());
 
         ECDSASigner signer = mock(ECDSASigner.class);
         doReturn(signerPublicKey).when(signer).getPublicKey(BTC.getKeyId());
@@ -1044,8 +1043,7 @@ class BtcReleaseClientTest {
         doReturn(mock(StateForFederator.class)).when(federatorSupport).getStateForFederator();
 
         ECKey ecKey = new ECKey();
-        BtcECKey fedKey = new BtcECKey();
-        ECPublicKey signerPublicKey = new ECPublicKey(fedKey.getPubKey());
+        ECPublicKey signerPublicKey = new ECPublicKey(federationMember.getBtcPublicKey().getPubKey());
 
         ECDSASigner signer = mock(ECDSASigner.class);
         doReturn(signerPublicKey).when(signer).getPublicKey(BTC.getKeyId());

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -138,7 +138,7 @@ class BtcReleaseClientTest {
     void start_whenFederationMemberNotPartOfDesiredFederation_shouldThrowException() {
         // Arrange
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -165,7 +165,7 @@ class BtcReleaseClientTest {
     void if_start_not_called_rsk_blockchain_not_listened() {
         Ethereum ethereum = mock(Ethereum.class);
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        Mockito.doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        Mockito.doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -186,7 +186,7 @@ class BtcReleaseClientTest {
         Ethereum ethereum = mock(Ethereum.class);
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
-        Mockito.doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        Mockito.doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -217,7 +217,7 @@ class BtcReleaseClientTest {
         Ethereum ethereum = mock(Ethereum.class);
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
-        Mockito.doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        Mockito.doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
       
@@ -251,7 +251,7 @@ class BtcReleaseClientTest {
         Ethereum ethereum = mock(Ethereum.class);
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        Mockito.doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        Mockito.doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -306,7 +306,7 @@ class BtcReleaseClientTest {
         when(signer.sign(eq(BTC.getKeyId()), ArgumentMatchers.any())).thenReturn(ethSig);
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -412,7 +412,7 @@ class BtcReleaseClientTest {
         doReturn(ethSig).when(signer).sign(any(KeyId.class), any(SignerMessage.class));
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -512,7 +512,7 @@ class BtcReleaseClientTest {
         doReturn(ecKey.doSign(new byte[]{})).when(signer).sign(any(KeyId.class), any(SignerMessage.class));
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -618,7 +618,7 @@ class BtcReleaseClientTest {
         doReturn(ecKey.doSign(new byte[]{})).when(signer).sign(any(KeyId.class), any(SignerMessage.class));
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -702,12 +702,12 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenOnlySvpSpendTxWaitingForSignaturesIsAvailable_shouldAddSignature() throws Exception {
         // Arrange
-        Federation federation = TestUtils.createFederation(params, 9);
-        FederationMember federationMember = federation.getMembers().get(0);
-        BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, federation);
+        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        FederationMember federationMember = proposedFederation.getMembers().get(0);
+        BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
-        Map.Entry<Keccak256, BtcTransaction> entry = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
-        StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(entry);
+        Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
+        StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(svpSpendTxWFS);
 
         Ethereum ethereum = mock(Ethereum.class);
         AtomicReference<EthereumListener> ethereumListener = new AtomicReference<>();
@@ -733,7 +733,7 @@ class BtcReleaseClientTest {
         doReturn(ecKey.doSign(new byte[]{})).when(signer).sign(any(KeyId.class), any(SignerMessage.class));
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -780,7 +780,7 @@ class BtcReleaseClientTest {
             storageSynchronizer
         );
 
-        btcReleaseClient.start(federation);
+        btcReleaseClient.start(proposedFederation);
 
         // Act
         ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
@@ -795,12 +795,12 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenSvpSpendTxIsNotReadyToBeSigned_shouldNotAddSignature() throws Exception {
         // Arrange
-        Federation federation = TestUtils.createFederation(params, 9);
-        FederationMember federationMember = federation.getMembers().get(0);
-        BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, federation);
+        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        FederationMember federationMember = proposedFederation.getMembers().get(0);
+        BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
-        Map.Entry<Keccak256, BtcTransaction> entry = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
-        StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(entry);
+        Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
+        StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(svpSpendTxWFS);
 
         Ethereum ethereum = mock(Ethereum.class);
         AtomicReference<EthereumListener> ethereumListener = new AtomicReference<>();
@@ -826,7 +826,7 @@ class BtcReleaseClientTest {
         doReturn(ecKey.doSign(new byte[]{})).when(signer).sign(any(KeyId.class), any(SignerMessage.class));
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -873,7 +873,7 @@ class BtcReleaseClientTest {
             storageSynchronizer
         );
 
-        btcReleaseClient.start(federation);
+        btcReleaseClient.start(proposedFederation);
       
         // Since the current best block will also be the block that 
         // contains the svp spend tx waiting for signatures hash then 
@@ -910,7 +910,7 @@ class BtcReleaseClientTest {
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -962,7 +962,7 @@ class BtcReleaseClientTest {
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(false).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -1014,7 +1014,7 @@ class BtcReleaseClientTest {
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -1062,7 +1062,7 @@ class BtcReleaseClientTest {
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        doReturn(Constants.regtest()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
         doReturn(false).when(powpegNodeSystemProperties).isPegoutEnabled();
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -1179,7 +1179,7 @@ class BtcReleaseClientTest {
         releaseInput.setScriptSig(inputScript);
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -1226,7 +1226,7 @@ class BtcReleaseClientTest {
         releaseTx.addInput(releaseInput);
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -1291,7 +1291,7 @@ class BtcReleaseClientTest {
         releaseInput.setScriptSig(inputScript);
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -1377,7 +1377,7 @@ class BtcReleaseClientTest {
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -1414,7 +1414,7 @@ class BtcReleaseClientTest {
         Script redeemScriptToExtract)
     {
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
 
@@ -1489,7 +1489,7 @@ class BtcReleaseClientTest {
         HSMReleaseCreationInformationException, ReleaseRequirementsEnforcerException,
         HSMUnsupportedVersionException, SignerMessageBuilderException {
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.isPegoutEnabled()).thenReturn(true);
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
@@ -1600,7 +1600,7 @@ class BtcReleaseClientTest {
 
     private BtcReleaseClient createBtcClient() {
         PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
-        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.regtest());
+        when(powpegNodeSystemProperties.getNetworkConstants()).thenReturn(Constants.mainnet());
         when(powpegNodeSystemProperties.isPegoutEnabled()).thenReturn(true); // Enabled by default
         when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
             .thenReturn(PEGOUT_SIGNED_CACHE_TTL);

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -139,8 +139,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -160,8 +158,6 @@ class BtcReleaseClientTest {
 
         new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             mock(FederatorSupport.class),
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -181,8 +177,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -212,8 +206,6 @@ class BtcReleaseClientTest {
       
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -246,8 +238,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -310,8 +300,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient client = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -442,8 +430,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -533,8 +519,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -639,8 +623,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -753,8 +735,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -868,8 +848,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -988,8 +966,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1084,8 +1060,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1142,8 +1116,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             nodeBlockProcessor
@@ -1194,8 +1166,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             nodeBlockProcessor
@@ -1246,8 +1216,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             nodeBlockProcessor
@@ -1294,8 +1262,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             nodeBlockProcessor
@@ -1414,8 +1380,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient client = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1459,8 +1423,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient client = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             mock(FederatorSupport.class),
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1519,8 +1481,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient client = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             mock(FederatorSupport.class),
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1608,8 +1568,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient client = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1642,8 +1600,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient client = new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             mock(FederatorSupport.class),
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
@@ -1779,8 +1735,6 @@ class BtcReleaseClientTest {
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereumImpl,
-            blockStore,
-            receiptStore,
             federatorSupport,
             powpegNodeSystemProperties,
             nodeBlockProcessor
@@ -1829,8 +1783,6 @@ class BtcReleaseClientTest {
 
         return new BtcReleaseClient(
             mock(Ethereum.class),
-            blockStore,
-            receiptStore,
             mock(FederatorSupport.class),
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -787,7 +787,7 @@ class BtcReleaseClientTest {
     void onBestBlock_whenBothPegoutAndSvpSpendTxWaitingForSignaturesIsAvailable_shouldAddSignatureForBoth() throws Exception {
         // Arrange
         List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(9).toList();
-        BtcECKey federationKey = keys.get(0);
+        BtcECKey fedKey = keys.get(0);
         FederationMember federationMember = FederationMember.getFederationMembersFromKeys(keys).get(0);
         Federation federation = TestUtils.createFederation(params, keys);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
@@ -797,7 +797,7 @@ class BtcReleaseClientTest {
         StateForFederator stateForFederator = new StateForFederator(rskTxsWaitingForSignatures);
 
         List<BtcECKey> proposedKeys = Stream.generate(BtcECKey::new).limit(8).collect(Collectors.toList());
-        proposedKeys.add(federationKey);
+        proposedKeys.add(fedKey);
         Federation proposedFederation = TestUtils.createFederation(params, proposedKeys);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(1);
@@ -819,7 +819,6 @@ class BtcReleaseClientTest {
         doReturn(Optional.of(stateForProposedFederator)).when(federatorSupport).getStateForProposedFederator();
 
         ECKey ecKey = new ECKey();
-        BtcECKey fedKey = new BtcECKey();
         ECPublicKey signerPublicKey = new ECPublicKey(fedKey.getPubKey());
 
         ECDSASigner signer = mock(ECDSASigner.class);


### PR DESCRIPTION
### Summary

Modifies the `onBestBlock` implementation for the `BtcReleaseClient` such that it always process new svp spend tx waiting for signatures is available. 

This also introduces a new filter called `isReadyToSign`. This conditional check will ensure that there has been enough confirmations before attempting to sign a transaction. 

### Motivation & Context

https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md