### PR TITLE
feat: Added the case in getExpectedFederation to consider p2sh p2wsh feds

### DIFF
--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -215,8 +215,16 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
             return nonStandardErpFederation;
         }
 
-        // Finally, try building a P2SH ERP federation
-        return FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
+        // If addresses match build a P2SH ERP federation
+        ErpFederation p2shErpFederation =
+            FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
+
+        if (p2shErpFederation.getAddress().equals(expectedFederationAddress)) {
+            return p2shErpFederation;
+        }
+
+        // Finally, try building a P2SH P2WSH ERP federation
+        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, erpPubKeys, activationDelay);
 
         // TODO: what if no federation built matches the expected address?
         //  It could mean that there is a different type of federation in the Bridge that we are not considering here

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -448,7 +448,7 @@ public class BtcReleaseClient {
                         BtcTransaction.SigHash.ALL,
                         false
                 );
-                if (BridgeUtils.isInputSignedByThisFederator(federatorPublicKey, sigHash, txIn)) {
+                if (BridgeUtils.isInputSignedByThisFederator(pegoutBtcTx, inputIndex, federatorPublicKey, sigHash)) {
                     String message = String.format(
                             "Btc tx %s input %d already signed by current federator with public key %s",
                             pegoutBtcTx.getHashAsString(),

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -86,12 +86,13 @@ class FederationProviderFromFederatorSupportTest {
         Address expectedFederationAddress = expectedFederation.getAddress();
 
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getFederationSize()).thenReturn(4);
-        when(federatorSupportMock.getFederationThreshold()).thenReturn(2);
+        int expectedFederationSize = expectedFederation.getSize();
+        when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
+        when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
         when(federatorSupportMock.getFederationCreationTime()).thenReturn(creationTime);
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < expectedFederationSize; i++) {
             when(federatorSupportMock.getFederatorPublicKey(i)).thenReturn(BtcECKey.fromPrivate(BigInteger.valueOf((i+1)*1000)));
         }
 
@@ -112,15 +113,14 @@ class FederationProviderFromFederatorSupportTest {
         Address expectedFederationAddress = expectedFederation.getAddress();
 
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getFederationSize()).thenReturn(4);
-        when(federatorSupportMock.getFederationThreshold()).thenReturn(2);
+        int expectedFederationSize = expectedFederation.getSize();
+        when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
+        when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
         when(federatorSupportMock.getFederationCreationTime()).thenReturn(creationTime);
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        for (int i = 0; i < 4; i++) {
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+1)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+2)));
+        for (int i = 0; i < expectedFederationSize; i++) {
+            mockRetiringFederationMemberKeys(i);
         }
 
         Federation obtainedFederation = federationProvider.getActiveFederation();
@@ -130,31 +130,25 @@ class FederationProviderFromFederatorSupportTest {
         assertEquals(expectedFederationAddress, obtainedFederation.getAddress());
     }
 
-    @Test
-    void getActiveFederation_erp_federation() {
-        ActivationConfig.ForBlock configMock = mockActivationConfig(true);
-
-        Federation expectedFederation = createNonStandardErpFederation(
-            federationMembersFromPks,
-            configMock
-        );
+    @ParameterizedTest
+    @MethodSource("federation_args")
+    void getActiveFederation_withTheAddressCorrespondingToItsVersion_shouldReturnTheCorrectActiveFederation(ActivationConfig.ForBlock configMock, Federation expectedFederation, int expectedFormatVersion) {
         Address expectedFederationAddress = expectedFederation.getAddress();
 
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getFederationSize()).thenReturn(5);
-        when(federatorSupportMock.getFederationThreshold()).thenReturn(3);
+        int expectedFederationSize = expectedFederation.getSize();
+        when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
+        when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
         when(federatorSupportMock.getFederationCreationTime()).thenReturn(creationTime);
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        for (int i = 0; i < 5; i++) {
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+1)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+2)));
+        for (int i = 0; i < expectedFederationSize; i++) {
+            mockRetiringFederationMemberKeys(i);
         }
 
         Federation obtainedFederation = federationProvider.getActiveFederation();
 
-        assertEquals(NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION, obtainedFederation.getFormatVersion());
+        assertEquals(expectedFormatVersion, obtainedFederation.getFormatVersion());
         assertEquals(expectedFederation, obtainedFederation);
         assertEquals(expectedFederationAddress, obtainedFederation.getAddress());
     }
@@ -171,16 +165,15 @@ class FederationProviderFromFederatorSupportTest {
         Address expectedFederationAddress = expectedFederation.getAddress();
 
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getFederationSize()).thenReturn(5);
-        when(federatorSupportMock.getFederationThreshold()).thenReturn(3);
+        int expectedFederationSize = expectedFederation.getSize();
+        when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
+        when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
         when(federatorSupportMock.getFederationCreationTime()).thenReturn(creationTime);
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
 
-        for (int i = 0; i < 5; i++) {
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+1)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+2)));
+        for (int i = 0; i < expectedFederationSize; i++) {
+            mockRetiringFederationMemberKeys(i);
         }
 
         Federation obtainedFederation = federationProvider.getActiveFederation();
@@ -191,60 +184,10 @@ class FederationProviderFromFederatorSupportTest {
         assertEquals(HARDCODED_TESTNET_FED_REDEEM_SCRIPT, obtainedFederation.getRedeemScript());
     }
 
-    @Test
-    void getActiveFederation_p2sh_erp_federation() {
-        ActivationConfig.ForBlock configMock = mockActivationConfig(true);
-
-        Federation expectedFederation = createP2shErpFederation(
-            federationMembersFromPks
-        );
-        Address expectedFederationAddress = expectedFederation.getAddress();
-
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getFederationSize()).thenReturn(5);
-        when(federatorSupportMock.getFederationThreshold()).thenReturn(3);
-        when(federatorSupportMock.getFederationCreationTime()).thenReturn(creationTime);
-        when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
-        when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        for (int i = 0; i < 5; i++) {
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+1)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+2)));
-        }
-
-        Federation obtainedFederation = federationProvider.getActiveFederation();
-
-        assertEquals(P2SH_ERP_FEDERATION_FORMAT_VERSION, obtainedFederation.getFormatVersion());
-        assertEquals(expectedFederation, obtainedFederation);
-        assertEquals(expectedFederationAddress, obtainedFederation.getAddress());
-    }
-
-    @Test
-    void getActiveFederation_p2sh_pw2sh_erp_federation() {
-        ActivationConfig.ForBlock configMock = mockActivationConfig(true);
-
-        Federation expectedFederation = createP2shP2wshErpFederation(
-            federationMembersFromPks
-        );
-        Address expectedFederationAddress = expectedFederation.getAddress();
-
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
-        when(federatorSupportMock.getFederationSize()).thenReturn(5);
-        when(federatorSupportMock.getFederationThreshold()).thenReturn(3);
-        when(federatorSupportMock.getFederationCreationTime()).thenReturn(creationTime);
-        when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
-        when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
-        for (int i = 0; i < 5; i++) {
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+1)));
-            when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i+1)*1000+2)));
-        }
-
-        Federation obtainedFederation = federationProvider.getActiveFederation();
-
-        assertEquals(P2SH_P2WSH_ERP_FEDERATION_FORMAT_VERSION, obtainedFederation.getFormatVersion());
-        assertEquals(expectedFederation, obtainedFederation);
-        assertEquals(expectedFederationAddress, obtainedFederation.getAddress());
+    private void mockRetiringFederationMemberKeys(int i) {
+        when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000)));
+        when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000+1)));
+        when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000+2)));
     }
 
     @Test
@@ -346,13 +289,13 @@ class FederationProviderFromFederatorSupportTest {
     }
 
 
-    private void mockFederationMemberKeys(int i) {
-        when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000)));
-        when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000+1)));
-        when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000+2)));
+    private void mockFederationMemberKeys(int memberIndex) {
+        when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(memberIndex, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((memberIndex+1)*1000)));
+        when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(memberIndex, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((memberIndex+1)*1000+1)));
+        when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(memberIndex, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((memberIndex+1)*1000+2)));
     }
 
-    private static Stream<Arguments> retiring_federation_args() {
+    private static Stream<Arguments> federation_args() {
         ActivationConfig.ForBlock rskip123ActivatedConfigMock = mockActivationConfig(true);
         return Stream.of(
             Arguments.of(rskip123ActivatedConfigMock,
@@ -376,8 +319,8 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     @ParameterizedTest
-    @MethodSource("retiring_federation_args")
-    void getRetiringFederation_present_federation(ActivationConfig.ForBlock configMock, Federation expectedFederation, int expectedFormatVersion) {
+    @MethodSource("federation_args")
+    void getRetiringFederation_withTheAddressCorrespondingToItsVersion_shouldReturnTheCorrectRetiringFederation(ActivationConfig.ForBlock configMock, Federation expectedFederation, int expectedFormatVersion) {
         Address expectedFederationAddress = expectedFederation.getAddress();
 
         when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -120,7 +120,7 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
         for (int i = 0; i < expectedFederationSize; i++) {
-            mockRetiringFederationMemberKeys(i);
+            mockFederationMemberKeys(i);
         }
 
         Federation obtainedFederation = federationProvider.getActiveFederation();
@@ -143,7 +143,7 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederationAddress);
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
         for (int i = 0; i < expectedFederationSize; i++) {
-            mockRetiringFederationMemberKeys(i);
+            mockFederationMemberKeys(i);
         }
 
         Federation obtainedFederation = federationProvider.getActiveFederation();
@@ -173,7 +173,7 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
 
         for (int i = 0; i < expectedFederationSize; i++) {
-            mockRetiringFederationMemberKeys(i);
+            mockFederationMemberKeys(i);
         }
 
         Federation obtainedFederation = federationProvider.getActiveFederation();
@@ -184,7 +184,7 @@ class FederationProviderFromFederatorSupportTest {
         assertEquals(HARDCODED_TESTNET_FED_REDEEM_SCRIPT, obtainedFederation.getRedeemScript());
     }
 
-    private void mockRetiringFederationMemberKeys(int i) {
+    private void mockFederationMemberKeys(int i) {
         when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000)));
         when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000+1)));
         when(federatorSupportMock.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((i +1)*1000+2)));
@@ -289,7 +289,7 @@ class FederationProviderFromFederatorSupportTest {
     }
 
 
-    private void mockFederationMemberKeys(int memberIndex) {
+    private void mockRetiringFederationMemberKeys(int memberIndex) {
         when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(memberIndex, FederationMember.KeyType.BTC)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((memberIndex+1)*1000)));
         when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(memberIndex, FederationMember.KeyType.RSK)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((memberIndex+1)*1000+1)));
         when(federatorSupportMock.getRetiringFederatorPublicKeyOfType(memberIndex, FederationMember.KeyType.MST)).thenReturn(ECKey.fromPrivate(BigInteger.valueOf((memberIndex+1)*1000+2)));
@@ -331,7 +331,7 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getRetiringFederationAddress()).thenReturn(Optional.of(expectedFederationAddress));
         when(federatorSupportMock.getBtcParams()).thenReturn(testnetParams);
         for (int i = 0; i < expectedFederationSize; i++) {
-            mockFederationMemberKeys(i);
+            mockRetiringFederationMemberKeys(i);
         }
 
         Optional<Federation> obtainedFederationOptional = federationProvider.getRetiringFederation();

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -26,7 +26,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.bouncycastle.util.encoders.Hex;
@@ -59,14 +58,14 @@ class FederationProviderFromFederatorSupportTest {
     private static final FederationConstants federationConstants = FederationTestNetConstants.getInstance();
     private static final NetworkParameters testnetParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
     private static final Instant creationTime = Instant.ofEpochSecond(5);
-    private static ActivationConfig.ForBlock configMock;
+    private static ActivationConfig.ForBlock activations;
 
     private FederatorSupport federatorSupportMock;
     private FederationProvider federationProvider;
 
     @BeforeEach
     void createProvider() {
-        configMock = mock(ActivationConfig.ForBlock.class);
+        activations = mock(ActivationConfig.ForBlock.class);
         federatorSupportMock = mock(FederatorSupport.class);
         federationProvider = new FederationProviderFromFederatorSupport(
             federatorSupportMock,
@@ -76,14 +75,14 @@ class FederationProviderFromFederatorSupportTest {
 
     @Test
     void getActiveFederation_beforeMultikey() {
-        when(configMock.isActive(RSKIP123)).thenReturn(false);
+        when(activations.isActive(RSKIP123)).thenReturn(false);
 
         Federation expectedFederation = createFederation(
             getFederationMembersFromPks(0, 1000, 2000, 3000, 4000)
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         int expectedFederationSize = expectedFederation.getSize();
         when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
         when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
@@ -103,14 +102,14 @@ class FederationProviderFromFederatorSupportTest {
 
     @Test
     void getActiveFederation_afterMultikey() {
-        when(configMock.isActive(RSKIP123)).thenReturn(true);
+        when(activations.isActive(RSKIP123)).thenReturn(true);
 
         Federation expectedFederation = createFederation(
             getFederationMembersFromPks(1, 1000, 2000, 3000, 4000)
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         int expectedFederationSize = expectedFederation.getSize();
         when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
         when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
@@ -153,16 +152,16 @@ class FederationProviderFromFederatorSupportTest {
 
     @Test
     void getActiveFederation_erp_federation_testnet_hardcoded() {
-        when(configMock.isActive(RSKIP123)).thenReturn(true);
-        when(configMock.isActive(RSKIP284)).thenReturn(false);
+        when(activations.isActive(RSKIP123)).thenReturn(true);
+        when(activations.isActive(RSKIP284)).thenReturn(false);
 
         Federation expectedFederation = createNonStandardErpFederation(
             federationMembersFromPks,
-            configMock
+            activations
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         int expectedFederationSize = expectedFederation.getSize();
         when(federatorSupportMock.getFederationSize()).thenReturn(expectedFederationSize);
         when(federatorSupportMock.getFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
@@ -218,7 +217,7 @@ class FederationProviderFromFederatorSupportTest {
 
     @Test
     void getRetiringFederation_present_beforeMultikey() {
-        when(configMock.isActive(RSKIP123)).thenReturn(false);
+        when(activations.isActive(RSKIP123)).thenReturn(false);
 
         List<FederationMember> retiringFederationMembers = getFederationMembersFromPks(0, 2000, 4000, 6000, 8000, 10000, 12000);
         Federation expectedFederation = createFederation(
@@ -226,7 +225,7 @@ class FederationProviderFromFederatorSupportTest {
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         int expectedFederationSize = retiringFederationMembers.size();
         when(federatorSupportMock.getRetiringFederationSize()).thenReturn(expectedFederationSize);
         when(federatorSupportMock.getRetiringFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
@@ -249,7 +248,7 @@ class FederationProviderFromFederatorSupportTest {
 
     @Test
     void getRetiringFederation_present_afterMultikey() {
-        when(configMock.isActive(RSKIP123)).thenReturn(true);
+        when(activations.isActive(RSKIP123)).thenReturn(true);
 
         List<FederationMember> retiringFederationMembers = getFederationMembersFromPks(1, 2000, 4000, 6000, 8000, 10000, 12000);
         Federation expectedFederation = createFederation(
@@ -257,7 +256,7 @@ class FederationProviderFromFederatorSupportTest {
         );
         Address expectedFederationAddress = expectedFederation.getAddress();
 
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         int expectedFederationSize = expectedFederation.getSize();
         when(federatorSupportMock.getRetiringFederationSize()).thenReturn(expectedFederationSize);
         when(federatorSupportMock.getRetiringFederationThreshold()).thenReturn(expectedFederation.getNumberOfSignaturesRequired());
@@ -287,22 +286,22 @@ class FederationProviderFromFederatorSupportTest {
     }
 
     private static Stream<Arguments> federation_args() {
-        when(configMock.isActive(RSKIP123)).thenReturn(true);
+        when(activations.isActive(RSKIP123)).thenReturn(true);
         return Stream.of(
-            Arguments.of(configMock,
+            Arguments.of(activations,
                 createNonStandardErpFederation(
                     federationMembersFromPks,
-                    configMock
+                    activations
                 ),
                 NON_STANDARD_ERP_FEDERATION_FORMAT_VERSION
             ),
             Arguments.of(
-                configMock,
+                activations,
                 createP2shErpFederation(federationMembersFromPks),
                 P2SH_ERP_FEDERATION_FORMAT_VERSION
             ),
             Arguments.of(
-                configMock,
+                activations,
                 createP2shP2wshErpFederation(federationMembersFromPks),
                 P2SH_P2WSH_ERP_FEDERATION_FORMAT_VERSION
             )
@@ -338,8 +337,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenProposedFederationSizeIsNonExistent_shouldReturnEmptyOptional() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         when(federatorSupportMock.getProposedFederationSize())
             .thenReturn(Optional.of(FEDERATION_NON_EXISTENT.getCode()));
 
@@ -351,8 +350,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenSomeDataDoesNotExists_shouldThrowIllegalStateException() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         Federation expectedFederation = createP2shErpFederation(federationMembersFromPks);
         Address expectedFederationAddress = expectedFederation.getAddress();
         Integer federationSize = 5;
@@ -371,8 +370,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenExistsAndIsP2shErpFederation_shouldReturnProposedFederation() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         Federation expectedFederation = createP2shErpFederation(federationMembersFromPks);
         Address expectedFederationAddress = expectedFederation.getAddress();
         Integer federationSize = expectedFederation.getSize();
@@ -403,8 +402,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederation_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(false);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(false);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
 
         // Act
         Optional<Federation> result = federationProvider.getProposedFederation();
@@ -416,8 +415,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederationAddress_whenAddressExists_shouldReturnAddress() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.of(DEFAULT_ADDRESS));
 
         // Act
@@ -431,8 +430,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederationAddress_whenNoAddressExists_shouldReturnEmptyOptional() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(true);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(true);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
         when(federatorSupportMock.getProposedFederationAddress()).thenReturn(Optional.empty());
 
         // Act
@@ -445,8 +444,8 @@ class FederationProviderFromFederatorSupportTest {
     @Test
     void getProposedFederationAddress_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
         // Arrange
-        when(configMock.isActive(RSKIP419)).thenReturn(false);
-        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(configMock);
+        when(activations.isActive(RSKIP419)).thenReturn(false);
+        when(federatorSupportMock.getConfigForBestBlock()).thenReturn(activations);
 
         // Act
         Optional<Address> result = federationProvider.getProposedFederationAddress();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To obtain the active and the retiring federations, the getExpectedFederation function uses different methods from rskj that return info about the federations. Given that none of the methods in rskj returns the entire federation, it considers the different existing federation types to build a federation that matches the expected federation address.


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
