### PR TITLE
Ignore non-standard outputs when searching for the witness commitment hash

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -329,7 +329,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             throw new IllegalArgumentException(message);
         }
 
-        Optional<co.rsk.bitcoinj.core.Sha256Hash> expectedWitnessCommitment = BitcoinUtils.findWitnessCommitment(coinbaseTransaction);
+        Optional<co.rsk.bitcoinj.core.Sha256Hash> expectedWitnessCommitment = BitcoinUtils.findWitnessCommitment(coinbaseTransaction, federatorSupport.getConfigForBestBlock());
         co.rsk.bitcoinj.core.Sha256Hash calculatedWitnessCommitment = co.rsk.bitcoinj.core.Sha256Hash.twiceOf(
             witnessMerkleRoot.getReversedBytes(),
             witnessReservedValue

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -21,7 +21,6 @@ import co.rsk.federate.mock.*;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.net.NodeBlockProcessor;
 import co.rsk.peg.PegUtilsLegacy;
-import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.btcLockSender.*;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.constants.BridgeConstants;

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -9,9 +9,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.HashUtil;
 
 public final class BitcoinTestUtils {
+
+    public static final byte[]  WITNESS_COMMITMENT_HEADER = Hex.decode("aa21a9ed");
+    public static final Sha256Hash WITNESS_RESERVED_VALUE = Sha256Hash.ZERO_HASH;
+    public static final int WITNESS_COMMITMENT_LENGTH = WITNESS_COMMITMENT_HEADER.length + Sha256Hash.LENGTH;
 
     private BitcoinTestUtils() { }
 

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizerTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientStorageSynchronizerTest.java
@@ -186,13 +186,10 @@ class BtcReleaseClientStorageSynchronizerTest {
         TransactionReceipt receipt = mock(TransactionReceipt.class);
         List<LogInfo> logs = new ArrayList<>();
 
-        SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
-
         BridgeEventLoggerImpl bridgeEventLogger = new BridgeEventLoggerImpl(
             new BridgeRegTestConstants(),
             activations,
-            logs,
-            signatureCache
+            logs
         );
 
         Keccak256 value = createHash(3);
@@ -282,13 +279,10 @@ class BtcReleaseClientStorageSynchronizerTest {
         TransactionReceipt receipt = mock(TransactionReceipt.class);
         List<LogInfo> logs = new ArrayList<>();
 
-        SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
-
         BridgeEventLoggerImpl bridgeEventLogger = new BridgeEventLoggerImpl(
             new BridgeRegTestConstants(),
             activations,
-            logs,
-            signatureCache
+            logs
         );
 
         Keccak256 releaseRequestTxHash = createHash(3);


### PR DESCRIPTION
Ignore non-standard outputs when searching for the witness commitment hash

## ## Motivation and Context

Coinbase transactions may sometimes contain non-standard outputs that cause the Bridge to fail parsing them. When iterating through the outputs of a coinbase transaction in search for the witness commitment hash, non-standard outputs should be ignored and continue searching through the remaining outputs.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)

`rskj:coinbase-parsing-integration-rebased`