### PR TITLE
Fix block selection. Remove HSM version 3

### DIFF
--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -164,7 +164,9 @@ public class FedNodeRunner implements NodeRunner {
             hsmClientProtocolFactory.buildHSMClientProtocolFromConfig(powHsmConfig);
 
         int version = protocol.getVersion();
-        evaluateHsmVersion(version);
+        if (!HSMVersion.isValidHSMVersion(version)) {
+            throw new HSMUnsupportedVersionException("Unsupported HSM version " + version);
+        }
 
         logger.debug("[run] Using HSM version {}", version);
 
@@ -177,15 +179,6 @@ public class FedNodeRunner implements NodeRunner {
             protocol, powHsmConfig);
         hsmBookkeepingService = buildBookKeepingService(
             hsmBookkeepingClient, powHsmConfig);
-    }
-
-    private static void evaluateHsmVersion(int version) throws HSMUnsupportedVersionException {
-        try {
-            HSMVersion.valueOf("V" + version);
-        } catch (IllegalArgumentException e) {
-            logger.debug("[run] Unsupported HSM version  {}", version);
-            throw new HSMUnsupportedVersionException("Unsupported HSM version " + version);
-        }
     }
 
     private void configureFederatorSupport() throws SignerException {

--- a/src/main/java/co/rsk/federate/signing/ECDSAHSMSigner.java
+++ b/src/main/java/co/rsk/federate/signing/ECDSAHSMSigner.java
@@ -107,7 +107,7 @@ public class ECDSAHSMSigner implements ECDSASigner {
 
     @Override
     public int getVersionForKeyId(KeyId keyId) throws SignerException {
-        int version = 0;
+        int version;
         if (!canSignWith(keyId)) {
             throw new SignerException(String.format("Can't find version for this key for the requested signing key: %s", keyId));
         }

--- a/src/main/java/co/rsk/federate/signing/ECDSAHSMSigner.java
+++ b/src/main/java/co/rsk/federate/signing/ECDSAHSMSigner.java
@@ -107,10 +107,11 @@ public class ECDSAHSMSigner implements ECDSASigner {
 
     @Override
     public int getVersionForKeyId(KeyId keyId) throws SignerException {
-        int version;
         if (!canSignWith(keyId)) {
             throw new SignerException(String.format("Can't find version for this key for the requested signing key: %s", keyId));
         }
+
+        int version;
         try {
             ensureHsmClient();
             version = client.getVersion();

--- a/src/main/java/co/rsk/federate/signing/hsm/HSMVersion.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/HSMVersion.java
@@ -6,7 +6,6 @@ import java.util.List;
 public enum HSMVersion {
     V1(1),
     V2(2),
-    V3(3),
     V4(4),
     V5(5),
     ;
@@ -22,14 +21,10 @@ public enum HSMVersion {
     }
 
     public static List<HSMVersion> getPowHSMVersions() {
-        return Arrays.asList(V2, V3, V4, V5);
+        return Arrays.asList(V2, V4, V5);
     }
 
     public static boolean isPowHSM(int version) {
         return getPowHSMVersions().stream().anyMatch(hsmVersion -> hsmVersion.number == version);
-    }
-
-    public static boolean isPowHSM(HSMVersion version){
-        return getPowHSMVersions().contains(version);
     }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/HSMVersion.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/HSMVersion.java
@@ -27,4 +27,8 @@ public enum HSMVersion {
     public static boolean isPowHSM(int version) {
         return getPowHSMVersions().stream().anyMatch(hsmVersion -> hsmVersion.number == version);
     }
+
+    public static boolean isValidHSMVersion(int version) {
+        return Arrays.stream(values()).anyMatch(hsmVersion -> hsmVersion.number == version);
+    }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProvider.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProvider.java
@@ -95,7 +95,7 @@ public class ConfirmedBlocksProvider {
     private BigInteger getBlockDifficultyToConsider(Block block) {
         BigInteger blockDifficulty = block.getDifficulty().asBigInteger();
         BigInteger difficultyToConsider = blockDifficulty;
-        if (hsmVersion >= HSMVersion.V3.getNumber()) {
+        if (hsmVersion >= HSMVersion.V4.getNumber()) {
             BigInteger unclesDifficulty = block.getUncleList().stream()
                 .map(uncle -> uncle.getDifficulty().asBigInteger())
                 .reduce(BigInteger.ZERO, BigInteger::add);

--- a/src/main/java/co/rsk/federate/signing/hsm/advanceblockchain/HsmBookkeepingClientImpl.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/advanceblockchain/HsmBookkeepingClientImpl.java
@@ -167,7 +167,7 @@ public class HsmBookkeepingClientImpl implements HSMBookkeepingClient {
             ObjectNode payload = this.hsmClientProtocol.buildCommand(ADVANCE_BLOCKCHAIN.getCommand(), getVersion());
             addBlocksToPayload(payload, blockHeaderChunk);
 
-            if (getVersion() >= HSMVersion.V3.getNumber()) {
+            if (getVersion() >= HSMVersion.V4.getNumber()) {
                 List<String[]> brothers = getBrothers(blockHeaderChunk, message);
                 addBrothersToPayload(payload, brothers);
             }

--- a/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.when;
 
 import co.rsk.NodeRunner;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.federate.signing.config.SignerType;
 import co.rsk.federate.signing.hsm.HSMUnsupportedVersionException;
 import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.peg.constants.BridgeConstants;
@@ -524,7 +523,7 @@ class FedNodeRunnerTest {
                 new PowHSMBlockchainParameters(
                     createHash(1).toHexString(),
                     new BigInteger("4405500"),
-                    NetworkParameters.ID_UNITTESTNET.toString()));
+                    NetworkParameters.ID_UNITTESTNET));
         }
 
         return configBuilder.build(PowPegNodeKeyId.BTC);

--- a/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
@@ -193,7 +193,7 @@ class FedNodeRunnerTest {
     }
 
     @Test
-    void test_with_hsm_v3_config_shouldFail() throws Exception {
+    void hsm_v3_config_shouldFail() throws Exception {
         SignerConfigBuilder configBuilder = SignerConfigBuilder.builder()
             .withHsmSigner("m/44'/0'/0'/0/0");
         SignerConfig btcSignerConfig = configBuilder.build(BTC);

--- a/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
+++ b/src/test/java/co/rsk/federate/FedNodeRunnerTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.when;
 
 import co.rsk.NodeRunner;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.federate.signing.config.SignerType;
+import co.rsk.federate.signing.hsm.HSMUnsupportedVersionException;
 import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.federate.btcreleaseclient.BtcReleaseClient;
@@ -50,6 +52,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
 import java.util.List;
 import org.ethereum.config.Constants;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -82,7 +85,7 @@ class FedNodeRunnerTest {
         when(constants.getBridgeConstants()).thenReturn(bridgeConstants);
         when(bridgeConstants.getBtcParamsString()).thenReturn(NetworkParameters.ID_REGTEST);
 
-        int hsmVersion = HSMVersion.V3.getNumber();
+        int hsmVersion = HSMVersion.V4.getNumber();
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(hsmVersion);
         HSMClientProtocolFactory hsmClientProtocolFactory = mock(HSMClientProtocolFactory.class);
@@ -187,6 +190,36 @@ class FedNodeRunnerTest {
 
         HSMBookkeepingService bookkeepingService = TestUtils.getInternalState(fedNodeRunner, "hsmBookkeepingService");
         assertNull(bookkeepingService);
+    }
+
+    @Test
+    void test_with_hsm_v3_config_shouldFail() throws Exception {
+        SignerConfigBuilder configBuilder = SignerConfigBuilder.builder()
+            .withHsmSigner("m/44'/0'/0'/0/0");
+        SignerConfig btcSignerConfig = configBuilder.build(BTC);
+
+        when(fedNodeSystemProperties.signerConfig(BTC.getId())).thenReturn(btcSignerConfig);
+        HSMClientProtocol protocol = mock(HSMClientProtocol.class);
+        when(protocol.getVersion()).thenReturn(3);
+        HSMClientProtocolFactory hsmClientProtocolFactory = mock(HSMClientProtocolFactory.class);
+        when(hsmClientProtocolFactory.buildHSMClientProtocolFromConfig(any())).thenReturn(protocol);
+
+        fedNodeRunner = new FedNodeRunner(
+            mock(BtcToRskClient.class),
+            mock(BtcToRskClient.class),
+            mock(BtcReleaseClient.class),
+            mock(FederationWatcher.class),
+            mock(FederatorSupport.class),
+            mock(FederateLogger.class),
+            mock(RskLogMonitor.class),
+            mock(NodeRunner.class),
+            fedNodeSystemProperties,
+            hsmClientProtocolFactory,
+            mock(HSMBookKeepingClientProvider.class),
+            mock(FedNodeContext.class)
+        );
+
+        Assertions.assertThrows(HSMUnsupportedVersionException.class, fedNodeRunner::run, "Unsupported HSM version 3");
     }
 
     @Test
@@ -486,7 +519,7 @@ class FedNodeRunnerTest {
                 new BigInteger("4405500"), 500000L, 1000, 100, true);
         }
 
-        if (version.getNumber() >= 3) {
+        if (version.getNumber() >= 4) {
             when(hsmBookkeepingClient.getBlockchainParameters()).thenReturn(
                 new PowHSMBlockchainParameters(
                     createHash(1).toHexString(),

--- a/src/test/java/co/rsk/federate/signing/ECDSAHSMSignerTest.java
+++ b/src/test/java/co/rsk/federate/signing/ECDSAHSMSignerTest.java
@@ -257,18 +257,11 @@ class ECDSAHSMSignerTest {
     @Test
     void getVersionForKeyId_SignerException() throws HSMClientException {
         KeyId key = new KeyId("keyAB");
-        int version = HSMVersion.V3.getNumber();
+
         when(providerMock.getSigningClient()).thenReturn(clientMock);
-        when(clientMock.getVersion()).thenReturn( version);
 
-        try {
-            signer.getVersionForKeyId(key);
-            fail();
-        } catch (SignerException e) {
-            assertEquals(e.getMessage(),String.format("Can't find version for this key for the requested signing key: %s", key));
-        }
-
-        verify(clientMock,times(0)).getVersion();
+        assertThrows(SignerException.class, () -> signer.getVersionForKeyId(key), "No mapped HSM key id found");
+        verify(clientMock,never()).getVersion();
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
@@ -282,8 +282,57 @@ class ConfirmedBlocksProviderTest {
     }
 
     @Test
-    void getBlockDifficultyToConsider_forBlockWithUncles_capsEachDifficulty() {
-        BigInteger difficultyCapMainnet = MAINNET.getDifficultyCap();
+    void getBlockDifficultyToConsider_forHSMVersionLessThan4_doesNotConsiderUnclesAndCapDifficulty() {
+        // arrange
+        Block block = buildBlockWithUncles();
+
+        // build blocks provider for hsm version 2
+        ConfirmedBlocksProvider confirmedBlocksProvider = new ConfirmedBlocksProvider(
+            BigInteger.valueOf(160),
+            100,
+            mock(BlockStore.class),
+            MAINNET.getDifficultyCap(),
+            HSMVersion.V2.getNumber()
+        );
+
+        // act
+        BigInteger consideredDifficulty = confirmedBlocksProvider.getBlockDifficultyToConsider(block);
+
+        // assert
+        // HSM version less than 4 does not consider brothers nor cap difficulty
+        // = 7000000000000000000001 difficulty from block 4
+        BigInteger expectedConsideredDifficulty = new BigInteger("7000000000000000000001");
+        assertEquals(expectedConsideredDifficulty, consideredDifficulty);
+    }
+
+    @Test
+    void getBlockDifficultyToConsider_forHSMVersionMoreThan4_considersUnclesAndCapDifficulty() {
+        // arrange
+        Block block = buildBlockWithUncles();
+
+        // build blocks provider for hsm version 4
+        ConfirmedBlocksProvider confirmedBlocksProvider = new ConfirmedBlocksProvider(
+            BigInteger.valueOf(160),
+            100,
+            mock(BlockStore.class),
+            MAINNET.getDifficultyCap(),
+            HSMVersion.V4.getNumber()
+        );
+
+        // act
+        BigInteger consideredDifficulty = confirmedBlocksProvider.getBlockDifficultyToConsider(block);
+
+        // assert
+        // HSM 4 considers brothers difficulty
+        // 7000000000000000000001 difficulty round to 7000000000000000000000 from block 4
+        // + 1000000000000000000000 difficulty from block 2 (uncle)
+        // + 8000000000000000000000 difficulty round to 7000000000000000000000 from block 3 (uncle)
+        // = 15000000000000000000000 considered difficulty
+        BigInteger expectedConsideredDifficulty = new BigInteger("15000000000000000000000");
+        assertEquals(expectedConsideredDifficulty, consideredDifficulty);
+    }
+
+    private Block buildBlockWithUncles() {
         // Block 1 - Brothers: 2, 3
         // Block 4 - Parent: 1, Uncles: 2, 3
 
@@ -319,27 +368,6 @@ class ConfirmedBlocksProviderTest {
             .build();
         // build block 4 with block 2 and block 3 as uncles
         List<BlockHeader> block4Uncles = Arrays.asList(block2Header, block3Header);
-        Block block4 = new Block(block4Header, Collections.emptyList(), block4Uncles, true, true);
-
-        // build blocks provider
-        ConfirmedBlocksProvider confirmedBlocksProvider = new ConfirmedBlocksProvider(
-            BigInteger.valueOf(160),
-            100,
-            mock(BlockStore.class),
-            difficultyCapMainnet,
-            HSMVersion.V4.getNumber()
-        );
-
-        // act
-        BigInteger consideredDifficulty = confirmedBlocksProvider.getBlockDifficultyToConsider(block4);
-
-        // assert
-        // HSM 4 considers brothers difficulty
-        // 7000000000000000000001 difficulty round to 7000000000000000000000 from block 4
-        // + 1000000000000000000000 difficulty from block 2 (uncle)
-        // + 8000000000000000000000 difficulty round to 7000000000000000000000 from block 3 (uncle)
-        // = 15000000000000000000000 considered difficulty
-        BigInteger expectedConsideredDifficulty = new BigInteger("15000000000000000000000");
-        assertEquals(expectedConsideredDifficulty, consideredDifficulty);
+        return new Block(block4Header, Collections.emptyList(), block4Uncles, true, true);
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
@@ -121,7 +121,7 @@ class ConfirmedBlocksProviderTest {
     }
 
     @Test
-    void getConfirmedBlocksHSMVersion3AboveDifficultyCap() {
+    void getConfirmedBlocksHSMVersion4AboveDifficultyCap() {
         Keccak256 startingPoint = TestUtils.createHash(1);
         BlockStore mockBlockStore = mock(BlockStore.class);
         Block startingBlock = TestUtils.mockBlock(10, startingPoint);
@@ -150,7 +150,7 @@ class ConfirmedBlocksProviderTest {
     }
 
     @Test
-    void getConfirmedBlocksHSMVersion3BelowDifficultyCap() {
+    void getConfirmedBlocksHSMVersion4BelowDifficultyCap() {
         Keccak256 startingPoint = TestUtils.createHash(1);
         BlockStore mockBlockStore = mock(BlockStore.class);
         Block startingBlock = TestUtils.mockBlock(10, startingPoint);

--- a/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/ConfirmedBlocksProviderTest.java
@@ -1,5 +1,6 @@
 package co.rsk.federate.signing.hsm.advanceblockchain;
 
+import static co.rsk.federate.signing.hsm.config.NetworkDifficultyCap.MAINNET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,7 @@ import co.rsk.federate.signing.utils.TestUtils;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
@@ -277,5 +279,67 @@ class ConfirmedBlocksProviderTest {
         // HSM 3 considers brothers difficulty
         // Assert 1 element in confirmed and 7 in potential list
         assertEquals(8, confirmedBlocks.size());
+    }
+
+    @Test
+    void getBlockDifficultyToConsider_forBlockWithUncles_capsEachDifficulty() {
+        BigInteger difficultyCapMainnet = MAINNET.getDifficultyCap();
+        // Block 1 - Brothers: 2, 3
+        // Block 4 - Parent: 1, Uncles: 2, 3
+
+        // block 1
+        BlockHeader block1Header = blockHeaderBuilder
+            .setNumber(1)
+            .setParentHashFromKeccak256(TestUtils.createHash(0))
+            .build();
+        Keccak256 block1ParentHash = block1Header.getParentHash();
+
+        // block 2
+        BigInteger difficultyBelowCap = new BigInteger("1000000000000000000000");
+        BlockHeader block2Header = blockHeaderBuilder
+            .setNumber(2)
+            .setParentHashFromKeccak256(block1ParentHash)
+            .setDifficulty(new BlockDifficulty(difficultyBelowCap))
+            .build();
+
+        // block 3
+        BigInteger difficultyAboveCap = new BigInteger("8000000000000000000000");
+        BlockHeader block3Header = blockHeaderBuilder
+            .setNumber(3)
+            .setParentHashFromKeccak256(block1ParentHash)
+            .setDifficulty(new BlockDifficulty(difficultyAboveCap))
+            .build();
+
+        // block 4
+        BigInteger difficultyRightAboveCap = new BigInteger("7000000000000000000001");
+        BlockHeader block4Header = blockHeaderBuilder
+            .setNumber(4)
+            .setParentHashFromKeccak256(block1Header.getHash())
+            .setDifficulty(new BlockDifficulty(difficultyRightAboveCap))
+            .build();
+        // build block 4 with block 2 and block 3 as uncles
+        List<BlockHeader> block4Uncles = Arrays.asList(block2Header, block3Header);
+        Block block4 = new Block(block4Header, Collections.emptyList(), block4Uncles, true, true);
+
+        // build blocks provider
+        ConfirmedBlocksProvider confirmedBlocksProvider = new ConfirmedBlocksProvider(
+            BigInteger.valueOf(160),
+            100,
+            mock(BlockStore.class),
+            difficultyCapMainnet,
+            HSMVersion.V4.getNumber()
+        );
+
+        // act
+        BigInteger consideredDifficulty = confirmedBlocksProvider.getBlockDifficultyToConsider(block4);
+
+        // assert
+        // HSM 4 considers brothers difficulty
+        // 7000000000000000000001 difficulty round to 7000000000000000000000 from block 4
+        // + 1000000000000000000000 difficulty from block 2 (uncle)
+        // + 8000000000000000000000 difficulty round to 7000000000000000000000 from block 3 (uncle)
+        // = 15000000000000000000000 considered difficulty
+        BigInteger expectedConsideredDifficulty = new BigInteger("15000000000000000000000");
+        assertEquals(expectedConsideredDifficulty, consideredDifficulty);
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/HSMBookKeepingClientProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/advanceblockchain/HSMBookKeepingClientProviderTest.java
@@ -38,7 +38,6 @@ class HSMBookKeepingClientProviderTest {
     @Test
     void test_getHSMBookkeepingClient() throws HSMClientException{
         getHSMBookkeepingClient(2);
-        getHSMBookkeepingClient(3);
         getHSMBookkeepingClient(4);
     }
 
@@ -51,7 +50,7 @@ class HSMBookKeepingClientProviderTest {
 
     @Test
     void getHSMBookkeepingClient_unknown_version() throws HSMClientException {
-        when(hsmClientProtocol.getVersion()).thenReturn(-5);
+        when(hsmClientProtocol.getVersion()).thenReturn(3);
 
         assertThrows(HSMUnsupportedVersionException.class, () ->
             hsmBookKeepingClientProvider.getHSMBookKeepingClient(hsmClientProtocol)

--- a/src/test/java/co/rsk/federate/signing/hsm/client/HSMSigningClientProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/HSMSigningClientProviderTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import co.rsk.federate.signing.PowPegNodeKeyId;
 import co.rsk.federate.signing.hsm.HSMClientException;
 import co.rsk.federate.signing.hsm.HSMUnsupportedTypeException;
 import co.rsk.federate.signing.hsm.HSMUnsupportedVersionException;
@@ -31,8 +32,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class HSMSigningClientProviderTest {
 
@@ -49,40 +50,40 @@ class HSMSigningClientProviderTest {
 
     private static Stream<Arguments> keyIdProvider() {
         return Stream.of(
-            Arguments.of("BTC", PowHSMSigningClientBtc.class),
-            Arguments.of("RSK", PowHSMSigningClientRskMst.class),
-            Arguments.of("MST", PowHSMSigningClientRskMst.class)
+            Arguments.of(PowPegNodeKeyId.BTC, PowHSMSigningClientBtc.class),
+            Arguments.of(PowPegNodeKeyId.RSK, PowHSMSigningClientRskMst.class),
+            Arguments.of(PowPegNodeKeyId.MST, PowHSMSigningClientRskMst.class)
         );
     }
 
     @ParameterizedTest
     @MethodSource("keyIdProvider")
-    void getClientV2(String keyId, Class<PowHSMSigningClient> expectedHsmClientType) throws Exception {
+    void getClientV2(PowPegNodeKeyId keyId, Class<PowHSMSigningClient> expectedHsmClientType) throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
-        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId);
+        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId.getId());
         when(protocol.getVersion()).thenReturn(2);
         HSMSigningClient client = clientProvider.getSigningClient();
         assertTrue(expectedHsmClientType.isInstance(client));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"BTC", "RSK", "MST"})
-    void getSigningClient_whenProtocolVersion3_shouldFail(String keyId) throws Exception {
+    @EnumSource(PowPegNodeKeyId.class)
+    void getSigningClient_whenProtocolVersion3_shouldFail(PowPegNodeKeyId keyId) throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 
-        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId);
+        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId.getId());
         Assertions.assertThrows(HSMUnsupportedVersionException.class,
             clientProvider::getSigningClient, "Unsupported HSM version 3");
     }
 
     @ParameterizedTest
     @MethodSource("keyIdProvider")
-    void getClientV4(String keyId, Class<?> expectedHsmClientType) throws Exception {
+    void getClientV4(PowPegNodeKeyId keyId, Class<?> expectedHsmClientType) throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(4);
 
-        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId);
+        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId.getId());
         HSMSigningClient client = clientProvider.getSigningClient();
 
         assertTrue(expectedHsmClientType.isInstance(client));
@@ -90,11 +91,11 @@ class HSMSigningClientProviderTest {
 
     @ParameterizedTest
     @MethodSource("keyIdProvider")
-    void getClientV5(String keyId, Class<?> expectedHsmClientType) throws Exception {
+    void getClientV5(PowPegNodeKeyId keyId, Class<?> expectedHsmClientType) throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(5);
 
-        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId);
+        HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, keyId.getId());
         HSMSigningClient client = clientProvider.getSigningClient();
 
         assertTrue(expectedHsmClientType.isInstance(client));

--- a/src/test/java/co/rsk/federate/signing/hsm/client/HSMSigningClientProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/HSMSigningClientProviderTest.java
@@ -75,7 +75,7 @@ class HSMSigningClientProviderTest {
     }
 
     @Test
-    void getClientV3BTC_shouldFail() throws Exception {
+    void getSigningClient_whenBtcAndProtocolVersion3_shouldFail() throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 
@@ -85,7 +85,7 @@ class HSMSigningClientProviderTest {
     }
 
     @Test
-    void getClientV3RSK_shouldFail() throws Exception {
+    void getSigningClient_whenRskAndProtocolVersion3_shouldFail() throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 
@@ -95,7 +95,7 @@ class HSMSigningClientProviderTest {
     }
 
     @Test
-    void getClientV3MST_shouldFail() throws Exception {
+    void getSigningClient_whenMstAndProtocolVersion3_shouldFail() throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 

--- a/src/test/java/co/rsk/federate/signing/hsm/client/HSMSigningClientProviderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/HSMSigningClientProviderTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import co.rsk.federate.signing.hsm.HSMClientException;
 import co.rsk.federate.signing.hsm.HSMUnsupportedTypeException;
 import co.rsk.federate.signing.hsm.HSMUnsupportedVersionException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class HSMSigningClientProviderTest {
@@ -74,36 +75,33 @@ class HSMSigningClientProviderTest {
     }
 
     @Test
-    void getClientV3BTC() throws Exception {
+    void getClientV3BTC_shouldFail() throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 
         HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, "BTC");
-        HSMSigningClient client = clientProvider.getSigningClient();
-
-        assertTrue(client instanceof PowHSMSigningClientBtc);
+        Assertions.assertThrows(HSMUnsupportedVersionException.class,
+            clientProvider::getSigningClient, "Unsupported HSM version 3");
     }
 
     @Test
-    void getClientV3RSK() throws Exception {
+    void getClientV3RSK_shouldFail() throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 
         HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, "RSK");
-        HSMSigningClient client = clientProvider.getSigningClient();
-
-        assertTrue(client instanceof PowHSMSigningClientRskMst);
+        Assertions.assertThrows(HSMUnsupportedVersionException.class,
+            clientProvider::getSigningClient, "Unsupported HSM version 3");
     }
 
     @Test
-    void getClientV3MST() throws Exception {
+    void getClientV3MST_shouldFail() throws Exception {
         HSMClientProtocol protocol = mock(HSMClientProtocol.class);
         when(protocol.getVersion()).thenReturn(3);
 
         HSMSigningClientProvider clientProvider = new HSMSigningClientProvider(protocol, "MST");
-        HSMSigningClient client = clientProvider.getSigningClient();
-
-        assertTrue(client instanceof PowHSMSigningClientRskMst);
+        Assertions.assertThrows(HSMUnsupportedVersionException.class,
+            clientProvider::getSigningClient, "Unsupported HSM version 3");
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -96,8 +97,8 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {2, 4, 5})
-    void createGetTxInfoToSign_returnOK(int versionNumber)
+    @EnumSource(HSMVersion.class)
+    void createGetTxInfoToSign_returnOK(HSMVersion hsmVersion)
         throws HSMReleaseCreationInformationException {
         List<LogInfo> logs = new ArrayList<>();
 
@@ -119,7 +120,7 @@ class ReleaseCreationInformationGetterTest {
         );
 
         createGetTxInfoToSign_returnOK(pegoutCreationInformation, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx, pegoutCreationBlock, pegoutCreationRskTxReceipt, versionNumber);
+            pegoutBtcTx, pegoutCreationBlock, pegoutCreationRskTxReceipt, hsmVersion.getNumber());
     }
 
     private void createGetTxInfoToSign_returnOK(

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -96,7 +96,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {2, 3, 4})
+    @ValueSource(ints = {2, 4, 5})
     void createGetTxInfoToSign_returnOK(int versionNumber)
         throws HSMReleaseCreationInformationException {
         List<LogInfo> logs = new ArrayList<>();

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
@@ -17,6 +17,8 @@ import org.ethereum.core.TransactionReceipt;
 import org.ethereum.db.ReceiptStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class SignerMessageBuilderFactoryTest {
 
@@ -27,10 +29,11 @@ class SignerMessageBuilderFactoryTest {
         factory = new SignerMessageBuilderFactory(mock(ReceiptStore.class));
     }
 
-    @Test
-    void buildWithWrongVersion() {
+    @ParameterizedTest()
+    @ValueSource(ints = {-4, -3, -2, -1, 0, 3})
+    void buildWithWrongVersion(int wrongVersion) {
         assertThrows(HSMUnsupportedVersionException.class, () -> factory.buildFromConfig(
-            3,
+            wrongVersion,
             mock(ReleaseCreationInformation.class)
         ));
 

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
@@ -30,7 +30,7 @@ class SignerMessageBuilderFactoryTest {
     @Test
     void buildWithWrongVersion() {
         assertThrows(HSMUnsupportedVersionException.class, () -> factory.buildFromConfig(
-            -5,
+            3,
             mock(ReleaseCreationInformation.class)
         ));
 
@@ -48,11 +48,6 @@ class SignerMessageBuilderFactoryTest {
     @Test
     void buildFromConfig_hsm_2_ok() throws HSMClientException {
         test_buildFromConfig_hsm(2);
-    }
-
-    @Test
-    void buildFromConfig_hsm_3_ok() throws HSMClientException {
-        test_buildFromConfig_hsm(3);
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
@@ -23,7 +23,7 @@ class SignerMessageBuilderFactoryTest {
     private SignerMessageBuilderFactory factory;
 
     @BeforeEach
-    public void createFactory() {
+    void createFactory() {
         factory = new SignerMessageBuilderFactory(mock(ReceiptStore.class));
     }
 

--- a/src/test/java/co/rsk/federate/signing/hsm/requirements/ReleaseRequirementsEnforcerTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/requirements/ReleaseRequirementsEnforcerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.federate.signing.hsm.message.ReleaseCreationInformation;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,11 +41,6 @@ class ReleaseRequirementsEnforcerTest {
     }
 
     @Test
-    void enforce_version_three_ok() throws Exception {
-        test_enforce_version(ancestorBlockUpdater, enforcer, HSMVersion.V3);
-    }
-
-    @Test
     void enforce_version_four_ok() throws Exception {
         test_enforce_version(ancestorBlockUpdater, enforcer, HSMVersion.V4);
     }
@@ -53,6 +49,13 @@ class ReleaseRequirementsEnforcerTest {
         enforcer.enforce(version.getNumber(), mock(ReleaseCreationInformation.class));
 
         verify(ancestorBlockUpdater, times(1)).ensureAncestorBlockInPosition(any());
+    }
+
+    @Test
+    void enforce_version_three_fail() throws Exception {
+        Assertions.assertThrows(ReleaseRequirementsEnforcerException.class, () -> {
+            enforcer.enforce(3, mock(ReleaseCreationInformation.class));
+        }, "Unsupported version 3");
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/signing/hsm/requirements/ReleaseRequirementsEnforcerTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/requirements/ReleaseRequirementsEnforcerTest.java
@@ -17,32 +17,28 @@ import org.junit.jupiter.api.Test;
 class ReleaseRequirementsEnforcerTest {
 
     private AncestorBlockUpdater ancestorBlockUpdater;
-    private ReleaseRequirementsEnforcer enforcer;
+    private ReleaseRequirementsEnforcer releaseRequirementsEnforcer;
 
     @BeforeEach
     void setup() {
         ancestorBlockUpdater = mock(AncestorBlockUpdater.class);
-        enforcer = new ReleaseRequirementsEnforcer(ancestorBlockUpdater);
+        releaseRequirementsEnforcer = new ReleaseRequirementsEnforcer(ancestorBlockUpdater);
     }
 
     @Test
     void enforce_does_nothing_if_version_one() throws Exception {
-        AncestorBlockUpdater ancestorBlockUpdater = mock(AncestorBlockUpdater.class);
-        ReleaseRequirementsEnforcer enforcer = new ReleaseRequirementsEnforcer(ancestorBlockUpdater);
-
-        enforcer.enforce(1, mock(ReleaseCreationInformation.class));
-
+        releaseRequirementsEnforcer.enforce(1, mock(ReleaseCreationInformation.class));
         verify(ancestorBlockUpdater, never()).ensureAncestorBlockInPosition(any());
     }
 
     @Test
     void enforce_version_two_ok() throws Exception {
-        test_enforce_version(ancestorBlockUpdater, enforcer, HSMVersion.V2);
+        test_enforce_version(ancestorBlockUpdater, releaseRequirementsEnforcer, HSMVersion.V2);
     }
 
     @Test
     void enforce_version_four_ok() throws Exception {
-        test_enforce_version(ancestorBlockUpdater, enforcer, HSMVersion.V4);
+        test_enforce_version(ancestorBlockUpdater, releaseRequirementsEnforcer, HSMVersion.V4);
     }
 
     void test_enforce_version(AncestorBlockUpdater ancestorBlockUpdater, ReleaseRequirementsEnforcer enforcer, HSMVersion version) throws Exception {
@@ -52,25 +48,23 @@ class ReleaseRequirementsEnforcerTest {
     }
 
     @Test
-    void enforce_version_three_fail() throws Exception {
+    void enforce_version_three_fail() {
         Assertions.assertThrows(ReleaseRequirementsEnforcerException.class, () -> {
-            enforcer.enforce(3, mock(ReleaseCreationInformation.class));
+            releaseRequirementsEnforcer.enforce(3, mock(ReleaseCreationInformation.class));
         }, "Unsupported version 3");
     }
 
     @Test
     void enforce_version_two_updater_fails() throws Exception {
-        AncestorBlockUpdater ancestorBlockUpdater = mock(AncestorBlockUpdater.class);
-        doThrow(new Exception()).when(ancestorBlockUpdater).ensureAncestorBlockInPosition(any());
-        ReleaseRequirementsEnforcer enforcer = new ReleaseRequirementsEnforcer(ancestorBlockUpdater);
+        AncestorBlockUpdater blockUpdater = mock(AncestorBlockUpdater.class);
+        doThrow(new Exception()).when(blockUpdater).ensureAncestorBlockInPosition(any());
+        ReleaseRequirementsEnforcer enforcer = new ReleaseRequirementsEnforcer(blockUpdater);
 
         assertThrows(ReleaseRequirementsEnforcerException.class, () -> enforcer.enforce(HSMVersion.V2.getNumber(), mock(ReleaseCreationInformation.class)));
     }
 
     @Test
     void enforce_invalid_version() {
-        ReleaseRequirementsEnforcer enforcer = new ReleaseRequirementsEnforcer(mock(AncestorBlockUpdater.class));
-
-        assertThrows(ReleaseRequirementsEnforcerException.class, () -> enforcer.enforce(-5, mock(ReleaseCreationInformation.class)));
+        assertThrows(ReleaseRequirementsEnforcerException.class, () -> releaseRequirementsEnforcer.enforce(-5, mock(ReleaseCreationInformation.class)));
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/requirements/ReleaseRequirementsEnforcerTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/requirements/ReleaseRequirementsEnforcerTest.java
@@ -56,9 +56,8 @@ class ReleaseRequirementsEnforcerTest {
 
     @Test
     void enforce_version_two_updater_fails() throws Exception {
-        AncestorBlockUpdater blockUpdater = mock(AncestorBlockUpdater.class);
-        doThrow(new Exception()).when(blockUpdater).ensureAncestorBlockInPosition(any());
-        ReleaseRequirementsEnforcer enforcer = new ReleaseRequirementsEnforcer(blockUpdater);
+        doThrow(new Exception()).when(ancestorBlockUpdater).ensureAncestorBlockInPosition(any());
+        ReleaseRequirementsEnforcer enforcer = new ReleaseRequirementsEnforcer(ancestorBlockUpdater);
 
         assertThrows(ReleaseRequirementsEnforcerException.class, () -> enforcer.enforce(HSMVersion.V2.getNumber(), mock(ReleaseCreationInformation.class)));
     }


### PR DESCRIPTION
**Background**
- The implementation of getConfirmedBlocks method was wrong: it was calculating the block difficulty considering uncles, and then applying the cap, instead of applying the cap in each uncle.
This was causing that the node thought it should send many more blocks to the HSM to reach the expected difficulty, ended up sending difficulty to advance aprox 1000 blocks, and our intention is for it to advance 100 blocks each time.

- On the other side, the HSM version 3 never really existed, so it didn’t have sense to have it as a possible HSM version. 

**Requirements**
- Fix block selection algorithm to apply the cap in each uncle and not at the end.
- Remove HSM version 3 as a possible version