### PR TITLE
Ignore non-standard outputs when searching for the witness commitment hash

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -332,7 +332,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             throw new IllegalArgumentException(message);
         }
 
-        Optional<co.rsk.bitcoinj.core.Sha256Hash> expectedWitnessCommitment = BitcoinUtils.findWitnessCommitment(coinbaseTransaction);
+        Optional<co.rsk.bitcoinj.core.Sha256Hash> expectedWitnessCommitment = BitcoinUtils.findWitnessCommitment(coinbaseTransaction, federatorSupport.getConfigForBestBlock());
         co.rsk.bitcoinj.core.Sha256Hash calculatedWitnessCommitment = co.rsk.bitcoinj.core.Sha256Hash.twiceOf(
             witnessMerkleRoot.getReversedBytes(),
             witnessReservedValue

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -38,6 +38,7 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStoreException;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
@@ -60,12 +61,18 @@ class BtcToRskClientTest {
     private BtcToRskClientBuilder btcToRskClientBuilder;
     private List<BtcECKey> federationPrivateKeys;
     private NetworkParameters networkParameters;
+    private ForBlock activationsForBlock;
 
     @BeforeEach
     void setup() throws PeginInstructionsException, IOException {
         activationConfig = mock(ActivationConfig.class);
-        when(activationConfig.forBlock(anyLong())).thenReturn(mock(ActivationConfig.ForBlock.class));
         when(activationConfig.isActive(eq(ConsensusRule.RSKIP89), anyLong())).thenReturn(true);
+        when(activationConfig.isActive(eq(ConsensusRule.RSKIP460), anyLong())).thenReturn(true);
+
+        activationsForBlock = mock(ForBlock.class);
+        when(activationConfig.forBlock(anyLong())).thenReturn(activationsForBlock);
+        when(activationsForBlock.isActive(eq(ConsensusRule.RSKIP89))).thenReturn(true);
+        when(activationsForBlock.isActive(eq(ConsensusRule.RSKIP460))).thenReturn(true);
 
         bridgeRegTestConstants = new BridgeRegTestConstants();
         networkParameters = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString());
@@ -475,10 +482,11 @@ class BtcToRskClientTest {
 
         ActivationConfig mockedActivationConfig = mock(ActivationConfig.class);
         when(mockedActivationConfig.isActive(eq(ConsensusRule.RSKIP143), anyLong())).thenReturn(true);
+        when(mockedActivationConfig.isActive(eq(ConsensusRule.RSKIP460), anyLong())).thenReturn(true);
 
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
         when(federatorSupport.getFederationMember()).thenReturn(activeFederationMember);
-        when(federatorSupport.getConfigForBestBlock()).thenReturn(mock(ActivationConfig.ForBlock.class));
+        when(federatorSupport.getConfigForBestBlock()).thenReturn(activationsForBlock);
 
         BtcToRskClient client = spy(buildWithFactoryAndSetup(
             federatorSupport,

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -478,6 +478,7 @@ class BtcToRskClientTest {
 
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
         when(federatorSupport.getFederationMember()).thenReturn(activeFederationMember);
+        when(federatorSupport.getConfigForBestBlock()).thenReturn(mock(ActivationConfig.ForBlock.class));
 
         BtcToRskClient client = spy(buildWithFactoryAndSetup(
             federatorSupport,

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -21,7 +21,6 @@ import co.rsk.federate.mock.*;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.net.NodeBlockProcessor;
 import co.rsk.peg.PegUtilsLegacy;
-import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.btcLockSender.*;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.constants.BridgeConstants;

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -11,9 +11,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.HashUtil;
 
 public final class BitcoinTestUtils {
+
+    public static final byte[]  WITNESS_COMMITMENT_HEADER = Hex.decode("aa21a9ed");
+    public static final Sha256Hash WITNESS_RESERVED_VALUE = Sha256Hash.ZERO_HASH;
+    public static final int WITNESS_COMMITMENT_LENGTH = WITNESS_COMMITMENT_HEADER.length + Sha256Hash.LENGTH;
 
     private BitcoinTestUtils() { }
 


### PR DESCRIPTION
Ignore non-standard outputs when searching for the witness commitment hash

## ## Motivation and Context

Coinbase transactions may sometimes contain non-standard outputs that cause the Bridge to fail parsing them. When iterating through the outputs of a coinbase transaction in search for the witness commitment hash, non-standard outputs should be ignored and continue searching through the remaining outputs.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)

`rskj:coinbase-parsing-integration-rebased`