### PR TITLE
Some fixes with how the powpeg node interacts with the SVP protocol

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -240,10 +240,12 @@ public class BtcReleaseClient {
           
             // Sign svp spend tx waiting for signatures, if it exists,
             // before attempting to sign any pegouts.
-            federatorSupport.getStateForProposedFederator()
-                .map(StateForProposedFederator::getSvpSpendTxWaitingForSignatures)
-                .filter(svpSpendTxWaitingForSignatures -> isSVPSpendTxReadyToSign(block.getNumber(), svpSpendTxWaitingForSignatures))
-                .ifPresent(svpSpendTxReadyToBeSigned -> processReleases(Set.of(svpSpendTxReadyToBeSigned)));
+            if (activationConfig.isActive(ConsensusRule.RSKIP419, block.getNumber())) {
+                federatorSupport.getStateForProposedFederator()
+                    .map(StateForProposedFederator::getSvpSpendTxWaitingForSignatures)
+                    .filter(svpSpendTxWaitingForSignatures -> isSVPSpendTxReadyToSign(block.getNumber(), svpSpendTxWaitingForSignatures))
+                    .ifPresent(svpSpendTxReadyToBeSigned -> processReleases(Set.of(svpSpendTxReadyToBeSigned)));
+            }
 
             // Processing transactions waiting for signatures on best block only still "works",
             // since it all lies within RSK's blockchain and normal rules apply. I.e., this

--- a/src/main/java/co/rsk/federate/watcher/FederationWatcher.java
+++ b/src/main/java/co/rsk/federate/watcher/FederationWatcher.java
@@ -97,7 +97,7 @@ public class FederationWatcher {
         boolean hasProposedFederationChanged = !currentlyProposedFederationAddress.equals(oldProposedFederationAddress);
 
         if (hasProposedFederationChanged) {
-            logger.info("[updateRetiringFederation] Proposed federation changed from {} to {}",
+            logger.info("[updateProposedFederation] Proposed federation changed from {} to {}",
                     oldProposedFederationAddress.orElse(null),
                     currentlyProposedFederationAddress.orElse(null));
 

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -80,7 +80,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
@@ -740,9 +740,12 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
+        ActivationConfig activationConfig = mock(ActivationConfig.class);
+        when(activationConfig.isActive(ConsensusRule.RSKIP419, bestBlock.getNumber())).thenReturn(true);
+
         btcReleaseClient.setup(
             signer,
-            mock(ActivationConfig.class),
+            activationConfig,
             signerMessageBuilderFactory,
             releaseCreationInformationGetter,
             mock(ReleaseRequirementsEnforcer.class),
@@ -853,9 +856,12 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
+        ActivationConfig activationConfig = mock(ActivationConfig.class);
+        when(activationConfig.isActive(ConsensusRule.RSKIP419, bestBlock.getNumber())).thenReturn(true);
+
         btcReleaseClient.setup(
             signer,
-            mock(ActivationConfig.class),
+            activationConfig,
             signerMessageBuilderFactory,
             releaseCreationInformationGetter,
             mock(ReleaseRequirementsEnforcer.class),
@@ -971,9 +977,12 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
+        ActivationConfig activationConfig = mock(ActivationConfig.class);
+        when(activationConfig.isActive(ConsensusRule.RSKIP419, bestBlock.getNumber())).thenReturn(true);
+
         btcReleaseClient.setup(
             signer,
-            mock(ActivationConfig.class),
+            activationConfig,
             signerMessageBuilderFactory,
             releaseCreationInformationGetter,
             mock(ReleaseRequirementsEnforcer.class),


### PR DESCRIPTION
## Description
Similar to previous PR. The call to get the svp spend tx wfs should also be behind the RSKIP419 check before Lovell is activated. 

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md

## How Has This Been Tested?
Locally in Regtest.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
