### PR TITLE
Remove signatures from svp spend tx before searching it while running HSM 

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -287,22 +287,22 @@ public class BtcReleaseClient {
          * </p>
          *
          * @param currentBlockNumber the current block number in the blockchain
-         * @param svpSpendTx the Keccak256 hash and the Bitcoin transaction of the svp spend transaction waiting to be signed
+         * @param svpSpendTxEntry the Keccak256 hash and the Bitcoin transaction of the svp spend transaction waiting to be signed
          * @return {@code true} if the transaction has the required number of confirmations and is ready to be signed;
          *         {@code false} otherwise
          */
-        private boolean isSVPSpendTxReadyToSign(long currentBlockNumber, Map.Entry<Keccak256, BtcTransaction> svpSpendTx) {
+        private boolean isSVPSpendTxReadyToSign(long currentBlockNumber, Map.Entry<Keccak256, BtcTransaction> svpSpendTxEntry) {
             try {
 
-                BtcTransaction btcTx = svpSpendTx.getValue();
+                BtcTransaction svpSpendTx = svpSpendTxEntry.getValue();
 
-                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx before removing signatures [{}]", btcTx.getHash());
-                BitcoinUtils.removeSignaturesFromTransactionWithP2shMultiSigInputs(btcTx);
-                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx after removing signatures [{}]", btcTx.getHash());
+                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx before removing signatures [{}]", svpSpendTx.getHash());
+                BitcoinUtils.removeSignaturesFromTransactionWithP2shMultiSigInputs(svpSpendTx);
+                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx after removing signatures [{}]", svpSpendTx.getHash());
 
                 int version = signer.getVersionForKeyId(BTC.getKeyId());
                 ReleaseCreationInformation releaseCreationInformation = releaseCreationInformationGetter.getTxInfoToSign(
-                    version, svpSpendTx.getKey(), btcTx);
+                    version, svpSpendTxEntry.getKey(), svpSpendTx);
 
                 boolean isReadyToSign = Optional.ofNullable(releaseCreationInformation)
                     .map(ReleaseCreationInformation::getPegoutCreationBlock)
@@ -312,7 +312,7 @@ public class BtcReleaseClient {
                     .isPresent();
                 
                 logger.info("[isSvpSpendTxReadyToSign] SVP spend tx readiness check for signing: tx hash [{}], Current block [{}], Ready to sign? [{}]",
-                    svpSpendTx.getKey(),
+                    svpSpendTxEntry.getKey(),
                     currentBlockNumber,
                     isReadyToSign ? "YES" : "NO");
 

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -43,7 +43,6 @@ import co.rsk.peg.federation.ErpFederation;
 import co.rsk.peg.StateForFederator;
 import co.rsk.peg.StateForProposedFederator;
 import co.rsk.peg.bitcoin.BitcoinUtils;
-
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -286,19 +286,23 @@ public class BtcReleaseClient {
          * </p>
          *
          * @param currentBlockNumber the current block number in the blockchain
-         * @param svpTxHash the Keccak256 hash of the svp spend transaction waiting to be signed
+         * @param svpSpendTx the Keccak256 hash and the Bitcoin transaction of the svp spend transaction waiting to be signed
          * @return {@code true} if the transaction has the required number of confirmations and is ready to be signed;
          *         {@code false} otherwise
          */
         private boolean isSVPSpendTxReadyToSign(long currentBlockNumber, Map.Entry<Keccak256, BtcTransaction> svpSpendTx) {
             try {
-                BtcTransaction btcTx = svpSpendTx.getValue();
-                Federation spendingFed = getSpendingFederation(btcTx);
-                removeSignaturesFromTransaction(btcTx, spendingFed);
+
+                BtcTransaction svpSpendTxWithoutSignatures = svpSpendTx.getValue();
+                Federation spendingFed = getSpendingFederation(svpSpendTxWithoutSignatures);
+
+                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx before removing signatures [{}]", svpSpendTxWithoutSignatures);
+                removeSignaturesFromTransaction(svpSpendTxWithoutSignatures, spendingFed);
+                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx after removing signatures [{}]", svpSpendTxWithoutSignatures);
 
                 int version = signer.getVersionForKeyId(BTC.getKeyId());
                 ReleaseCreationInformation releaseCreationInformation = releaseCreationInformationGetter.getTxInfoToSign(
-                    version, svpSpendTx.getKey(), btcTx);
+                    version, svpSpendTx.getKey(), svpSpendTxWithoutSignatures);
 
                 boolean isReadyToSign = Optional.ofNullable(releaseCreationInformation)
                     .map(ReleaseCreationInformation::getPegoutCreationBlock)

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -42,6 +42,8 @@ import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.federation.ErpFederation;
 import co.rsk.peg.StateForFederator;
 import co.rsk.peg.StateForProposedFederator;
+import co.rsk.peg.bitcoin.BitcoinUtils;
+
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -293,16 +295,15 @@ public class BtcReleaseClient {
         private boolean isSVPSpendTxReadyToSign(long currentBlockNumber, Map.Entry<Keccak256, BtcTransaction> svpSpendTx) {
             try {
 
-                BtcTransaction svpSpendTxWithoutSignatures = svpSpendTx.getValue();
-                Federation spendingFed = getSpendingFederation(svpSpendTxWithoutSignatures);
+                BtcTransaction btcTx = svpSpendTx.getValue();
 
-                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx before removing signatures [{}]", svpSpendTxWithoutSignatures);
-                removeSignaturesFromTransaction(svpSpendTxWithoutSignatures, spendingFed);
-                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx after removing signatures [{}]", svpSpendTxWithoutSignatures);
+                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx before removing signatures [{}]", btcTx.getHash());
+                BitcoinUtils.removeSignaturesFromTransactionWithP2shMultiSigInputs(btcTx);
+                logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx after removing signatures [{}]", btcTx.getHash());
 
                 int version = signer.getVersionForKeyId(BTC.getKeyId());
                 ReleaseCreationInformation releaseCreationInformation = releaseCreationInformationGetter.getTxInfoToSign(
-                    version, svpSpendTx.getKey(), svpSpendTxWithoutSignatures);
+                    version, svpSpendTx.getKey(), btcTx);
 
                 boolean isReadyToSign = Optional.ofNullable(releaseCreationInformation)
                     .map(ReleaseCreationInformation::getPegoutCreationBlock)

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -66,9 +66,6 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.db.BlockStore;
-import org.ethereum.db.ReceiptStore;
-import org.ethereum.db.TransactionInfo;
 import org.ethereum.facade.Ethereum;
 import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.util.RLP;
@@ -295,9 +292,13 @@ public class BtcReleaseClient {
          */
         private boolean isSVPSpendTxReadyToSign(long currentBlockNumber, Map.Entry<Keccak256, BtcTransaction> svpSpendTx) {
             try {
+                BtcTransaction btcTx = svpSpendTx.getValue();
+                Federation spendingFed = getSpendingFederation(btcTx);
+                removeSignaturesFromTransaction(btcTx, spendingFed);
+
                 int version = signer.getVersionForKeyId(BTC.getKeyId());
                 ReleaseCreationInformation releaseCreationInformation = releaseCreationInformationGetter.getTxInfoToSign(
-                    version, svpSpendTx.getKey(), svpSpendTx.getValue());
+                    version, svpSpendTx.getKey(), btcTx);
 
                 boolean isReadyToSign = Optional.ofNullable(releaseCreationInformation)
                     .map(ReleaseCreationInformation::getPegoutCreationBlock)

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -33,7 +33,7 @@ import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
-import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import co.rsk.federate.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.constants.BridgeConstants;
@@ -771,7 +771,8 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenSvpSpendTxWaitingForSignaturesIsAvailableWithSignatureFromAnotherFederationMember_shouldSendAddSignature() throws Exception {
         // Arrange
-        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        List<BtcECKey> federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
+        Federation proposedFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), federationPrivateKeys);
         FederationMember federationMember = proposedFederation.getMembers().get(0);
         Script scriptSig = proposedFederation.getP2SHScript().createEmptyInputScript(null, proposedFederation.getRedeemScript());
 
@@ -787,7 +788,7 @@ class BtcReleaseClientTest {
             BitcoinTestUtils.signTransactionInputFromP2shMultiSig(
                 svpSpendTx,
                 inputs.indexOf(input),
-                List.of(new BtcECKey())
+                List.of(federationPrivateKeys.get(0))
             );
         }
       
@@ -879,7 +880,7 @@ class BtcReleaseClientTest {
         BitcoinUtils.removeSignaturesFromTransactionWithP2shMultiSigInputs(svpSpendTx);
         assertEquals(svpSpendTxHashBeforeSigning, svpSpendTx.getHash());
         verify(releaseCreationInformationGetter).getTxInfoToSign(
-            any(),
+            anyInt(),
             eq(svpSpendCreationRskTxHash),
             eq(svpSpendTx));
 

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -771,9 +771,8 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenSvpSpendTxWaitingForSignaturesIsAvailableWithSignatureFromAnotherFederationMember_shouldSendAddSignature() throws Exception {
         // Arrange
-        List<BtcECKey> federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
-        Federation proposedFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), federationPrivateKeys);
-        FederationMember federationMember = proposedFederation.getMembers().get(0);
+        List<BtcECKey> federationKeys = TestUtils.getFederationPrivateKeys(9);
+        Federation proposedFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), federationKeys);
         Script scriptSig = proposedFederation.getP2SHScript().createEmptyInputScript(null, proposedFederation.getRedeemScript());
 
         BtcTransaction svpSpendTx = new BtcTransaction(params);
@@ -788,7 +787,7 @@ class BtcReleaseClientTest {
             BitcoinTestUtils.signTransactionInputFromP2shMultiSig(
                 svpSpendTx,
                 inputs.indexOf(input),
-                List.of(federationPrivateKeys.get(0))
+                List.of(federationKeys.get(0))
             );
         }
       
@@ -804,6 +803,7 @@ class BtcReleaseClientTest {
         }).when(ethereum).addListener(any(EthereumListener.class));
 
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
+        FederationMember federationMember = proposedFederation.getMembers().get(0);
         doReturn(federationMember).when(federatorSupport).getFederationMember();
         // return svp spend tx waiting for signatures
         doReturn(Optional.of(stateForProposedFederator)).when(federatorSupport).getStateForProposedFederator();

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
@@ -32,6 +33,8 @@ import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.crypto.Keccak256;
@@ -759,6 +762,128 @@ class BtcReleaseClientTest {
         ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
 
         // Assert
+        verify(federatorSupport).addSignature(
+            anyList(),
+            any(byte[].class)
+        );
+    }
+
+    @Test
+    void onBestBlock_whenSvpSpendTxWaitingForSignaturesIsAvailableWithSignatureFromAnotherFederationMember_shouldSendAddSignature() throws Exception {
+        // Arrange
+        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        FederationMember federationMember = proposedFederation.getMembers().get(0);
+        Script scriptSig = proposedFederation.getP2SHScript().createEmptyInputScript(null, proposedFederation.getRedeemScript());
+
+        BtcTransaction svpSpendTx = new BtcTransaction(params);
+        svpSpendTx.addInput(BitcoinTestUtils.createHash(1), 0, scriptSig);
+        svpSpendTx.addInput(BitcoinTestUtils.createHash(2), 0, scriptSig);
+        svpSpendTx.addOutput(Coin.COIN, new BtcECKey().toAddress(params));
+        Sha256Hash svpSpendTxHashBeforeSigning = svpSpendTx.getHash();
+
+        // Sign the svp spend tx
+        List<TransactionInput> inputs = svpSpendTx.getInputs();
+        for (TransactionInput input : inputs) {
+            BitcoinTestUtils.signTransactionInputFromP2shMultiSig(
+                svpSpendTx,
+                inputs.indexOf(input),
+                List.of(new BtcECKey())
+            );
+        }
+      
+        Keccak256 svpSpendCreationRskTxHash = createHash(0);
+        Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
+        StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(svpSpendTxWFS);
+
+        Ethereum ethereum = mock(Ethereum.class);
+        AtomicReference<EthereumListener> ethereumListener = new AtomicReference<>();
+        doAnswer((InvocationOnMock invocation) -> {
+            ethereumListener.set((EthereumListener) invocation.getArguments()[0]);
+            return null;
+        }).when(ethereum).addListener(any(EthereumListener.class));
+
+        FederatorSupport federatorSupport = mock(FederatorSupport.class);
+        doReturn(federationMember).when(federatorSupport).getFederationMember();
+        // return svp spend tx waiting for signatures
+        doReturn(Optional.of(stateForProposedFederator)).when(federatorSupport).getStateForProposedFederator();
+        // returns zero pegouts waiting for signatures
+        doReturn(mock(StateForFederator.class)).when(federatorSupport).getStateForFederator();
+
+        ECKey ecKey = new ECKey();
+        ECPublicKey signerPublicKey = new ECPublicKey(federationMember.getBtcPublicKey().getPubKey());
+
+        ECDSASigner signer = mock(ECDSASigner.class);
+        doReturn(signerPublicKey).when(signer).getPublicKey(BTC.getKeyId());
+        doReturn(1).when(signer).getVersionForKeyId(ArgumentMatchers.any(KeyId.class));
+        doReturn(ecKey.doSign(new byte[]{})).when(signer).sign(any(KeyId.class), any(SignerMessage.class));
+
+        PowpegNodeSystemProperties powpegNodeSystemProperties = mock(PowpegNodeSystemProperties.class);
+        doReturn(Constants.mainnet()).when(powpegNodeSystemProperties).getNetworkConstants();
+        doReturn(true).when(powpegNodeSystemProperties).isPegoutEnabled();
+        when(powpegNodeSystemProperties.getPegoutSignedCacheTtl())
+            .thenReturn(PEGOUT_SIGNED_CACHE_TTL);
+
+        SignerMessageBuilderFactory signerMessageBuilderFactory = new SignerMessageBuilderFactory(
+            mock(ReceiptStore.class)
+        );
+
+        Keccak256 blockHash = createHash(2);
+        Long blockNumber = 0L;
+        Block block = mock(Block.class);
+        TransactionReceipt txReceipt = mock(TransactionReceipt.class);
+        TransactionInfo txInfo = mock(TransactionInfo.class);
+        when(block.getHash()).thenReturn(blockHash);
+        when(block.getNumber()).thenReturn(blockNumber);
+        when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
+        when(txInfo.getReceipt()).thenReturn(txReceipt);
+        when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        when(receiptStore.getInMainChain(svpSpendCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
+
+        ReleaseCreationInformationGetter releaseCreationInformationGetter =
+            spy(new ReleaseCreationInformationGetter(
+                receiptStore, blockStore
+            ));
+
+        BtcReleaseClientStorageSynchronizer storageSynchronizer =
+            mock(BtcReleaseClientStorageSynchronizer.class);
+        when(storageSynchronizer.isSynced()).thenReturn(true);
+
+        BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
+            ethereum,
+            federatorSupport,
+            powpegNodeSystemProperties,
+            mock(NodeBlockProcessor.class)
+        );
+
+        ActivationConfig activationConfig = mock(ActivationConfig.class);
+        when(activationConfig.isActive(ConsensusRule.RSKIP419, bestBlock.getNumber())).thenReturn(true);
+
+        btcReleaseClient.setup(
+            signer,
+            activationConfig,
+            signerMessageBuilderFactory,
+            releaseCreationInformationGetter,
+            mock(ReleaseRequirementsEnforcer.class),
+            mock(BtcReleaseClientStorageAccessor.class),
+            storageSynchronizer
+        );
+
+        btcReleaseClient.start(proposedFederation);
+
+        // Act
+        ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
+
+        // Assert
+        
+        // We should have searched by the expected svp spend tx hash
+        BitcoinUtils.removeSignaturesFromTransactionWithP2shMultiSigInputs(svpSpendTx);
+        assertEquals(svpSpendTxHashBeforeSigning, svpSpendTx.getHash());
+        verify(releaseCreationInformationGetter).getTxInfoToSign(
+            any(),
+            eq(svpSpendCreationRskTxHash),
+            eq(svpSpendTx));
+
+        // We should have added a signature for the svp spend tx
         verify(federatorSupport).addSignature(
             anyList(),
             any(byte[].class)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When running with an HSM, the node is unable to find the related event since it is taking account the hash of the transaction with the singnatures on it. It must remove the signatures from the bitcoin transaction before comparing with the tx hash of the event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

`rskj:fix/remove-sigs-svp-spend`
`fed:fix/remove-sigs-svp-spend`