### PR TITLE
Update testnet difficulty cap to 3,000,000,000

### DIFF
--- a/src/main/java/co/rsk/federate/signing/hsm/config/NetworkDifficultyCap.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/config/NetworkDifficultyCap.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 
 public enum NetworkDifficultyCap {
   MAINNET(new BigInteger("7000000000000000000000")),
-  TESTNET(BigInteger.valueOf(1000000000000000L)),
+  TESTNET(BigInteger.valueOf(3000000000L)),
   REGTEST(BigInteger.valueOf(20L));
 
   private final BigInteger difficultyCap;


### PR DESCRIPTION
This is the new difficulty cap value since HSM v5.4.1, see https://github.com/rsksmart/rsk-powhsm/pull/300

`rskj:LOVELL-7.0.0-rc`