### PR TITLE
Add RSKIP419 check for proposed federation methods

### DIFF
--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -20,6 +20,7 @@ package co.rsk.federate;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static co.rsk.peg.federation.FederationMember.KeyType;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP419;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -143,6 +144,10 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
 
     @Override
     public Optional<Federation> getProposedFederation() {
+        if (!federatorSupport.getConfigForBestBlock().isActive(RSKIP419)) {
+            return Optional.empty();
+        }
+
         Integer federationSize = federatorSupport.getProposedFederationSize()
             .orElse(FEDERATION_NON_EXISTENT.getCode());
         if (federationSize == FEDERATION_NON_EXISTENT.getCode()) {
@@ -181,7 +186,9 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
 
     @Override
     public Optional<Address> getProposedFederationAddress() {
-        return federatorSupport.getProposedFederationAddress();
+        return Optional.of(federatorSupport)
+            .filter(fedSupport -> fedSupport.getConfigForBestBlock().isActive(RSKIP419))
+            .flatMap(FederatorSupport::getProposedFederationAddress);
     }
 
     private Federation getExpectedFederation(Federation initialFederation, Address expectedFederationAddress) {

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -3,6 +3,7 @@ package co.rsk.federate;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP123;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP284;
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP419;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -374,6 +375,9 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenProposedFederationSizeIsNonExistent_shouldReturnEmptyOptional() {
         // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationSize())
             .thenReturn(Optional.of(FEDERATION_NON_EXISTENT.getCode()));
 
@@ -385,6 +389,9 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenSomeDataDoesNotExists_shouldThrowIllegalStateException() {
         // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         Federation expectedFederation = createP2shErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000));
         Address expectedFederationAddress = expectedFederation.getAddress();
@@ -404,6 +411,9 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenExistsAndIsP2shErpFederation_shouldReturnProposedFederation() {
         // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         Federation expectedFederation = createP2shErpFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000, 5000));
         Address expectedFederationAddress = expectedFederation.getAddress();
@@ -433,8 +443,25 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @Test
+    void getProposedFederation_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
+        // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(false);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+
+        // Act
+        Optional<Federation> result = federationProvider.getProposedFederation();
+
+        // Assert
+        assertFalse(result.isPresent());
+    }
+
+    @Test
     void getProposedFederationAddress_whenAddressExists_shouldReturnAddress() {
         // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(DEFAULT_ADDRESS));
 
         // Act
@@ -448,7 +475,24 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederationAddress_whenNoAddressExists_shouldReturnEmptyOptional() {
         // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Address> result = federationProvider.getProposedFederationAddress();
+
+        // Assert
+        assertFalse(result.isPresent());
+    }
+  
+    @Test
+    void getProposedFederationAddress_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
+        // Arrange
+        ActivationConfig.ForBlock configMock = mock(ActivationConfig.ForBlock.class);
+        when(configMock.isActive(RSKIP419)).thenReturn(false);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
 
         // Act
         Optional<Address> result = federationProvider.getProposedFederationAddress();


### PR DESCRIPTION
### Summary

While running the `powpeg-node` before Lovell activation the Federation Watcher Rootstock listener will throw exceptions since the proposed federation methods are not allowed to be executed. The idea is from the side of the `powpeg-node` to check if `RSKIP419` is activated before sending the `callTx` to the Bridge.

Stacktrace:

```
2024-11-19-12:24:19.613 INFO [c.r.f.w.FederationWatcher]  [onBestBlock] New best block, updating state
2024-11-19-12:24:19.613 TRACE [c.r.f.BridgeTransactionSender]  Bridge call - method: getProposedFederationAddress
2024-11-19-12:24:19.614 WARN [c.r.p.Bridge]  'GET_PROPOSED_FEDERATION_ADDRESS' is not enabled to run
2024-11-19-12:24:19.614 WARN [c.r.p.Bridge]  'GET_PROPOSED_FEDERATION_ADDRESS' is not enabled to run
2024-11-19-12:24:19.614 INFO [c.r.p.Bridge]  [execute] Invalid data given: 956d9713.
2024-11-19-12:24:19.615 ERROR [c.r.p.Bridge]  Invalid data given: 956d9713.
co.rsk.peg.BridgeIllegalArgumentException: Invalid data given: 956d9713.
        at co.rsk.peg.Bridge.execute(Bridge.java:393)
        at org.ethereum.core.TransactionExecutor.call(TransactionExecutor.java:364)
        at org.ethereum.core.TransactionExecutor.execute(TransactionExecutor.java:304)
        at org.ethereum.core.TransactionExecutor.executeTransaction(TransactionExecutor.java:148)
        at co.rsk.core.ReversibleTransactionExecutor.reversibleExecution(ReversibleTransactionExecutor.java:116)
        at co.rsk.core.ReversibleTransactionExecutor.executeTransaction(ReversibleTransactionExecutor.java:93)
        at co.rsk.core.ReversibleTransactionExecutor.executeTransaction(ReversibleTransactionExecutor.java:70)
        at co.rsk.federate.BridgeTransactionSender.callTx(BridgeTransactionSender.java:60)
        at co.rsk.federate.BridgeTransactionSender.callTx(BridgeTransactionSender.java:52)
        at co.rsk.federate.FederatorSupport.getProposedFederationAddress(FederatorSupport.java:260)
        at co.rsk.federate.FederationProviderFromFederatorSupport.getProposedFederationAddress(FederationProviderFromFederatorSupport.java:184)
        at co.rsk.federate.watcher.FederationWatcher.updateProposedFederation(FederationWatcher.java:93)
        at co.rsk.federate.watcher.FederationWatcher.updateState(FederationWatcher.java:87)
        at co.rsk.federate.watcher.FederationWatcher$1.onBestBlock(FederationWatcher.java:76)
        at org.ethereum.listener.CompositeEthereumListener.lambda$onBestBlock$2(CompositeEthereumListener.java:71)
        at org.ethereum.listener.CompositeEthereumListener.scheduleListenerCallbacks(CompositeEthereumListener.java:132)
        at org.ethereum.listener.CompositeEthereumListener.onBestBlock(CompositeEthereumListener.java:71)
        at co.rsk.core.bc.BlockChainImpl.onBestBlock(BlockChainImpl.java:513)
        at co.rsk.core.bc.BlockChainImpl.internalTryToConnect(BlockChainImpl.java:304)
        at co.rsk.core.bc.BlockChainImpl.tryToConnect(BlockChainImpl.java:158)
        at org.ethereum.facade.EthereumImpl.addNewMinedBlock(EthereumImpl.java:62)
        at co.rsk.mine.MinerServerImpl.processSolution(MinerServerImpl.java:346)
        at co.rsk.mine.MinerServerImpl.submitBitcoinBlock(MinerServerImpl.java:291)
        at co.rsk.mine.MinerServerImpl.submitBitcoinBlock(MinerServerImpl.java:285)
        at co.rsk.mine.MinerClientImpl.mineBlock(MinerClientImpl.java:146)
        at co.rsk.mine.MinerClientImpl.doWork(MinerClientImpl.java:102)
        at co.rsk.mine.MinerClientImpl$1.run(MinerClientImpl.java:88)
```