### PR TITLE
Update onProposedFederationChange in order to register SVP spend tx in the Bridge

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -180,13 +180,15 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         if (federation == null) {
             logger.warn("[updateBridge] updateBridge skipped because no Federation is associated to this BtcToRskClient");
         }
+
         if (nodeBlockProcessor.hasBetterBlockToSync()) {
             logger.warn("[updateBridge] updateBridge skipped because the node is syncing blocks");
             return;
         }
+
         logger.debug("[updateBridge] Updating bridge");
 
-        if(shouldUpdateBridgeBtcBlockchain) {
+        if (shouldUpdateBridgeBtcBlockchain) {
             // Call receiveHeaders
             try {
                 int numberOfBlocksSent = updateBridgeBtcBlockchain();
@@ -197,7 +199,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             }
         }
 
-        if(shouldUpdateBridgeBtcCoinbaseTransactions) {
+        if (shouldUpdateBridgeBtcCoinbaseTransactions) {
             // Call registerBtcCoinbaseTransaction
             try {
                 logger.debug("[updateBridge] Updating transactions and sending update");
@@ -208,7 +210,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             }
         }
 
-        if(shouldUpdateBridgeBtcTransactions) {
+        if (shouldUpdateBridgeBtcTransactions) {
             // Call registerBtcTransaction
             try {
                 logger.debug("[updateBridge] Updating transactions and sending update");
@@ -219,7 +221,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             }
         }
 
-        if(shouldUpdateCollections) {
+        if (shouldUpdateCollections) {
             // Call updateCollections
             try {
                 logger.debug("[updateBridge] Sending updateCollections");

--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -111,9 +111,9 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     public void start(Federation federation) {
         logger.info("[start] Starting for Federation {}", federation.getAddress());
         this.federation = federation;
+
         FederationMember federator = federatorSupport.getFederationMember();
         boolean isMember = federation.isMember(federator);
-
         if (!isMember) {
             String message = String.format(
                 "Member %s is no part of the federation %s",
@@ -128,10 +128,9 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         logger.info("[start] Watching federation {} since I belong to it",
             federation.getAddress());
         bitcoinWrapper.addFederationListener(federation, this);
-        Optional<Integer> federatorIndex = federation.getBtcPublicKeyIndex(
-            federatorSupport.getFederationMember().getBtcPublicKey()
-        );
 
+        Optional<Integer> federatorIndex = federation.getBtcPublicKeyIndex(
+            federatorSupport.getFederationMember().getBtcPublicKey());
         if (!federatorIndex.isPresent()) {
             String message = String.format(
                 "Federator %s is a member of the federation %s but could not find the btcPublicKeyIndex",
@@ -142,20 +141,19 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             throw new IllegalStateException(message);
         }
 
-        TurnScheduler scheduler = new TurnScheduler(
-                bridgeConstants.getUpdateBridgeExecutionPeriod(),
-                federation.getSize()
-        );
-        long now = Clock.systemUTC().instant().toEpochMilli();
-
         if (isUpdateBridgeTimerEnabled) {
-            updateBridgeTimer = Executors.newSingleThreadScheduledExecutor();
+            long now = Clock.systemUTC().instant().toEpochMilli();
+            TurnScheduler scheduler = new TurnScheduler(
+              bridgeConstants.getUpdateBridgeExecutionPeriod(),
+              federation.getSize());
+
+            this.updateBridgeTimer = Executors.newSingleThreadScheduledExecutor();
+
             updateBridgeTimer.scheduleAtFixedRate(
                 this::updateBridge,
                 scheduler.getDelay(now, federatorIndex.get()),
                 scheduler.getInterval(),
-                TimeUnit.MILLISECONDS
-            );
+                TimeUnit.MILLISECONDS);
         } else {
             logger.info("[start] updateBridgeTimer is disabled");
         }
@@ -164,11 +162,11 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     public void stop() {
         logger.info("Stopping");
 
-        federation = null;
+        this.federation = null;
 
         if (updateBridgeTimer != null) {
             updateBridgeTimer.shutdown();
-            updateBridgeTimer = null;
+            this.updateBridgeTimer = null;
         }
     }
 

--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -347,7 +347,8 @@ public class FedNodeRunner implements NodeRunner {
             FederationWatcherListener federationWatcherListener = new FederationWatcherListenerImpl(
                 btcToRskClientActive,
                 btcToRskClientRetiring,
-                btcReleaseClient);
+                btcReleaseClient,
+                bitcoinWrapper);
 
             federationWatcher.start(federationProvider, federationWatcherListener);
         }

--- a/src/main/java/co/rsk/federate/watcher/FederationWatcherListenerImpl.java
+++ b/src/main/java/co/rsk/federate/watcher/FederationWatcherListenerImpl.java
@@ -1,6 +1,7 @@
 package co.rsk.federate.watcher;
 
 import co.rsk.federate.BtcToRskClient;
+import co.rsk.federate.bitcoin.BitcoinWrapper;
 import co.rsk.federate.btcreleaseclient.BtcReleaseClient;
 import co.rsk.peg.federation.Federation;
 import org.slf4j.Logger;
@@ -14,14 +15,17 @@ public class FederationWatcherListenerImpl implements FederationWatcherListener 
     private final BtcToRskClient btcToRskClientActive;
     private final BtcToRskClient btcToRskClientRetiring;
     private final BtcReleaseClient btcReleaseClient;
+    private final BitcoinWrapper bitcoinWrapper;
 
     public FederationWatcherListenerImpl(
             BtcToRskClient btcToRskClientActive,
             BtcToRskClient btcToRskClientRetiring,
-            BtcReleaseClient btcReleaseClient) {
+            BtcReleaseClient btcReleaseClient,
+            BitcoinWrapper bitcoinWrapper) {
         this.btcToRskClientActive = btcToRskClientActive;
         this.btcToRskClientRetiring = btcToRskClientRetiring;
         this.btcReleaseClient = btcReleaseClient;
+        this.bitcoinWrapper = bitcoinWrapper;
     }
 
     @Override
@@ -51,13 +55,17 @@ public class FederationWatcherListenerImpl implements FederationWatcherListener 
             // start {@code BtcReleaseClient} with proposed federation
             // so it can sign svp spend tx
             btcReleaseClient.start(newProposedFederation);
+
+            // add proposed federation to active btc to rsk client so
+            // it can register svp spend tx in the bridge
+            bitcoinWrapper.addFederationListener(newProposedFederation, btcToRskClientActive);
           
             logger.info(
-                "[onProposedFederationChange] Client for proposed federation [{}] started with success",
+                "[onProposedFederationChange] Clients for proposed federation [{}] started with success",
                 newProposedFederation.getAddress());
         } catch (Exception e) {
             logger.error(
-                "[onProposedFederationChange] Client for proposed federation [{}] failed to start",
+                "[onProposedFederationChange] Clients for proposed federation [{}] failed to start",
                 newProposedFederation.getAddress(),
                 e);
         }

--- a/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
+++ b/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.BtcToRskClient;
+import co.rsk.federate.bitcoin.BitcoinWrapper;
 import co.rsk.federate.btcreleaseclient.BtcReleaseClient;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
@@ -38,6 +39,7 @@ class FederationWatcherListenerImplTest {
     private BtcToRskClient btcToRskClientActive;
     private BtcToRskClient btcToRskClientRetiring;
     private BtcReleaseClient btcReleaseClient;
+    private BitcoinWrapper bitcoinWrapper;
     private FederationWatcherListener federationWatcherListener;
 
     @BeforeEach
@@ -45,8 +47,9 @@ class FederationWatcherListenerImplTest {
         btcToRskClientActive = mock(BtcToRskClient.class);
         btcToRskClientRetiring = mock(BtcToRskClient.class);
         btcReleaseClient = mock(BtcReleaseClient.class);
+        bitcoinWrapper = mock(BitcoinWrapper.class);
         federationWatcherListener = new FederationWatcherListenerImpl(
-            btcToRskClientActive, btcToRskClientRetiring, btcReleaseClient);
+            btcToRskClientActive, btcToRskClientRetiring, btcReleaseClient, bitcoinWrapper);
     }
    
     @Test
@@ -99,6 +102,7 @@ class FederationWatcherListenerImplTest {
 
         // Assert
         verify(btcReleaseClient, never()).start(any(Federation.class));
+        verify(bitcoinWrapper, never()).addFederationListener(any(Federation.class), any(BtcToRskClient.class));
     }
 
     @Test
@@ -108,6 +112,7 @@ class FederationWatcherListenerImplTest {
 
         // Assert
         verify(btcReleaseClient).start(FEDERATION);
+        verify(bitcoinWrapper).addFederationListener(FEDERATION, btcToRskClientActive);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With this approach we add the `proposedFederation` to the list of watched federations that the `BitcoinWrapper` listens to. Since the svp spend tx will be considered as a peg-out from the perspective of the `BitcoinWrapper` federation listener it will allow it to be registered with no problem.

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md

## How Has This Been Tested?
This was tested in Regtest, and complete the SVP protocol:

`2024-12-11-11:49:16.930 INFO [c.r.p.BridgeSupport]  [registerSvpSpendTx] Going to commit the proposed federation.`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
