### PR TITLE
Segwit compatible powpeg integration part3

### DIFF
--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
@@ -76,8 +76,10 @@ public class ReleaseCreationInformation {
         Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
         final byte[] pegoutTransactionCreatedSignatureTopic = pegoutTransactionCreatedEvent.encodeSignatureLong();
 
-        return !log.getTopics().isEmpty() && Arrays.equals(log.getTopics().get(0).getData(),
-            pegoutTransactionCreatedSignatureTopic);
+        boolean logHasTopics = !log.getTopics().isEmpty();
+        return logHasTopics &&
+            // event signature topic is always the first one
+            Arrays.equals(log.getTopics().get(0).getData(), pegoutTransactionCreatedSignatureTopic);
     }
 
     private byte[] decodePegoutTransactionEventData(byte[] pegoutCreatedTransactionEventData) {

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -100,9 +100,9 @@ public class ReleaseCreationInformationGetter {
             logger.trace("[getTxInfoToSign] Searching for rsk transaction {} in block {} ({})", pegoutCreationRskTxHash, block.getHash(), block.getNumber());
             List<Transaction> transactions = block.getTransactionsList().stream()
                 .filter(t -> t.getHash().equals(pegoutCreationRskTxHash))
-                .collect(Collectors.toList());
+                .toList();
             logger.trace("[getTxInfoToSign] Transactions found {}", transactions.size());
-            if(transactions.size() != 1) {
+            if (transactions.size() != 1) {
                 String message = String.format(
                     "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Filter size: %d",
                     pegoutCreationRskTxHash,

--- a/src/main/java/co/rsk/federate/watcher/FederationWatcher.java
+++ b/src/main/java/co/rsk/federate/watcher/FederationWatcher.java
@@ -97,20 +97,23 @@ public class FederationWatcher {
         boolean hasProposedFederationChanged = !currentlyProposedFederationAddress.equals(oldProposedFederationAddress);
 
         if (hasProposedFederationChanged) {
-            logger.info("[updateProposedFederation] Proposed federation changed from {} to {}",
-                    oldProposedFederationAddress.orElse(null),
-                    currentlyProposedFederationAddress.orElse(null));
-
             Federation currentlyProposedFederation = federationProvider.getProposedFederation().orElse(null);
 
             federationWatcherListener.onProposedFederationChange(currentlyProposedFederation);
             this.proposedFederation = currentlyProposedFederation;
+            logger.info(
+                "[updateProposedFederation] Proposed federation changed from {} to {}",
+                oldProposedFederationAddress.orElse(null),
+                currentlyProposedFederationAddress.orElse(null)
+            );
         }
     }    
 
     private void updateActiveFederation() {
         Address currentlyActiveFederationAddress = Objects.requireNonNull(
-            federationProvider.getActiveFederationAddress(), "The current active federation should always exist");
+            federationProvider.getActiveFederationAddress(),
+            "The current active federation should always exist"
+        );
         Address oldActiveFederationAddress = Optional.ofNullable(activeFederation)
             .map(Federation::getAddress)
             .orElse(null);
@@ -118,14 +121,14 @@ public class FederationWatcher {
         boolean hasActiveFederationChanged = !currentlyActiveFederationAddress.equals(oldActiveFederationAddress);
 
         if (hasActiveFederationChanged) {
-            logger.info("[updateActiveFederation] Active federation changed from {} to {}",
-                oldActiveFederationAddress,
-                currentlyActiveFederationAddress);
-
             Federation currentlyActiveFederation = federationProvider.getActiveFederation();
 
             federationWatcherListener.onActiveFederationChange(currentlyActiveFederation);
             this.activeFederation = currentlyActiveFederation;
+            logger.info("[updateActiveFederation] Active federation changed from {} to {}",
+                oldActiveFederationAddress,
+                currentlyActiveFederationAddress
+            );
         }
     }
 
@@ -137,14 +140,15 @@ public class FederationWatcher {
         boolean hasRetiringFederationChanged = !currentlyRetiringFederationAddress.equals(oldRetiringFederationAddress);
 
         if (hasRetiringFederationChanged) {
-            logger.info("[updateRetiringFederation] Retiring federation changed from {} to {}",
-                    oldRetiringFederationAddress.orElse(null),
-                    currentlyRetiringFederationAddress.orElse(null));
-
             Federation currentlyRetiringFederation = federationProvider.getRetiringFederation().orElse(null);
 
             federationWatcherListener.onRetiringFederationChange(currentlyRetiringFederation);
             this.retiringFederation = currentlyRetiringFederation;
+            logger.info(
+                "[updateRetiringFederation] Retiring federation changed from {} to {}",
+                oldRetiringFederationAddress.orElse(null),
+                currentlyRetiringFederationAddress.orElse(null)
+            );
         }
     }    
 }

--- a/src/test/java/co/rsk/federate/BtcToRskClientBuilder.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientBuilder.java
@@ -30,7 +30,7 @@ public class BtcToRskClientBuilder {
     private Federation federation;
     private PowpegNodeSystemProperties config;
 
-    public BtcToRskClientBuilder() throws PeginInstructionsException, IOException {
+    private BtcToRskClientBuilder() throws PeginInstructionsException, IOException {
         this.activationConfig = mock(ActivationConfig.class);
         this.bitcoinWrapper = mock(BitcoinWrapper.class);
         this.federatorSupport = mock(FederatorSupport.class);
@@ -51,6 +51,10 @@ public class BtcToRskClientBuilder {
         when(config.shouldUpdateBridgeBtcCoinbaseTransactions()).thenReturn(true);
         when(config.isUpdateBridgeTimerEnabled()).thenReturn(true);
         when(config.getAmountOfHeadersToSend()).thenReturn(100);
+    }
+
+    public static BtcToRskClientBuilder builder() throws PeginInstructionsException, IOException {
+        return new BtcToRskClientBuilder();
     }
 
     public BtcToRskClientBuilder withActivationConfig(ActivationConfig activationConfig) {
@@ -98,7 +102,7 @@ public class BtcToRskClientBuilder {
         return this;
     }
 
-    public BtcToRskClient build () throws Exception {
+    public BtcToRskClient build() throws Exception {
         when(config.getActivationConfig()).thenReturn(activationConfig);
         return new BtcToRskClient(
             bitcoinWrapper,

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -75,9 +75,9 @@ class BtcToRskClientTest {
         bridgeRegTestConstants = new BridgeRegTestConstants();
         networkParameters = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString());
         federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
-        activeFederation = TestUtils.createFederation(bridgeRegTestConstants.getBtcParams(), federationPrivateKeys);
+        activeFederation = TestUtils.createStandardMultisigFederation(bridgeRegTestConstants.getBtcParams(), federationPrivateKeys);
         activeFederationMember = FederationMember.getFederationMemberFromKey(federationPrivateKeys.get(0));
-        btcToRskClientBuilder = new BtcToRskClientBuilder();
+        btcToRskClientBuilder = BtcToRskClientBuilder.builder();
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -1418,7 +1418,7 @@ class BtcReleaseClientTest {
         );
 
         // Act
-        assertThrows(FederatorAlreadySignedException.class, () -> client.validateTxCanBeSigned(releaseCreationInformation));
+        assertThrows(FederatorAlreadySignedException.class, () -> client.validateTxCanBeSigned(releaseCreationInformation, releaseTx));
     }
 
     @Test
@@ -1464,7 +1464,7 @@ class BtcReleaseClientTest {
         );
 
         // Act
-        assertThrows(FederationCantSignException.class, () -> client.validateTxCanBeSigned(releaseCreationInformation));
+        assertThrows(FederationCantSignException.class, () -> client.validateTxCanBeSigned(releaseCreationInformation, releaseTx));
     }
 
     @Test
@@ -1550,7 +1550,7 @@ class BtcReleaseClientTest {
         );
 
         // Act
-        client.validateTxCanBeSigned(releaseCreationInformation);
+        client.validateTxCanBeSigned(releaseCreationInformation, releaseTx);
     }
 
     private void test_extractStandardRedeemScript(

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -99,8 +99,8 @@ class BtcReleaseClientTest {
     void start_whenFederationMemberNotPartOfDesiredFederation_shouldThrowException() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
-        Federation otherFederation = TestUtils.createFederation(params, 2);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation otherFederation = TestUtils.createStandardMultisigFederation(params, 2);
         FederationMember federationMember = otherFederation.getMembers().get(1);
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
@@ -142,12 +142,12 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
-        Federation fed1 = TestUtils.createFederation(params, 1);
+        Federation fed1 = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember1 = fed1.getMembers().get(0);
         doReturn(federationMember1).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed1);
 
-        Federation fed2 = TestUtils.createFederation(params, 1);
+        Federation fed2 = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember2 = fed2.getMembers().get(0);
         doReturn(federationMember2).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed2);
@@ -167,12 +167,12 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
-        Federation fed1 = TestUtils.createFederation(params, 1);
+        Federation fed1 = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember1 = fed1.getMembers().get(0);
         doReturn(federationMember1).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed1);
 
-        Federation fed2 = TestUtils.createFederation(params, 1);
+        Federation fed2 = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember2 = fed2.getMembers().get(0);
         doReturn(federationMember2).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed2);
@@ -195,12 +195,12 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
-        Federation fed1 = TestUtils.createFederation(params, 1);
+        Federation fed1 = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember1 = fed1.getMembers().get(0);
         doReturn(federationMember1).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed1);
 
-        Federation fed2 = TestUtils.createFederation(params, 1);
+        Federation fed2 = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember2 = fed2.getMembers().get(0);
         doReturn(federationMember2).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed2);
@@ -216,7 +216,7 @@ class BtcReleaseClientTest {
     void processReleases_ok() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember = federation.getMembers().get(0);
 
         // Create a tx from the Fed to a random btc address
@@ -702,7 +702,7 @@ class BtcReleaseClientTest {
     void having_two_pegouts_signs_only_one() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember = federation.getMembers().get(0);
         BtcTransaction tx1 = TestUtils.createBtcTransaction(params, federation);
         BtcTransaction tx2 = TestUtils.createBtcTransaction(params, federation);
@@ -803,7 +803,7 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenPegoutTxIsCached_shouldNotSignSamePegoutTxAgain() throws Exception {
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 9);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 9);
         FederationMember federationMember = federation.getMembers().get(0);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
@@ -898,7 +898,7 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenPegoutTxIsCachedWithInvalidTimestamp_shouldSignSamePegoutTxAgain() throws Exception {
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 9);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 9);
         FederationMember federationMember = federation.getMembers().get(0);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
@@ -999,7 +999,7 @@ class BtcReleaseClientTest {
     void onBestBlock_whenOnlySvpSpendTxWaitingForSignaturesIsAvailable_shouldAddSignature() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, 9);
         FederationMember federationMember = proposedFederation.getMembers().get(0);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
@@ -1097,7 +1097,7 @@ class BtcReleaseClientTest {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
         List<BtcECKey> federationKeys = TestUtils.getFederationPrivateKeys(9);
-        Federation proposedFederation = TestUtils.createFederation(bridgeConstants.getBtcParams(), federationKeys);
+        Federation proposedFederation = TestUtils.createStandardMultisigFederation(bridgeConstants.getBtcParams(), federationKeys);
         Script scriptSig = proposedFederation.getP2SHScript().createEmptyInputScript(null, proposedFederation.getRedeemScript());
 
         BtcTransaction svpSpendTx = new BtcTransaction(params);
@@ -1212,14 +1212,14 @@ class BtcReleaseClientTest {
     void onBestBlock_whenBothPegoutAndSvpSpendTxWaitingForSignaturesAreAvailableAndFederatorIsOnlyPartOfProposedFederation_shouldOnlyAddOneSignature() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 9);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 9);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
         rskTxsWaitingForSignatures.put(pegoutCreationRskTxHash, pegout);
         StateForFederator stateForFederator = new StateForFederator(rskTxsWaitingForSignatures);
 
-        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, 9);
         FederationMember federationMember = proposedFederation.getMembers().get(0);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(1);
@@ -1325,7 +1325,7 @@ class BtcReleaseClientTest {
         List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(9).toList();
         BtcECKey fedKey = keys.get(0);
         FederationMember federationMember = FederationMember.getFederationMembersFromKeys(keys).get(0);
-        Federation federation = TestUtils.createFederation(params, keys);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, keys);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
@@ -1334,7 +1334,7 @@ class BtcReleaseClientTest {
 
         List<BtcECKey> proposedKeys = Stream.generate(BtcECKey::new).limit(8).collect(Collectors.toList());
         proposedKeys.add(fedKey);
-        Federation proposedFederation = TestUtils.createFederation(params, proposedKeys);
+        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, proposedKeys);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(1);
         Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
@@ -1436,7 +1436,7 @@ class BtcReleaseClientTest {
     void onBestBlock_whenSvpSpendTxIsNotReadyToBeSigned_shouldNotAddSignature() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation proposedFederation = TestUtils.createFederation(params, 9);
+        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, 9);
         FederationMember federationMember = proposedFederation.getMembers().get(0);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
@@ -1523,7 +1523,7 @@ class BtcReleaseClientTest {
     void onBestBlock_return_when_node_is_syncing() throws BtcReleaseClientException {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1567,7 +1567,7 @@ class BtcReleaseClientTest {
     void onBestBlock_return_when_pegout_is_disabled() throws BtcReleaseClientException {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(false);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1611,7 +1611,7 @@ class BtcReleaseClientTest {
     void onBlock_return_when_node_is_syncing() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1651,7 +1651,7 @@ class BtcReleaseClientTest {
     void onBlock_return_when_pegout_is_disabled() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(false);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1691,7 +1691,7 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_ok() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = new BtcTransaction(params);
@@ -1708,7 +1708,7 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_fast_bridge_ok() throws Exception {
         // Create a StandardMultisigFederation
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
 
         // Create fast bridge redeem script
 
@@ -1731,7 +1731,7 @@ class BtcReleaseClientTest {
     @Test
     void validateTxCanBeSigned_erp_fed_ok() throws Exception {
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 3);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 3);
         FederationArgs federationArgs = federation.getArgs();
         ErpFederation nonStandardErpFederation =
             FederationFactory.buildNonStandardErpFederation(federationArgs, erpFedKeys, 5063, mock(ActivationConfig.ForBlock.class));
@@ -1819,7 +1819,7 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_federationCantSign() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = new BtcTransaction(params);
@@ -1862,7 +1862,7 @@ class BtcReleaseClientTest {
 
     @Test
     void extractStandardRedeemScript_fast_bridge_redeem_script() {
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
 
         Keccak256 flyoverDerivationHash = createHash(1);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
@@ -1875,7 +1875,7 @@ class BtcReleaseClientTest {
 
     @Test
     void extractStandardRedeemScript_erp_redeem_script() {
-        Federation federation = TestUtils.createFederation(params, 1);
+        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
         FederationArgs federationArgs = federation.getArgs();
 
         ErpFederation nonStandardErpFederation =

--- a/src/test/java/co/rsk/federate/signing/SigHashCalculatorTest.java
+++ b/src/test/java/co/rsk/federate/signing/SigHashCalculatorTest.java
@@ -30,7 +30,7 @@ class SigHashCalculatorTest {
     @Test
     void calculate_forLegacySigHashCalculator_forLegacyTxInput_shouldReturnExpectedLegacySigHash() {
         // arrange
-        Federation federation = TestUtils.createFederation(mainnet, 9);
+        Federation federation = TestUtils.createStandardMultisigFederation(mainnet, 9);
         setUp(federation);
 
         Script redeemScript = federation.getRedeemScript();
@@ -49,7 +49,7 @@ class SigHashCalculatorTest {
     @Test
     void calculate_forLegacySigHashCalculator_forSegwitTxInput_shouldNotReturnLegacySigHash() {
         // arrange
-        Federation federation = TestUtils.createSegwitFederation(mainnet, 20);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(mainnet, 20);
         setUp(federation);
 
         Script redeemScript = federation.getRedeemScript();
@@ -68,7 +68,7 @@ class SigHashCalculatorTest {
     @Test
     void calculate_forLegacySigHashCalculator_whenNoRedeemScriptInInput_shouldThrowISE() {
         // arrange
-        Federation federation = TestUtils.createFederation(mainnet, 9);
+        Federation federation = TestUtils.createStandardMultisigFederation(mainnet, 9);
         setUp(federation);
 
         SigHashCalculator sigHashCalculator = new LegacySigHashCalculatorImpl();
@@ -80,7 +80,7 @@ class SigHashCalculatorTest {
     @Test
     void calculate_forSegwitSigHashCalculator_forSegwitTxInput_shouldReturnExpectedSegwitSigHash() {
         // arrange
-        Federation federation = TestUtils.createSegwitFederation(mainnet, 20);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(mainnet, 20);
         setUp(federation);
 
         Script redeemScript = federation.getRedeemScript();
@@ -99,7 +99,7 @@ class SigHashCalculatorTest {
     @Test
     void calculate_forSegwitSigHashCalculator_forLegacyTxInput_shouldNotReturnLegacySigHash() {
         // arrange
-        Federation federation = TestUtils.createFederation(mainnet, 9);
+        Federation federation = TestUtils.createStandardMultisigFederation(mainnet, 9);
         setUp(federation);
 
         Script redeemScript = federation.getRedeemScript();
@@ -118,7 +118,7 @@ class SigHashCalculatorTest {
     @Test
     void calculate_forSegwitSigHashCalculator_whenNoRedeemScriptInInput_shouldThrowISE() {
         // arrange
-        Federation federation = TestUtils.createSegwitFederation(mainnet, 20);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(mainnet, 20);
         setUp(federation);
 
         int firstInputIndex = 0;

--- a/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
@@ -50,15 +50,15 @@ class PowHSMSigningClientBtcTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
 
-    private static final Federation newFederation = TestUtils.createFederation(
+    private static final Federation newFederation = TestUtils.createStandardMultisigFederation(
         bridgeMainnetConstants.getBtcParams(),
         9
     );
-    private static final Federation oldFederation = TestUtils.createFederation(
+    private static final Federation oldFederation = TestUtils.createStandardMultisigFederation(
         bridgeMainnetConstants.getBtcParams(),
         5
     );
-    private static final Federation oldSegwitFederation = TestUtils.createSegwitFederation(
+    private static final Federation oldSegwitFederation = TestUtils.createP2shP2wshErpFederation(
         bridgeMainnetConstants.getBtcParams(),
         5
     );

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -47,15 +47,15 @@ class PowHSMSignerMessageBuilderTest {
         btcMainnetParams,
         "userAddress"
     );
-    private static final Federation newFederation = TestUtils.createFederation(
+    private static final Federation newFederation = TestUtils.createStandardMultisigFederation(
         bridgeMainnetConstants.getBtcParams(),
         9
     );
-    private static final Federation oldFederation = TestUtils.createFederation(
+    private static final Federation oldFederation = TestUtils.createStandardMultisigFederation(
         bridgeMainnetConstants.getBtcParams(),
         9
     );
-    private static final Federation oldSegwitFederation = TestUtils.createSegwitFederation(
+    private static final Federation oldSegwitFederation = TestUtils.createP2shP2wshErpFederation(
         bridgeMainnetConstants.getBtcParams(),
         9
     );

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
@@ -26,7 +26,7 @@ class SignerMessageBuilderV1Test {
     void createHSMVersion1Message() {
         NetworkParameters params = RegTestParams.get();
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        final Federation activeFederation = TestUtils.createFederation(bridgeMainNetConstants.getBtcParams(), 9);
+        final Federation activeFederation = TestUtils.createStandardMultisigFederation(bridgeMainNetConstants.getBtcParams(), 9);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -30,6 +30,14 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 
 public final class TestUtils {
+    private static final long CREATION_BLOCK_NUMBER = 0;
+    private static final List<BtcECKey> erpFedPubKeysList = Stream.of(
+        "0257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d4",
+        "03c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f9",
+        "03cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b3",
+        "02370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80"
+    ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
+    private static final long erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
 
     private TestUtils() {
     }
@@ -92,36 +100,54 @@ public final class TestUtils {
         return block;
     }
 
-    public static Federation createFederation(NetworkParameters params, int amountOfMembers) {
-        final long CREATION_BLOCK_NUMBER = 0;
-        List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(amountOfMembers).toList();
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
-
-        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
+    public static Federation createStandardMultisigFederation(NetworkParameters params, int amountOfMembers) {
+        List<BtcECKey> keys = Stream
+            .generate(BtcECKey::new)
+            .limit(amountOfMembers)
+            .toList();
+        return createStandardMultisigFederation(params, keys);
     }
 
-    public static Federation createSegwitFederation(NetworkParameters params, int amountOfMembers) {
-        final long CREATION_BLOCK_NUMBER = 0;
-        List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(amountOfMembers).toList();
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
-        List<BtcECKey> erpFedPubKeysList = Stream.of(
-            "0257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d4",
-            "03c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f9",
-            "03cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b3",
-            "02370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80"
-        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
-        long erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
-
-        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, erpFedPubKeysList, erpFedActivationDelay);
-    }
-
-    public static Federation createFederation(NetworkParameters params, List<BtcECKey> federationPrivatekeys) {
+    public static Federation createStandardMultisigFederation(NetworkParameters params, List<BtcECKey> federationPrivatekeys) {
         final long CREATION_BLOCK_NUMBER = 0;
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPrivatekeys);
-        FederationArgs federationArgs = new FederationArgs(federationMembers, Instant.now(), CREATION_BLOCK_NUMBER, params);
+        FederationArgs federationArgs = new FederationArgs(
+            federationMembers,
+            Instant.now(),
+            CREATION_BLOCK_NUMBER,
+            params
+        );
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
+    }
+
+    public static Federation createP2shErpFederation(NetworkParameters params, int amountOfMembers) {
+        List<BtcECKey> keys = Stream
+            .generate(BtcECKey::new)
+            .limit(amountOfMembers)
+            .toList();
+        return createP2shErpFederation(params, keys);
+    }
+
+    public static Federation createP2shErpFederation(NetworkParameters params, List<BtcECKey> keys) {
+        final long CREATION_BLOCK_NUMBER = 0;
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
+        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
+        return FederationFactory.buildP2shErpFederation(federationArgs, erpFedPubKeysList, erpFedActivationDelay);
+    }
+
+    public static Federation createP2shP2wshErpFederation(NetworkParameters params, int amountOfMembers) {
+        List<BtcECKey> keys = Stream
+            .generate(BtcECKey::new)
+            .limit(amountOfMembers)
+            .toList();
+
+        return createP2shP2wshErpFederation(params, keys);
+    }
+
+    public static Federation createP2shP2wshErpFederation(NetworkParameters params, List<BtcECKey> keys) {
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
+        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
+        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, erpFedPubKeysList, erpFedActivationDelay);
     }
 
     public static List<BtcECKey> getFederationPrivateKeys(long amountOfMembers) {
@@ -187,9 +213,7 @@ public final class TestUtils {
         return btcTx;
     }
 
-    public static Script createBaseInputScriptThatSpendsFromTheFederation(
-        Federation federation
-    ) {
+    public static Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation) {
         return createBaseInputScriptThatSpendsFromTheFederation(federation, null);
     }
 


### PR DESCRIPTION
Part 3 of [RSKIP305](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP305.md) implementation

Relates to https://github.com/rsksmart/rskj/pull/3286

## Description
- Remove signatures from pegout transaction before looking up the hash in `release_requested` event
- When trying to get the current federation, members are queried from the Bridge and different types of federations are built until one matches the federation address obtained from the Bridge.  If one federation type fails to build, capture the exception and try with the next one. If none matches, throw an IllegalStateException. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
