### PR TITLE
Refactor btc to rsk client

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BtcToRskClient implements BlockListener, TransactionListener {
     protected static final int MAXIMUM_REGISTER_BTC_LOCK_TXS_PER_TURN = 40;
+    protected static final int BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK = 100;
 
     private static final Logger logger = LoggerFactory.getLogger(BtcToRskClient.class);
 
@@ -576,7 +577,10 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         logger.debug("[updateBridgeBtcTransactions] Tx to send count: {}", txsToSendToRskHashes.size());
 
         int numberOfTxsSent = 0;
-        for (Sha256Hash txHash : txsToSendToRskHashes) {
+
+        Iterator<Sha256Hash> txHashIterator = txsToSendToRskHashes.iterator();
+        while (txHashIterator.hasNext()) {
+            Sha256Hash txHash = txHashIterator.next();
             try {
                 Transaction tx = federatorWalletTxMap.get(txHash);
                 logger.debug("[updateBridgeBtcTransactions] Evaluating Btc Tx {}", txHash);
@@ -606,23 +610,22 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                         wTxId
                     );
 
-                    int btc2RskMinimumAcceptableConfirmationsOnRsk = 100;
                     // N = height at which transaction was processed
                     // M = current height M
-                    // K = btc2RskMinimumAcceptableConfirmationsOnRsk
+                    // K = BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK
                     // If M >= N + K, then remove the transaction from the list
                     Long txProcessedHeight = federatorSupport.getBtcTxHashProcessedHeight(txId);
                     Long bestChainHeight = federatorSupport.getRskBestChainHeight();
-                    if (bestChainHeight >= txProcessedHeight + btc2RskMinimumAcceptableConfirmationsOnRsk) {
-                        txsToSendToRskHashes.remove(txHash);
+                    if (bestChainHeight >= txProcessedHeight + BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK) {
+                        removeTxHashFromFile(txHashIterator);
                         logger.debug(
                             "[updateBridgeBtcTransactions] Btc Tx {} was processed at height {}, current height is {}. Tx removed from pending lock list",
                             txHash,
                             txProcessedHeight,
                             bestChainHeight
                         );
+                        continue;
                     }
-                    continue;
                 }
 
                 synchronized (this) {
@@ -645,7 +648,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                     }
 
                     if (!shouldSendTx(tx, federationWallet)) {
-                        txsToSendToRskHashes.remove(txHash);
+                        removeTxHashFromFile(txHashIterator);
                         logger.warn(
                             "[updateBridgeBtcTransactions] Removed transaction {} (wtxid: {}) from txs to sent to Bridge",
                             txId,
@@ -671,6 +674,22 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                     txHash,
                     e.getMessage()
                 );
+            }
+        }
+    }
+
+    private void removeTxHashFromFile(Iterator<Sha256Hash> txHashIterator) {
+        txHashIterator.remove();
+        writeToStorage();
+    }
+
+    private void writeToStorage() {
+        synchronized (this) {
+            try {
+                this.btcToRskClientFileStorage.write(this.fileData);
+                logger.debug("[writeToStorage] Persisted fileData to storage.");
+            } catch (IOException e) {
+                logger.error("[writeToStorage] Error {} persisting fileData to storage.", e.getMessage(), e);
             }
         }
     }

--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -1,5 +1,6 @@
 package co.rsk.federate;
 
+import static co.rsk.federate.PegUtils.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -11,15 +12,12 @@ import co.rsk.federate.io.*;
 import co.rsk.federate.timing.TurnScheduler;
 import co.rsk.net.NodeBlockProcessor;
 import co.rsk.peg.BridgeUtils;
-import co.rsk.peg.PegUtilsLegacy;
 import co.rsk.peg.PeginInformation;
 import co.rsk.peg.bitcoin.BitcoinUtils;
-import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.pegininstructions.PeginInstructionsException;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -54,7 +52,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     private BtcLockSenderProvider btcLockSenderProvider;
     private PeginInstructionsProvider peginInstructionsProvider;
     private boolean isUpdateBridgeTimerEnabled;
-    private Federation federation; // Federation on which this client is operating
+    private Federation federationToListen; // Federation on which this client is operating
     private ScheduledExecutorService updateBridgeTimer; // Timer that updates the bridge periodically
     private int amountOfHeadersToSend; // Set amount of headers to inform in a single call
     private BtcToRskClientFileData fileData = new BtcToRskClientFileData();
@@ -73,7 +71,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         BtcToRskClientFileStorage btcToRskClientFileStorage,
         BtcLockSenderProvider btcLockSenderProvider,
         PeginInstructionsProvider peginInstructionsProvider,
-        Federation federation,
+        Federation federationToListen,
         PowpegNodeSystemProperties config
     ) throws Exception {
         this.bitcoinWrapper = bitcoinWrapper;
@@ -83,7 +81,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         this.restoreFileData();
         this.btcLockSenderProvider = btcLockSenderProvider;
         this.peginInstructionsProvider = peginInstructionsProvider;
-        this.federation = federation;
+        this.federationToListen = federationToListen;
         setConfigVariables(config);
     }
 
@@ -103,11 +101,11 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         this.peginInstructionsProvider = peginInstructionsProvider;
         bitcoinWrapper.addBlockListener(this);
         setConfigVariables(config);
- }
+    }
 
     public void start(Federation federation) {
         logger.info("[start] Starting for federation {}", federation.getAddress());
-        this.federation = federation;
+        this.federationToListen = federation;
 
         FederationMember federator = federatorSupport.getFederationMember();
         BtcECKey federatorBtcKey = federator.getBtcPublicKey();
@@ -163,7 +161,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     public void stop() {
         logger.info("[stop] Stopping");
 
-        this.federation = null;
+        this.federationToListen = null;
 
         if (updateBridgeTimer != null) {
             updateBridgeTimer.shutdown();
@@ -176,7 +174,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     }
 
     public void updateBridge() {
-        if (federation == null) {
+        if (federationToListen == null) {
             logger.warn("[updateBridge] updateBridge skipped because no Federation is associated to this BtcToRskClient");
             return;
         }
@@ -186,7 +184,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             return;
         }
 
-        logger.debug("[updateBridge] Updating bridge. Federation {}", federation.getAddress());
+        logger.debug("[updateBridge] Updating bridge. Federation {}", federationToListen.getAddress());
 
         if (shouldUpdateBridgeBtcBlockchain) {
             // Call receiveHeaders
@@ -563,25 +561,26 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
 
     protected void updateBridgeBtcTransactions() {
         logger.debug("[updateBridgeBtcTransactions] Updating btc transactions");
-        Map<Sha256Hash, Transaction> federatorWalletTxMap = bitcoinWrapper.getTransactionMap(
-            bridgeConstants.getBtc2RskMinimumAcceptableConfirmations()
-        );
-        int numberOfTxsSent = 0;
-        Set<Sha256Hash> txsToSendToRskHashes = this.fileData.getTransactionProofs().keySet();
-        logger.debug("[updateBridgeBtcTransactions] Tx count: {}", txsToSendToRskHashes.size());
-
         co.rsk.bitcoinj.core.Context context = co.rsk.bitcoinj.core.Context.getOrCreate(bridgeConstants.getBtcParams());
         co.rsk.bitcoinj.wallet.Wallet federationWallet = BridgeUtils.getFederationNoSpendWallet(
             context,
-            federation,
+            federationToListen,
             false,
             null
         );
 
+        int btcToRskMinimumAcceptableConfirmations = bridgeConstants.getBtc2RskMinimumAcceptableConfirmations();
+        Map<Sha256Hash, Transaction> federatorWalletTxMap = bitcoinWrapper.getTransactionMap(btcToRskMinimumAcceptableConfirmations);
+
+        Set<Sha256Hash> txsToSendToRskHashes = this.fileData.getTransactionProofs().keySet();
+        logger.debug("[updateBridgeBtcTransactions] Tx to send count: {}", txsToSendToRskHashes.size());
+
+        int numberOfTxsSent = 0;
         for (Sha256Hash txHash : txsToSendToRskHashes) {
             try {
                 Transaction tx = federatorWalletTxMap.get(txHash);
                 logger.debug("[updateBridgeBtcTransactions] Evaluating Btc Tx {}", txHash);
+
                 if (tx == null) {
                     logger.debug(
                         "[updateBridgeBtcTransactions] Btc tx {} was not found in wallet or is not yet confirmed.",
@@ -590,141 +589,31 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                     // Don't remove it as we still have to wait for its confirmations.
                     continue;
                 }
+
+                Sha256Hash txId = tx.getTxId();
+                Sha256Hash wTxId = tx.getWTxId();
                 logger.debug(
                     "[updateBridgeBtcTransactions] Got Btc Tx {} (wtxid:{})",
-                    tx.getTxId(),
-                    tx.getWTxId()
+                    txId,
+                    wTxId
                 );
-                BtcTransaction btcTx = ThinConverter.toThinInstance(bridgeConstants.getBtcParams(), tx);
-
-                if (btcTx.getValueSentToMe(federationWallet).isZero()) {
-                    // Remove the tx from the set to be sent to the Bridge since it's not processable
-                    txsToSendToRskHashes.remove(txHash);
-
-                    logger.warn(
-                        "[updateBridgeBtcTransactions] Transaction {} (wtxid: {}) does not have any output to the current federation {}",
-                        btcTx.getHash(),
-                        btcTx.getHash(true),
-                        federation.getAddress()
-                    );
-                    continue;
-                }
-
-                long bestBlockNumber = federatorSupport.getRskBestChainHeight();
-                PeginInformation peginInformation = new PeginInformation(
-                    btcLockSenderProvider,
-                    peginInstructionsProvider,
-                    activationConfig.forBlock(bestBlockNumber)
-                );
-                try {
-                    peginInformation.parse(btcTx);
-                } catch (PeginInstructionsException e) {
-                    String message = String.format(
-                        "Could not get peg-in information for tx %s (wtxid: %s). %s",
-                        btcTx.getHash(),
-                        btcTx.getHash(true),
-                        e.getMessage()
-                    );
-                    logger.debug("[updateBridgeBtcTransactions] {}", message);
-                    // If tx sender could be retrieved then let the Bridge process the tx and refund the sender
-                    if (peginInformation.getSenderBtcAddress() != null) {
-                        logger.debug(
-                            "[updateBridgeBtcTransactions] Funds will be refunded to sender {}",
-                            peginInformation.getSenderBtcAddress()
-                        );
-                    } else {
-                        // Remove the tx from the set to be sent to the Bridge since it's not processable
-                        logger.debug("[updateBridgeBtcTransactions] Tx not processable, removing it from the list");
-                        txsToSendToRskHashes.remove(txHash);
-                        continue;
-                    }
-                }
-
-                // Check if the tx can be processed by the Bridge
-                if (!isTxProcessable(btcTx, peginInformation.getSenderBtcAddressType())) {
-                    logger.warn(
-                        "[updateBridgeBtcTransactions] Transaction hash {} (wtxid: {}) contains a type {} that it is not processable.",
-                        btcTx.getHash(),
-                        btcTx.getHash(true),
-                        peginInformation.getSenderBtcAddressType()
-                    );
-                    txsToSendToRskHashes.remove(txHash);
-                    continue;
-                }
 
                 // Check if the tx was processed (using the tx hash without witness)
-                if (!federatorSupport.isBtcTxHashAlreadyProcessed(tx.getTxId())) {
-                    logger.debug(
-                        "[updateBridgeBtcTransactions] Btc tx {} (wtxid: {}) with enough confirmations and not yet processed",
-                        tx.getTxId(),
-                        tx.getWTxId()
-                    );
-                    synchronized (this) {
-                        List<Proof> proofs = this.fileData.getTransactionProofs().get(txHash);
-                        if (proofs == null || proofs.isEmpty()) {
-                            logger.debug("[updateBridgeBtcTransactions] No proofs found for tx {}", txHash);
-                            continue;
-                        }
-
-                        StoredBlock txStoredBlock = findBestChainStoredBlockFor(tx);
-                        int blockHeight = txStoredBlock.getHeight();
-                        logger.debug(
-                            "[updateBridgeBtcTransactions] Tx {} belongs to block {} at height {}",
-                            txHash,
-                            txStoredBlock.getHeader().getHash(),
-                            blockHeight
-                        );
-                        PartialMerkleTree pmt = null;
-                        for (Proof proof : proofs) {
-                            if (proof.getBlockHash().equals(txStoredBlock.getHeader().getHash())) {
-                                pmt = proof.getPartialMerkleTree();
-                            }
-                        }
-
-                        // Make sure the proof was found
-                        if (pmt == null) {
-                            logger.error(
-                                "[updateBridgeBtcTransactions] Could not find proof that the transaction {} belongs to the block {}",
-                                txHash,
-                                txStoredBlock.getHeader().getHash()
-                            );
-                            continue;
-                        }
-
-                        federatorSupport.sendRegisterBtcTransaction(tx, blockHeight, pmt);
-                        logger.debug(
-                            "[updateBridgeBtcTransactions] Invoked registerBtcTransaction for tx {}",
-                            txHash
-                        );
-
-                        numberOfTxsSent++;
-                        // Sent a maximum of 40 registerBtcTransaction txs per federator
-                        if (numberOfTxsSent >= MAXIMUM_REGISTER_BTC_LOCK_TXS_PER_TURN) {
-                            logger.debug(
-                                "[updateBridgeBtcTransactions] Reached maximum number of txs to send to the Bridge: {}",
-                                MAXIMUM_REGISTER_BTC_LOCK_TXS_PER_TURN
-                            );
-                            break;
-                        }
-                    }
-                    // Tx could be null if having less than the desired amount of confirmations,
-                    // do not clear in that case since we'd leave a tx without processing
-                } else {
+                if (federatorSupport.isBtcTxHashAlreadyProcessed(txId)) {
                     logger.debug(
                         "[updateBridgeBtcTransactions] Btc Tx {} (wtxid: {}) already processed",
-                        tx.getTxId(),
-                        tx.getWTxId()
+                        txId,
+                        wTxId
                     );
-                    // Verify if the transaction was processed (using the tx id without witness)
-                    Long txProcessedHeight = federatorSupport.getBtcTxHashProcessedHeight(tx.getTxId());
-                    Long bestChainHeight = federatorSupport.getRskBestChainHeight();
 
                     int btc2RskMinimumAcceptableConfirmationsOnRsk = 100;
-                    // If the bridge says this transaction was processed at height N, and current height
-                    // is M, with M - N >= K
-                    // with K = btc2RskMinimumAcceptableConfirmationsOnRsk
-                    // then remove the transaction from the list
-                    if ((bestChainHeight - txProcessedHeight) >= btc2RskMinimumAcceptableConfirmationsOnRsk) {
+                    // N = height at which transaction was processed
+                    // M = current height M
+                    // K = btc2RskMinimumAcceptableConfirmationsOnRsk
+                    // If M >= N + K, then remove the transaction from the list
+                    Long txProcessedHeight = federatorSupport.getBtcTxHashProcessedHeight(txId);
+                    Long bestChainHeight = federatorSupport.getRskBestChainHeight();
+                    if (bestChainHeight >= txProcessedHeight + btc2RskMinimumAcceptableConfirmationsOnRsk) {
                         txsToSendToRskHashes.remove(txHash);
                         logger.debug(
                             "[updateBridgeBtcTransactions] Btc Tx {} was processed at height {}, current height is {}. Tx removed from pending lock list",
@@ -732,6 +621,48 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                             txProcessedHeight,
                             bestChainHeight
                         );
+                    }
+                    continue;
+                }
+
+                synchronized (this) {
+                    // validate tx proofs, stored block and pmt are found
+                    Optional<List<Proof>> txProofs = getTxProofs(tx);
+                    if (txProofs.isEmpty()) {
+                        logger.debug("[updateBridgeBtcTransactions] Couldn't find proof for tx {}", txHash);
+                        continue;
+                    }
+                    Optional<StoredBlock> txStoredBlockOpt = getStoredBlock(tx);
+                    if (txStoredBlockOpt.isEmpty()) {
+                        logger.debug("[updateBridgeBtcTransactions] Couldn't find stored block for tx {}", txHash);
+                        continue;
+                    }
+                    StoredBlock txStoredBlock = txStoredBlockOpt.get();
+                    Optional<PartialMerkleTree> pmt = getPMT(txProofs.get(), txStoredBlock);
+                    if (pmt.isEmpty()) {
+                        logger.debug("[updateBridgeBtcTransactions] Couldn't find pmt for tx {}", txHash);
+                        continue;
+                    }
+
+                    if (!shouldSendTx(tx, federationWallet)) {
+                        txsToSendToRskHashes.remove(txHash);
+                        logger.warn(
+                            "[updateBridgeBtcTransactions] Removed transaction {} (wtxid: {}) from txs to sent to Bridge",
+                            txId,
+                            wTxId
+                        );
+                        continue;
+                    }
+
+                    sendTx(tx, txStoredBlock, pmt.get());
+                    numberOfTxsSent++;
+                    // Sent a maximum of 40 registerBtcTransaction txs per federator
+                    if (numberOfTxsSent >= MAXIMUM_REGISTER_BTC_LOCK_TXS_PER_TURN) {
+                        logger.debug(
+                            "[updateBridgeBtcTransactions] Reached maximum number of txs to send to the Bridge: {}",
+                            MAXIMUM_REGISTER_BTC_LOCK_TXS_PER_TURN
+                        );
+                        break;
                     }
                 }
             } catch (Exception e) {
@@ -742,6 +673,92 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                 );
             }
         }
+    }
+
+    private Optional<List<Proof>> getTxProofs(Transaction tx) {
+        Map<Sha256Hash, List<Proof>> proofs = this.fileData.getTransactionProofs();
+
+        Sha256Hash txHash = tx.getWTxId();
+        return Optional.ofNullable(proofs.get(txHash))
+            .filter(txProofs -> !txProofs.isEmpty());
+    }
+
+    private Optional<StoredBlock> getStoredBlock(Transaction tx) {
+        try {
+            return Optional.of(findBestChainStoredBlockFor(tx));
+        } catch (BlockStoreException | IllegalStateException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<PartialMerkleTree> getPMT(List<Proof> txProofs, StoredBlock txStoredBlock) {
+        Sha256Hash blockHash = txStoredBlock.getHeader().getHash();
+
+        return txProofs.stream()
+            .filter(proof -> proof.getBlockHash().equals(blockHash))
+            .findFirst()
+            .map(Proof::getPartialMerkleTree);
+    }
+
+    private boolean shouldSendTx(Transaction tx, co.rsk.bitcoinj.wallet.Wallet federationWallet) {
+        logger.debug("[shouldSendTx] Checking if tx should be send {}", tx.getWTxId());
+        BtcTransaction btcTx = ThinConverter.toThinInstance(federationWallet.getNetworkParameters(), tx);
+
+        co.rsk.bitcoinj.core.Coin valueSentToMe = btcTx.getValueSentToMe(federationWallet);
+        if (valueSentToMe.isZero()) {
+            return false;
+        }
+
+        long bestBlockNumber = federatorSupport.getRskBestChainHeight();
+        ActivationConfig.ForBlock activations = activationConfig.forBlock(bestBlockNumber);
+        PeginInformation peginInformation = new PeginInformation(
+            btcLockSenderProvider,
+            peginInstructionsProvider,
+            activations
+        );
+
+        FederationProviderFromFederatorSupport federationProviderFromFederatorSupport = new FederationProviderFromFederatorSupport(
+            federatorSupport,
+            bridgeConstants.getFederationConstants()
+        );
+
+        Optional<Federation> proposedFederation = federationProviderFromFederatorSupport.getProposedFederation();
+        Optional<Federation> retiringFederation = federationProviderFromFederatorSupport.getRetiringFederation();
+        Federation activeFederation = federationProviderFromFederatorSupport.getActiveFederation();
+
+        if (proposedFederation.isPresent() && isSVPSpendTx(btcTx, proposedFederation.get(), activeFederation)) {
+            return true;
+        }
+        if (retiringFederation.isPresent() && isMigrationTx(btcTx, retiringFederation.get(), activeFederation)) {
+            return true;
+        }
+        if (isPegOutTx(btcTx, federationToListen)) {
+            return true;
+        }
+        return PegUtils.isValidPegInTx(btcTx, federationWallet, peginInformation);
+    }
+
+    private void sendTx(Transaction tx, StoredBlock txStoredBlock, PartialMerkleTree pmt) {
+        logger.debug(
+            "[sendTx] Will send btc tx {} (wtxid: {}) with enough confirmations",
+            tx.getTxId(),
+            tx.getWTxId()
+        );
+
+        Sha256Hash txHash = tx.getWTxId();
+        int blockHeight = txStoredBlock.getHeight();
+        logger.debug(
+            "[sendTx] Tx {} belongs to block {} at height {}",
+            txHash,
+            txStoredBlock.getHeader().getHash(),
+            blockHeight
+        );
+
+        federatorSupport.sendRegisterBtcTransaction(tx, blockHeight, pmt);
+        logger.debug(
+            "[sendTx] Invoked registerBtcTransaction for tx {}",
+            txHash
+        );
     }
 
     /**
@@ -820,8 +837,8 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     public void tearDown() throws IOException {
         logger.info("[tearDown] BtcToRskClient tearDown starting...");
 
-        if (federation != null) {
-            bitcoinWrapper.removeFederationListener(federation, this);
+        if (federationToListen != null) {
+            bitcoinWrapper.removeFederationListener(federationToListen, this);
         }
 
         bitcoinWrapper.removeBlockListener(this);
@@ -851,16 +868,6 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                 throw new Exception("Failed to read data from BtcToRskClient file", e);
             }
         }
-    }
-
-    private boolean isTxProcessable(BtcTransaction btcTx, TxSenderAddressType txSenderAddressType) {
-        long bestBlockNumber = federatorSupport.getRskBestChainHeight();
-
-        // If the tx is a peg-out it means we are receiving change (or migrating funds)
-        // so it should be processable
-        return PegUtilsLegacy.isPegOutTx(btcTx, Collections.singletonList(federation), activationConfig.forBlock(bestBlockNumber))
-            || activationConfig.isActive(ConsensusRule.RSKIP170, bestBlockNumber)
-            || BridgeUtils.txIsProcessableInLegacyVersion(txSenderAddressType, activationConfig.forBlock(bestBlockNumber));
     }
 
     @VisibleForTesting

--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -285,7 +285,7 @@ public class FedNodeRunner implements NodeRunner {
             BtcLockSenderProvider btcLockSenderProvider = new BtcLockSenderProvider();
             PeginInstructionsProvider peginInstructionsProvider = new PeginInstructionsProvider();
             btcToRskClientFileStorage = new BtcToRskClientFileStorageImpl(new BtcToRskClientFileStorageInfo(config));
-            bitcoinWrapper = createAndSetupBitcoinWrapper(btcLockSenderProvider, peginInstructionsProvider);
+            bitcoinWrapper = createAndSetupBitcoinWrapper();
 
             btcToRskClientActive.setup(
                 bitcoinWrapper,
@@ -330,12 +330,12 @@ public class FedNodeRunner implements NodeRunner {
                     )
                 )
             );
-            
+
             FederationWatcherListener federationWatcherListener = new FederationWatcherListenerImpl(
                 btcToRskClientActive,
                 btcToRskClientRetiring,
-                btcReleaseClient,
-                bitcoinWrapper);
+                btcReleaseClient
+            );
 
             federationWatcher.start(federationProvider, federationWatcherListener);
         }
@@ -380,20 +380,14 @@ public class FedNodeRunner implements NodeRunner {
         logger.info("[stop] Federation node Shut down.");
     }
 
-    private BitcoinWrapper createAndSetupBitcoinWrapper(
-        BtcLockSenderProvider btcLockSenderProvider,
-        PeginInstructionsProvider peginInstructionsProvider) throws UnknownHostException {
-
+    private BitcoinWrapper createAndSetupBitcoinWrapper() throws UnknownHostException {
+        final String BTC_TO_RSK_CLIENT_FILE_PREFIX = "BtcToRskClient";
         Context btcContext = new Context(ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString()));
         File pegDirectory = new File(this.btcToRskClientFileStorage.getInfo().getPegDirectoryPath());
-        Kit kit = new Kit(btcContext, pegDirectory, "BtcToRskClient");
+        Kit kit = new Kit(btcContext, pegDirectory, BTC_TO_RSK_CLIENT_FILE_PREFIX);
 
         BitcoinWrapper wrapper = new BitcoinWrapperImpl(
             btcContext,
-            bridgeConstants,
-            btcLockSenderProvider,
-            peginInstructionsProvider,
-            federatorSupport,
             kit
         );
         wrapper.setup(federatorSupport.getBitcoinPeerAddresses());

--- a/src/main/java/co/rsk/federate/PegUtils.java
+++ b/src/main/java/co/rsk/federate/PegUtils.java
@@ -1,0 +1,175 @@
+package co.rsk.federate;
+
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.script.*;
+import co.rsk.bitcoinj.wallet.Wallet;
+import co.rsk.peg.PeginInformation;
+import co.rsk.peg.bitcoin.BitcoinUtils;
+import co.rsk.peg.btcLockSender.BtcLockSender;
+import co.rsk.peg.federation.ErpFederation;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.pegininstructions.PeginInstructionsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class PegUtils {
+    public static final Coin MINIMUM_PEGIN_TX_VALUE = Coin.valueOf(500_000);
+    private static final Logger logger = LoggerFactory.getLogger(PegUtils.class);
+
+    private PegUtils() {}
+
+    public static boolean isSVPSpendTx(
+        BtcTransaction btcTx,
+        Federation proposedFederation,
+        Federation activeFederation
+    ) {
+        int svpSpendTxInputsCount = 2;
+        if (btcTx.getInputs().size() != svpSpendTxInputsCount) {
+            return false;
+        }
+        if (btcTx.countWitnesses() != svpSpendTxInputsCount) {
+            return false;
+        }
+
+        int svpSpendTxOutputsCount = 1;
+        if (btcTx.getOutputs().size() != svpSpendTxOutputsCount) {
+            return false;
+        }
+
+        Script defaultProposedFederationP2SHScript = getFederationStandardP2SHScript(proposedFederation);
+        int proposedFedInputIndex = 0;
+        int flyoverProposedFedInputIndex = 1;
+
+        int activeFedOutputIndex = 0;
+        Script activeFedScript = activeFederation.getP2SHScript();
+
+        return isInputFromScript(defaultProposedFederationP2SHScript, btcTx, proposedFedInputIndex)
+            && isInputFromScript(defaultProposedFederationP2SHScript, btcTx, flyoverProposedFedInputIndex)
+            && isOutputToScript(activeFedScript, btcTx.getOutput(activeFedOutputIndex));
+    }
+
+    public static boolean isMigrationTx(
+        BtcTransaction btcTx,
+        Federation retiringFederation,
+        Federation activeFederation
+    ) {
+        boolean moveFromRetiring = isPegOutTx(btcTx, retiringFederation);
+        boolean moveToActive = allTxOutputsAreToFed(btcTx, activeFederation);
+
+        return moveFromRetiring && moveToActive;
+    }
+
+    public static boolean isPegOutTx(BtcTransaction btcTx, Federation activeFederation) {
+        Script fedStandardP2SHScript = getFederationStandardP2SHScript(activeFederation);
+        int inputsSize = btcTx.getInputs().size();
+        for (int i = 0; i < inputsSize; i++) {
+            if (isInputFromScript(fedStandardP2SHScript, btcTx, i)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isInputFromScript(Script expectedSpendingScript, BtcTransaction btcTx, int inputIndex) {
+        Optional<Script> redeemScriptOptional = BitcoinUtils.extractRedeemScriptFromInput(btcTx, inputIndex);
+        if (redeemScriptOptional.isEmpty()) {
+            return false;
+        }
+
+        List<ScriptChunk> redeemScriptChunks = redeemScriptOptional.get().getChunks();
+        // Extract standard redeem script chunks since the registered utxo could be from a fast bridge or erp federation
+        try {
+            RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScriptChunks);
+            redeemScriptChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
+        } catch (ScriptException e) {
+            logger.debug("[isPegOutTx] There is no redeem script", e);
+            return false;
+        }
+
+        Script redeemScript = new ScriptBuilder().addChunks(redeemScriptChunks).build();
+        Script p2shOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+        Script p2wshOutputScript = ScriptBuilder.createP2SHP2WSHOutputScript(redeemScript);
+        return expectedSpendingScript.equals(p2shOutputScript) || expectedSpendingScript.equals(p2wshOutputScript);
+    }
+
+    private static Script getFederationStandardP2SHScript(Federation federation) {
+        if (!(federation instanceof ErpFederation)) {
+            return federation.getP2SHScript();
+        }
+
+        return ((ErpFederation) federation).getDefaultP2SHScript();
+    }
+
+    private static boolean allTxOutputsAreToFed(BtcTransaction btcTx, Federation federation) {
+        for (TransactionOutput output : btcTx.getOutputs()) {
+            if (!isOutputToScript(federation.getP2SHScript(), output)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isOutputToScript(Script expectedOutputScript, TransactionOutput output) {
+        Script txOutputScript = output.getScriptPubKey();
+        return expectedOutputScript.equals(txOutputScript);
+    }
+
+    public static boolean isValidPegInTx(BtcTransaction btcTx, Wallet federationWallet, PeginInformation peginInformation) {
+        boolean isAnyValueSentBelowMinimumPeginValue = !allUTXOsToFedAreAboveMinimumPeginValue(
+            btcTx,
+            federationWallet
+        );
+        if (isAnyValueSentBelowMinimumPeginValue) {
+            return false;
+        }
+
+        return isPegInTx(btcTx, peginInformation);
+    }
+
+    private static boolean allUTXOsToFedAreAboveMinimumPeginValue(
+        BtcTransaction btcTx,
+        Wallet fedWallet
+    ) {
+        List<co.rsk.bitcoinj.core.TransactionOutput> fedUtxos = btcTx.getWalletOutputs(fedWallet);
+        if (fedUtxos.isEmpty()) {
+            return false;
+        }
+
+        return fedUtxos.stream().allMatch(transactionOutput ->
+            transactionOutput.getValue().compareTo(PegUtils.MINIMUM_PEGIN_TX_VALUE) >= 0
+        );
+    }
+
+    private static boolean isPegInTx(BtcTransaction btcTx, PeginInformation peginInformation) {
+        try {
+            peginInformation.parse(btcTx);
+        } catch (PeginInstructionsException e) {
+            // pegin instructions exception is only being thrown when a pegin has an INVALID op return output structure
+            // meaning if there's NO op return found, or the protocol version is unknown, it won't throw.
+            co.rsk.bitcoinj.core.Address refundAddress = peginInformation.getSenderBtcAddress();
+            // if there's a refund address, i.e., refundAddress is not null, tx should be sent
+            return refundAddress != null;
+        }
+
+        // at this point, tx could be a legacy pegin or a pegin with instructions with valid op return structure
+        if (isLegacyPegin(peginInformation)) {
+            // if there's a valid lock sender, i.e., sender address type is not UNKNOWN, tx should be sent
+            return peginInformation.getSenderBtcAddressType() != BtcLockSender.TxSenderAddressType.UNKNOWN;
+        }
+
+        // at this point, tx is a pegin with instructions with valid structure,
+        // but we just want to send it if the protocol version is valid
+        return isPeginWithInstructionsProtocolVersionValid(peginInformation);
+    }
+
+    private static boolean isLegacyPegin(PeginInformation peginInformation) {
+        return peginInformation.getProtocolVersion() == 0;
+    }
+
+    private static boolean isPeginWithInstructionsProtocolVersionValid(PeginInformation peginInformation) {
+        return peginInformation.getProtocolVersion() == 1;
+    }
+}

--- a/src/main/java/co/rsk/federate/adapter/ThinConverter.java
+++ b/src/main/java/co/rsk/federate/adapter/ThinConverter.java
@@ -8,9 +8,6 @@ import co.rsk.peg.constants.BridgeConstants;
 
 import java.nio.ByteBuffer;
 
-/**
- * Created by oscar on 03/05/2017.
- */
 public class ThinConverter {
 
     private ThinConverter() {
@@ -64,10 +61,10 @@ public class ThinConverter {
         }
 
         return new Context(
-                NetworkParameters.fromID(context.getParams().getId()),
-                context.getEventHorizon(),
-                Coin.valueOf(context.getFeePerKb().getValue()),
-                context.isEnsureMinRequiredFee()
+            NetworkParameters.fromID(context.getParams().getId()),
+            context.getEventHorizon(),
+            Coin.valueOf(context.getFeePerKb().getValue()),
+            context.isEnsureMinRequiredFee()
         );
     }
 }

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -2,15 +2,9 @@ package co.rsk.federate.bitcoin;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.wallet.Wallet;
-import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.adapter.ThinConverter;
 import co.rsk.peg.*;
-import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
-import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.Federation;
-import co.rsk.peg.pegininstructions.PeginInstructionsException;
-import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
-import co.rsk.util.MaxSizeHashMap;
 import java.util.*;
 import org.bitcoinj.core.*;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
@@ -21,7 +15,6 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
-import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,42 +33,25 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
         }
     }
 
-    private static final int MAX_SIZE_MAP_STORED_BLOCKS = 10_000;
     private static final Logger logger = LoggerFactory.getLogger(BitcoinWrapperImpl.class);
 
     private final Context btcContext;
-    private final BridgeConstants bridgeConstants;
     private final List<FederationListener> watchedFederations;
     private final List<BlockListener> blockListeners;
     private final Collection<NewBestBlockListener> newBestBlockListeners;
 
-    private final Map<Sha256Hash, StoredBlock> knownBlocks = new MaxSizeHashMap<>(
-        MAX_SIZE_MAP_STORED_BLOCKS,
-        true
-    );
-    private final BtcLockSenderProvider btcLockSenderProvider;
-    private final PeginInstructionsProvider peginInstructionsProvider;
-    private final FederatorSupport federatorSupport;
     private final Kit kit;
 
     private boolean running = false;
 
     public BitcoinWrapperImpl(
         Context btcContext,
-        BridgeConstants bridgeConstants,
-        BtcLockSenderProvider btcLockSenderProvider,
-        PeginInstructionsProvider peginInstructionsProvider,
-        FederatorSupport federatorSupport,
-        Kit kit) {
-
+        Kit kit
+    ) {
         this.btcContext = btcContext;
-        this.bridgeConstants = bridgeConstants;
         this.blockListeners = new LinkedList<>();
         this.watchedFederations = new LinkedList<>();
         this.newBestBlockListeners = new LinkedList<>();
-        this.btcLockSenderProvider = btcLockSenderProvider;
-        this.peginInstructionsProvider = peginInstructionsProvider;
-        this.federatorSupport = federatorSupport;
         this.kit = kit;
     }
 
@@ -164,12 +140,10 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
             if (blockHash == null) {
                 return null;
             }
-            StoredBlock currentBlock = knownBlocks.get(blockHash);
-            if(currentBlock == null) {
-                currentBlock = blockStore.get(blockHash);
-                if (currentBlock == null) {
-                    return null;
-                }
+
+            StoredBlock currentBlock = blockStore.get(blockHash);
+            if (currentBlock == null) {
+                return null;
             }
             blockHash = currentBlock.getHeader().getPrevBlockHash();
         }
@@ -177,10 +151,7 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
         if (blockHash == null) {
             return null;
         }
-        StoredBlock block = knownBlocks.get(blockHash);
-        if(block == null) {
-            block = blockStore.get(blockHash);
-        }
+        StoredBlock block = blockStore.get(blockHash);
 
         if (block != null && block.getHeight() != height) {
             String message = String.format(
@@ -361,10 +332,8 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
         Context.propagate(btcContext);
 
         // Wrap tx in a co.rsk.bitcoinj.core.BtcTransaction
-        BtcTransaction btcTx = ThinConverter.toThinInstance(bridgeConstants.getBtcParams(), tx);
         co.rsk.bitcoinj.core.Context btcContextThin = ThinConverter.toThinInstance(btcContext);
-
-        ActivationConfig.ForBlock activations = federatorSupport.getConfigForBestBlock();
+        BtcTransaction btcTx = ThinConverter.toThinInstance(btcContextThin.getParams(), tx);
 
         for (FederationListener watched : watchedFederations) {
             Federation watchedFederation = watched.federation();
@@ -377,53 +346,11 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
                 watchedFederation.getAddress()
             );
 
-            if (PegUtilsLegacy.isValidPegInTx(
-                btcTx,
-                watchedFederation,
-                watchedFederationWallet,
-                bridgeConstants,
-                activations
-            )) {
-                PeginInformation peginInformation = new PeginInformation(
-                    btcLockSenderProvider,
-                    peginInstructionsProvider,
-                    activations
-                );
-
-                try {
-                    peginInformation.parse(btcTx);
-                } catch (PeginInstructionsException e) {
-                    logger.debug(
-                        "[coinsReceivedOrSent] [btctx: {} (wtxid: {})] failed to parse peg-in information",
-                        tx.getTxId(),
-                        tx.getWTxId(),
-                        e
-                    );
-                    // If tx sender could be retrieved then let the Bridge process the tx and refund the sender
-                    if (peginInformation.getSenderBtcAddress() != null) {
-                        logger.debug(
-                            "[coinsReceivedOrSent] [btctx: {} (wtxid: {})] is not a valid peg-in tx, funds will be refunded to sender",
-                            tx.getTxId(),
-                            tx.getWTxId()
-                        );
-                    } else {
-                        logger.debug(
-                            "[coinsReceivedOrSent] [btctx: {} (wtxid: {})] is not a valid peg-in tx and won't be processed",
-                            tx.getTxId(),
-                            tx.getWTxId()
-                        );
-                        continue;
-                    }
-                }
-
-                logger.debug("[coinsReceivedOrSent] [btctx: {} (wtxid: {})] is a peg-in", tx.getTxId(), tx.getWTxId());
-                listener.onTransaction(tx);
+            co.rsk.bitcoinj.core.Coin valueSentToMe = btcTx.getValueSentToMe(watchedFederationWallet);
+            if (valueSentToMe.isZero()) {
+                continue;
             }
-
-            if (PegUtilsLegacy.isPegOutTx(btcTx, Collections.singletonList(watchedFederation), activations)) {
-                logger.debug("[coinsReceivedOrSent] [btctx: {} (wtxid: {})] is a peg-out", tx.getTxId(), tx.getWTxId());
-                listener.onTransaction(tx);
-            }
+            listener.onTransaction(tx);
         }
     }
 }

--- a/src/main/java/co/rsk/federate/bitcoin/Kit.java
+++ b/src/main/java/co/rsk/federate/bitcoin/Kit.java
@@ -8,7 +8,6 @@ import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.LevelDBBlockStore;
-import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 import org.ethereum.util.FileUtil;
@@ -17,13 +16,13 @@ import org.slf4j.LoggerFactory;
 
 public class Kit extends WalletAppKit {
 
-    private Context btcContext;
+    private static final Logger logger = LoggerFactory.getLogger(Kit.class);
+
+    private final Context btcContext;
     private BlocksDownloadedEventListener blockListener;
     private WalletCoinsReceivedEventListener coinsReceivedListener;
     private WalletCoinsSentEventListener coinsSentListener;
     private NewBestBlockListener newBestBlockListener;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Kit.class);
 
     public Kit(Context btcContext, File directory, String filePrefix) {
         super(btcContext.getParams(), directory, filePrefix, 1514764800);
@@ -35,7 +34,8 @@ public class Kit extends WalletAppKit {
         BlocksDownloadedEventListener blockListener,
         WalletCoinsReceivedEventListener coinsReceivedListener,
         WalletCoinsSentEventListener coinsSentListener,
-        NewBestBlockListener newBestBlockListener) {
+        NewBestBlockListener newBestBlockListener
+    ) {
 
         this.blockListener = blockListener;
         this.coinsReceivedListener = coinsReceivedListener;
@@ -45,22 +45,17 @@ public class Kit extends WalletAppKit {
 
     @Override
     protected void onSetupCompleted() {
-        LOGGER.debug("[onSetupCompleted] Setup completed");
+        logger.debug("[onSetupCompleted] Setup completed");
         Context.propagate(btcContext);
         vPeerGroup.addBlocksDownloadedEventListener(blockListener);
         if(!vWallet.isConsistent()) {
-            LOGGER.warn("[onSetupCompleted] Wallet database is in an inconsistent state, starting to reset it");
+            logger.warn("[onSetupCompleted] Wallet database is in an inconsistent state, starting to reset it");
             vWallet.reset();
         }
         vWallet.addCoinsReceivedEventListener(coinsReceivedListener);
         vWallet.addCoinsSentEventListener(coinsSentListener);
         vPeerGroup.setDownloadTxDependencies(0);
         vChain.addNewBestBlockListener(newBestBlockListener);
-    }
-
-    @Override
-    protected Wallet createWallet() {
-        return super.createWallet();
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/watcher/FederationWatcherListenerImpl.java
+++ b/src/main/java/co/rsk/federate/watcher/FederationWatcherListenerImpl.java
@@ -1,7 +1,6 @@
 package co.rsk.federate.watcher;
 
 import co.rsk.federate.BtcToRskClient;
-import co.rsk.federate.bitcoin.BitcoinWrapper;
 import co.rsk.federate.btcreleaseclient.BtcReleaseClient;
 import co.rsk.peg.federation.Federation;
 import org.slf4j.Logger;
@@ -11,21 +10,19 @@ import java.util.Objects;
 public class FederationWatcherListenerImpl implements FederationWatcherListener {
 
     private static final Logger logger = LoggerFactory.getLogger(FederationWatcherListenerImpl.class);
-    
+
     private final BtcToRskClient btcToRskClientActive;
     private final BtcToRskClient btcToRskClientRetiring;
     private final BtcReleaseClient btcReleaseClient;
-    private final BitcoinWrapper bitcoinWrapper;
 
     public FederationWatcherListenerImpl(
-            BtcToRskClient btcToRskClientActive,
-            BtcToRskClient btcToRskClientRetiring,
-            BtcReleaseClient btcReleaseClient,
-            BitcoinWrapper bitcoinWrapper) {
+        BtcToRskClient btcToRskClientActive,
+        BtcToRskClient btcToRskClientRetiring,
+        BtcReleaseClient btcReleaseClient
+    ) {
         this.btcToRskClientActive = btcToRskClientActive;
         this.btcToRskClientRetiring = btcToRskClientRetiring;
         this.btcReleaseClient = btcReleaseClient;
-        this.bitcoinWrapper = bitcoinWrapper;
     }
 
     @Override
@@ -52,14 +49,10 @@ public class FederationWatcherListenerImpl implements FederationWatcherListener 
         }
 
         try {
-            // start {@code BtcReleaseClient} with proposed federation
+            // start {@code BtcReleaseClient} with proposed federation,
             // so it can sign svp spend tx
             btcReleaseClient.start(newProposedFederation);
 
-            // add proposed federation to active btc to rsk client so
-            // it can register svp spend tx in the bridge
-            bitcoinWrapper.addFederationListener(newProposedFederation, btcToRskClientActive);
-          
             logger.info(
                 "[onProposedFederationChange] Clients for proposed federation [{}] started with success",
                 newProposedFederation.getAddress());
@@ -74,7 +67,7 @@ public class FederationWatcherListenerImpl implements FederationWatcherListener 
     private void triggerClientChange(BtcToRskClient btcToRskClient, Federation newFederation) {
         // This method assumes that the new federation cannot be null
         Objects.requireNonNull(newFederation);
-      
+
         try {
             // Stop the current clients
             btcToRskClient.stop();
@@ -94,7 +87,7 @@ public class FederationWatcherListenerImpl implements FederationWatcherListener 
                 e);
         }
     }
-    
+
     private void clearRetiringFederationClient() {
         logger.info("[triggerClientChange] Clearing retiring federation client");
 

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -1,26 +1,23 @@
 package co.rsk.federate;
 
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
+import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static java.util.Objects.nonNull;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.crypto.TransactionSignature;
-import co.rsk.bitcoinj.params.RegTestParams;
-import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.cli.CliArgs;
 import co.rsk.config.*;
 import co.rsk.federate.adapter.ThinConverter;
-import co.rsk.federate.bitcoin.BitcoinWrapper;
-import co.rsk.federate.bitcoin.BitcoinWrapperImpl;
+import co.rsk.federate.bitcoin.*;
 import co.rsk.federate.config.PowpegNodeSystemProperties;
 import co.rsk.federate.io.*;
 import co.rsk.federate.mock.*;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.net.NodeBlockProcessor;
-import co.rsk.peg.PegUtilsLegacy;
 import co.rsk.peg.btcLockSender.*;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.constants.BridgeConstants;
@@ -30,55 +27,64 @@ import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
-import com.google.common.collect.Lists;
+
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
+
+import com.google.common.collect.Lists;
 import org.bitcoinj.core.*;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.wallet.Wallet;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.internal.util.MockUtil;
 import org.spongycastle.util.encoders.Hex;
 
-/**
- * Created by ajlopez on 6/1/2016.
- */
 class BtcToRskClientTest {
-    private static final Sha256Hash WITNESS_RESERVED_VALUE = Sha256Hash.ZERO_HASH;
-    private static final int WITNESS_COMMITMENT_LENGTH = 36; // 4 bytes for header, 32 for hash
+    private static final BridgeConstants BRIDGE_MAINNET_CONSTANTS = BridgeMainNetConstants.getInstance();
+    private static final String MAINNET_BTC_PARAMS_STRING = BRIDGE_MAINNET_CONSTANTS.getBtcParamsString();
+    private static final co.rsk.bitcoinj.core.NetworkParameters MAINNET_BTC_PARAMS = BRIDGE_MAINNET_CONSTANTS.getBtcParams();
+
     private int nhash = 0;
     private ActivationConfig activationConfig;
     private BridgeConstants bridgeRegTestConstants;
     private Federation activeFederation;
     private FederationMember activeFederationMember;
     private BtcToRskClientBuilder btcToRskClientBuilder;
-    private List<BtcECKey> federationPrivateKeys;
     private NetworkParameters networkParameters;
     private ForBlock activationsForBlock;
+    private SimpleFederatorSupport federatorSupport;
 
     @BeforeEach
     void setup() throws PeginInstructionsException, IOException {
-        activationConfig = mock(ActivationConfig.class);
-        when(activationConfig.isActive(eq(ConsensusRule.RSKIP89), anyLong())).thenReturn(true);
-        when(activationConfig.isActive(eq(ConsensusRule.RSKIP460), anyLong())).thenReturn(true);
-
         activationsForBlock = mock(ForBlock.class);
+        when(activationsForBlock.isActive(any(ConsensusRule.class))).thenReturn(true);
+
+        activationConfig = mock(ActivationConfig.class);
+        when(activationConfig.isActive(any(ConsensusRule.class), anyLong())).thenReturn(true);
         when(activationConfig.forBlock(anyLong())).thenReturn(activationsForBlock);
-        when(activationsForBlock.isActive(ConsensusRule.RSKIP89)).thenReturn(true);
-        when(activationsForBlock.isActive(ConsensusRule.RSKIP460)).thenReturn(true);
 
         bridgeRegTestConstants = new BridgeRegTestConstants();
         networkParameters = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString());
-        federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
-        activeFederation = TestUtils.createStandardMultisigFederation(bridgeRegTestConstants.getBtcParams(), federationPrivateKeys);
+        List<BtcECKey> federationPrivateKeys = TestUtils.getFederationPrivateKeys(9);
+        activeFederation = TestUtils.createP2shP2wshErpFederation(bridgeRegTestConstants, federationPrivateKeys);
         activeFederationMember = FederationMember.getFederationMemberFromKey(federationPrivateKeys.get(0));
         btcToRskClientBuilder = BtcToRskClientBuilder.builder();
+
+        federatorSupport = new SimpleFederatorSupport();
+        federatorSupport.setFederation(activeFederation);
+        co.rsk.bitcoinj.core.Context.propagate(new co.rsk.bitcoinj.core.Context(bridgeRegTestConstants.getBtcParams()));
     }
 
     @Test
@@ -791,7 +797,6 @@ class BtcToRskClientTest {
         SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         federatorSupport.setBtcBlockchainBestChainHeight(1);
         federatorSupport.setBtcBlockchainBlockLocator(createLocator(blocks, 1, 0));
 
@@ -1009,7 +1014,6 @@ class BtcToRskClientTest {
     @Test
     void updateNoTransaction() throws Exception {
         SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
 
         BtcToRskClient client = createClientWithMocks(bitcoinWrapper, federatorSupport);
 
@@ -1027,7 +1031,6 @@ class BtcToRskClientTest {
         Set<Transaction> txs = new HashSet<>();
         txs.add(createTransaction());
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
         bitcoinWrapper.setTransactions(txs);
 
@@ -1048,7 +1051,6 @@ class BtcToRskClientTest {
         Set<Transaction> txs = new HashSet<>();
         txs.add(tx);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
         bitcoinWrapper.setTransactions(txs);
 
@@ -1082,7 +1084,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -1141,7 +1142,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -1215,7 +1215,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -1289,7 +1288,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -1347,7 +1345,6 @@ class BtcToRskClientTest {
 
         Block block = createBlock(blocks[3].getHeader().getHash(), txs.toArray(new Transaction[]{}));
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -1408,7 +1405,8 @@ class BtcToRskClientTest {
             // The block in the fork
             Block block2 = createBlock(forkedBlock.getHeader().getHash(), tx);
 
-            SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
+            federatorSupport = new SimpleFederatorSupport();
+            federatorSupport.setFederation(activeFederation);
             BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
             BtcToRskClient client = btcToRskClientBuilder
@@ -1480,8 +1478,6 @@ class BtcToRskClientTest {
         // The block in the fork
         Block block2 = createBlock(forkedBlock.getHeader().getHash(), tx);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-
         BtcToRskClient client = createClientWithMocks(bitcoinWrapper, federatorSupport);
 
         client.onTransaction(tx);
@@ -1513,8 +1509,6 @@ class BtcToRskClientTest {
         SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
 
         BtcToRskClient client = btcToRskClientBuilder
             .withBitcoinWrapper(bitcoinWrapper)
@@ -1551,18 +1545,10 @@ class BtcToRskClientTest {
         SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2SHMULTISIG);
 
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP143);
-
         BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
+            .withActivationConfig(activationConfig)
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
@@ -1605,17 +1591,10 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2SHP2WPKH);
 
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP143);
-
         BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
+            .withActivationConfig(activationConfig)
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
@@ -1642,309 +1621,6 @@ class BtcToRskClientTest {
     }
 
     @Test
-    void updateTransactionWithMultisig_before_rskip143() throws Exception {
-        SimpleBtcTransaction tx = (SimpleBtcTransaction)createTransaction();
-        Set<Transaction> txs = new HashSet<>();
-        txs.add(tx);
-
-        StoredBlock[] blocks = createBlockchain(4);
-        Block blockWithTx = createBlock(blocks[3].getHeader().getHash(), tx);
-
-        Map<Sha256Hash, Integer> appears = new HashMap<>();
-        appears.put(blockWithTx.getHash(), 1);
-        tx.setAppearsInHashes(appears);
-
-        SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
-        bitcoinWrapper.setTransactions(txs);
-        bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(false).when(activations).isActive(ConsensusRule.RSKIP143);
-
-        int amountOfHeadersToSend = 100;
-        BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2SHMULTISIG);
-
-        PowpegNodeSystemProperties config = mock(PowpegNodeSystemProperties.class);
-        when(config.getAmountOfHeadersToSend()).thenReturn(amountOfHeadersToSend);
-
-        BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
-            .withBitcoinWrapper(bitcoinWrapper)
-            .withFederatorSupport(federatorSupport)
-            .withBridgeConstants(bridgeRegTestConstants)
-            .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
-            .withFedNodeSystemProperties(config)
-            .build();
-
-        client.onTransaction(tx);
-        client.onBlock(blockWithTx);
-
-        client.updateBridgeBtcTransactions();
-
-        List<SimpleFederatorSupport.TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction =
-            federatorSupport.getTxsSentToRegisterBtcTransaction();
-
-        assertNotNull(txsSentToRegisterBtcTransaction);
-        assertTrue(txsSentToRegisterBtcTransaction.isEmpty());
-    }
-
-    @Test
-    void updateTransaction_with_release_before_rskip143() throws Exception {
-        co.rsk.bitcoinj.core.NetworkParameters params = RegTestParams.get();
-        co.rsk.bitcoinj.core.Address randomAddress =
-                new co.rsk.bitcoinj.core.Address(params, org.bouncycastle.util.encoders.Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
-
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(false).when(activations).isActive(ConsensusRule.RSKIP143);
-
-        // Create a tx from the Fed to a random btc address
-        BtcTransaction releaseTx1 = new BtcTransaction(params);
-        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN, randomAddress);
-        releaseTx1.addOutput(co.rsk.bitcoinj.core.Coin.COIN.divide(2), activeFederation.getAddress()); // Change output
-        co.rsk.bitcoinj.core.TransactionInput releaseInput1 =
-                new co.rsk.bitcoinj.core.TransactionInput(params, releaseTx1,
-                        new byte[]{}, new co.rsk.bitcoinj.core.TransactionOutPoint(params, 0, co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH));
-        releaseTx1.addInput(releaseInput1);
-
-        // Sign it using the Federation members
-        co.rsk.bitcoinj.script.Script redeemScript = activeFederation.getRedeemScript();
-        co.rsk.bitcoinj.script.Script inputScript = createBaseInputScriptThatSpendsFromTheFederation(
-            activeFederation);
-        releaseInput1.setScriptSig(inputScript);
-
-        co.rsk.bitcoinj.core.Sha256Hash sighash = releaseTx1.hashForSignature(0, redeemScript, BtcTransaction.SigHash.ALL, false);
-
-        for (int i = 0; i < activeFederation.getNumberOfSignaturesRequired(); i++) {
-            BtcECKey federatorPrivKey = federationPrivateKeys.get(i);
-            BtcECKey federatorPublicKey = activeFederation.getBtcPublicKeys().get(i);
-
-            BtcECKey.ECDSASignature sig = federatorPrivKey.sign(sighash);
-            TransactionSignature txSig = new TransactionSignature(sig, BtcTransaction.SigHash.ALL, false);
-
-            int sigIndex = inputScript.getSigInsertionIndex(sighash, federatorPublicKey);
-            inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex, 1, 1);
-        }
-        releaseInput1.setScriptSig(inputScript);
-
-        // Verify it was properly signed
-        assertTrue(PegUtilsLegacy.isPegOutTx(releaseTx1, Collections.singletonList(
-            activeFederation), activations));
-
-        Transaction releaseTx = ThinConverter.toOriginalInstance(bridgeRegTestConstants.getBtcParamsString(), releaseTx1);
-
-        // Construct environment
-        Set<Transaction> txs = new HashSet<>();
-        txs.add(releaseTx);
-
-        StoredBlock[] blocks = createBlockchain(4);
-        Block blockWithTx = createBlock(blocks[3].getHeader().getHash(), releaseTx);
-        releaseTx.addBlockAppearance(blockWithTx.getHash(), 1);
-
-        SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
-        bitcoinWrapper.setTransactions(txs);
-        bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-        // set a fake member to federatorSupport to recreate a not-null runner
-        federatorSupport.setMember(activeFederationMember);
-
-        BtcToRskClient client = buildWithFactoryAndSetup(
-            federatorSupport,
-            mock(NodeBlockProcessor.class),
-            activationsConfig,
-            bitcoinWrapper,
-            bridgeRegTestConstants,
-            getMockedBtcToRskClientFileStorage(),
-            new BtcLockSenderProvider(),
-            new PeginInstructionsProvider(),
-            null
-        );
-
-        // Assign Federation to BtcToRskClient
-        client.start(activeFederation);
-
-        // Ensure tx is loaded and its proof is also loaded
-        client.onTransaction(releaseTx);
-        client.onBlock(blockWithTx);
-
-        // Try to inform tx
-        client.updateBridgeBtcTransactions();
-
-        // The release tx should be informed
-        List<SimpleFederatorSupport.TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction =
-            federatorSupport.getTxsSentToRegisterBtcTransaction();
-
-        assertNotNull(txsSentToRegisterBtcTransaction);
-        assertFalse(txsSentToRegisterBtcTransaction.isEmpty());
-        assertEquals(releaseTx.getTxId(), txsSentToRegisterBtcTransaction.get(0).tx.getTxId());
-    }
-
-    @Test
-    void updateTransactionWithSegwitCompatible_before_rskip143() throws Exception {
-        SimpleBtcTransaction tx = (SimpleBtcTransaction) createSegwitTransaction();
-        Set<Transaction> txs = new HashSet<>();
-        txs.add(tx);
-
-        StoredBlock[] blocks = createBlockchain(4);
-        Block blockWithTx = createBlock(blocks[3].getHeader().getHash(), tx);
-
-        Map<Sha256Hash, Integer> appears = new HashMap<>();
-        appears.put(blockWithTx.getHash(), 1);
-        tx.setAppearsInHashes(appears);
-
-        SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
-        bitcoinWrapper.setTransactions(txs);
-        bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(false).when(activations).isActive(ConsensusRule.RSKIP143);
-
-        BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2SHP2WPKH);
-        int amountOfHeadersToSend = 100;
-
-        PowpegNodeSystemProperties config = mock(PowpegNodeSystemProperties.class);
-        when(config.getAmountOfHeadersToSend()).thenReturn(amountOfHeadersToSend);
-
-        BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
-            .withBitcoinWrapper(bitcoinWrapper)
-            .withFederatorSupport(federatorSupport)
-            .withBridgeConstants(bridgeRegTestConstants)
-            .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
-            .withFedNodeSystemProperties(config)
-            .build();
-
-        client.onTransaction(tx);
-        client.onBlock(blockWithTx);
-
-        client.updateBridgeBtcTransactions();
-
-        List<SimpleFederatorSupport.TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction =
-            federatorSupport.getTxsSentToRegisterBtcTransaction();
-
-        assertNotNull(txsSentToRegisterBtcTransaction);
-        assertTrue(txsSentToRegisterBtcTransaction.isEmpty());
-    }
-
-    @Test
-    void updateTransactionWithSenderUnknown_before_rskip170() throws Exception {
-        SimpleBtcTransaction tx = (SimpleBtcTransaction) createTransaction();
-        Set<Transaction> txs = new HashSet<>();
-        txs.add(tx);
-
-        StoredBlock[] blocks = createBlockchain(4);
-        Block blockWithTx = createBlock(blocks[3].getHeader().getHash(), tx);
-
-        Map<Sha256Hash, Integer> appears = new HashMap<>();
-        appears.put(blockWithTx.getHash(), 1);
-        tx.setAppearsInHashes(appears);
-
-        SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
-        bitcoinWrapper.setTransactions(txs);
-        bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP143);
-        doReturn(false).when(activationsConfig).isActive(eq(ConsensusRule.RSKIP170), anyLong());
-
-        BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.UNKNOWN);
-        int amountOfHeadersToSend = 100;
-
-        PowpegNodeSystemProperties config = mock(PowpegNodeSystemProperties.class);
-        when(config.getAmountOfHeadersToSend()).thenReturn(amountOfHeadersToSend);
-
-        BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
-            .withBitcoinWrapper(bitcoinWrapper)
-            .withFederatorSupport(federatorSupport)
-            .withBridgeConstants(bridgeRegTestConstants)
-            .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
-            .withFedNodeSystemProperties(config)
-            .build();
-
-        client.onTransaction(tx);
-        client.onBlock(blockWithTx);
-
-        client.updateBridgeBtcTransactions();
-
-        List<SimpleFederatorSupport.TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction =
-            federatorSupport.getTxsSentToRegisterBtcTransaction();
-
-        assertNotNull(txsSentToRegisterBtcTransaction);
-        assertTrue(txsSentToRegisterBtcTransaction.isEmpty());
-    }
-
-    @Test
-    void updateTransactionWithSenderUnknown_after_rskip170() throws Exception {
-        SimpleBtcTransaction tx = (SimpleBtcTransaction) createTransaction();
-        Set<Transaction> txs = new HashSet<>();
-        txs.add(tx);
-
-        SimpleBitcoinWrapper bitcoinWrapper = new SimpleBitcoinWrapper();
-        bitcoinWrapper.setTransactions(txs);
-
-        Block block = createBlock(tx);
-        Map<Sha256Hash, Integer> appears = new HashMap<>();
-        appears.put(block.getHash(), 1);
-        tx.setAppearsInHashes(appears);
-
-        StoredBlock[] blocks = createBlockchain(4);
-        blocks[4] = new StoredBlock(block, null, 4); // Replace the last block with the one containing the transaction
-        bitcoinWrapper.setBlocks(blocks);
-
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-        BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.UNKNOWN);
-
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP143);
-        doReturn(true).when(activationsConfig).isActive(eq(ConsensusRule.RSKIP170), anyLong());
-
-        BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
-            .withBitcoinWrapper(bitcoinWrapper)
-            .withFederatorSupport(federatorSupport)
-            .withBridgeConstants(bridgeRegTestConstants)
-            .withBtcLockSenderProvider(btcLockSenderProvider)
-            .withFederation(activeFederation)
-            .build();
-
-        client.onTransaction(tx);
-        client.onBlock(block);
-
-        client.updateBridgeBtcTransactions();
-
-        List<SimpleFederatorSupport.TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction =
-            federatorSupport.getTxsSentToRegisterBtcTransaction();
-
-        assertNotNull(txsSentToRegisterBtcTransaction);
-        assertFalse(txsSentToRegisterBtcTransaction.isEmpty());
-    }
-
-    @Test
     void updateTransaction_peginInformationParsingFails_withoutSenderAddress() throws Exception {
         SimpleBtcTransaction tx = (SimpleBtcTransaction) createTransaction();
         Set<Transaction> txs = new HashSet<>();
@@ -1961,8 +1637,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-
         ActivationConfig activationsConfig = mock(ActivationConfig.class);
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         doReturn(activations).when(activationsConfig).forBlock(anyLong());
@@ -1975,7 +1649,7 @@ class BtcToRskClientTest {
         when(peginInstructionsProvider.buildPeginInstructions(any())).thenThrow(PeginInstructionsException.class);
 
         BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
+            .withActivationConfig(activationConfig)
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
@@ -2011,16 +1685,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
-
-        ActivationConfig activationsConfig = mock(ActivationConfig.class);
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        doReturn(activations).when(activationsConfig).forBlock(anyLong());
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP89);
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP143);
-        doReturn(true).when(activations).isActive(ConsensusRule.RSKIP170);
-        doReturn(true).when(activationsConfig).isActive(eq(ConsensusRule.RSKIP170), anyLong());
-
         BtcLockSender btcLockSender = mock(BtcLockSender.class);
         when(btcLockSender.getBTCAddress()).thenReturn(mock(co.rsk.bitcoinj.core.Address.class));
         BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
@@ -2030,7 +1694,7 @@ class BtcToRskClientTest {
         when(peginInstructionsProvider.buildPeginInstructions(any())).thenThrow(PeginInstructionsException.class);
 
         BtcToRskClient client = btcToRskClientBuilder
-            .withActivationConfig(activationsConfig)
+            .withActivationConfig(activationConfig)
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
             .withBridgeConstants(bridgeRegTestConstants)
@@ -2077,7 +1741,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setTransactions(txs);
         bitcoinWrapper.setBlocks(blocks);
 
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -2122,7 +1785,6 @@ class BtcToRskClientTest {
         bitcoinWrapper.setBlocks(blocks);
 
         Block block = createBlock(tx);
-        SimpleFederatorSupport federatorSupport = new SimpleFederatorSupport();
         BtcLockSenderProvider btcLockSenderProvider = mockBtcLockSenderProvider(TxSenderAddressType.P2PKH);
 
         BtcToRskClient client = btcToRskClientBuilder
@@ -2143,6 +1805,1614 @@ class BtcToRskClientTest {
 
         assertNotNull(txsSentToRegisterBtcTransaction);
         assertTrue(txsSentToRegisterBtcTransaction.isEmpty());
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class UpdateBridgeBtcTransactionsTests {
+        private static final NetworkParameters MAINNET_PARAMS = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING);
+        private static final Context MAINNET_CONTEXT = new Context(MAINNET_PARAMS);
+
+        private static final int PREV_BLOCK_HEIGHT = 3;
+
+        @TempDir
+        private Path tempDir;
+        private BtcToRskClientFileStorage btcToRskClientFileStorage;
+
+        private Wallet wallet;
+        private KitForTests kit;
+        private BitcoinWrapperImpl bitcoinWrapper;
+        private BtcToRskClient client;
+        private FederatorSupport federatorSupport;
+        private BtcLockSenderProvider btcLockSenderProvider;
+        private PeginInstructionsProvider peginInstructionsProvider;
+
+        @BeforeEach
+        void setUp() {
+            co.rsk.bitcoinj.core.Context.propagate(new co.rsk.bitcoinj.core.Context(MAINNET_BTC_PARAMS));
+
+            ForBlock activations = mock(ForBlock.class);
+            when(activations.isActive(any(ConsensusRule.class))).thenReturn(true);
+            when(activationConfig.forBlock(anyLong())).thenReturn(activations);
+            when(activationConfig.isActive(any(ConsensusRule.class), anyLong())).thenReturn(true);
+
+            federatorSupport = mock(FederatorSupport.class);
+            when(federatorSupport.getConfigForBestBlock()).thenReturn(activations);
+            // assuming no retiring fed for general setup
+            when(federatorSupport.getRetiringFederationSize()).thenReturn(FEDERATION_NON_EXISTENT.getCode());
+
+            btcLockSenderProvider = new BtcLockSenderProvider();
+            peginInstructionsProvider = new PeginInstructionsProvider();
+
+            // using a temporary directory for testing
+            FileStorageInfo fileStorageInfo = mock(BtcToRskClientFileStorageInfo.class);
+            String pegDir = tempDir.toString();
+            String filePath = tempDir.resolve("btcToRskClient2.rlp").toString();
+            when(fileStorageInfo.getPegDirectoryPath()).thenReturn(pegDir);
+            when(fileStorageInfo.getFilePath()).thenReturn(filePath);
+            btcToRskClientFileStorage = new BtcToRskClientFileStorageImpl(fileStorageInfo);
+
+            wallet = mock(Wallet.class);
+            kit = new KitForTests(MAINNET_CONTEXT, mock(File.class), "", wallet);
+            setUpBitcoinWrapper(kit);
+        }
+
+        private void setUpActiveFed(Federation activeFederation) throws Exception {
+            when(federatorSupport.getFederationSize()).thenReturn(activeFederation.getSize());
+            for (int i = 0; i < activeFederation.getSize(); i++) {
+                FederationMember member = activeFederation.getMembers().get(i);
+                org.ethereum.crypto.ECKey btcKey = org.ethereum.crypto.ECKey.fromPublicOnly(member.getBtcPublicKey().getPubKey());
+                when(federatorSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(btcKey);
+                org.ethereum.crypto.ECKey rskKey = member.getRskPublicKey();
+                when(federatorSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(rskKey);
+                org.ethereum.crypto.ECKey mstKey = member.getMstPublicKey();
+                when(federatorSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(mstKey);
+            }
+            when(federatorSupport.getFederationCreationTime()).thenReturn(activeFederation.getCreationTime());
+            when(federatorSupport.getFederationCreationBlockNumber()).thenReturn(activeFederation.getCreationBlockNumber());
+            when(federatorSupport.getBtcParams()).thenReturn(MAINNET_BTC_PARAMS);
+            when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
+
+            setUpClient(activeFederation);
+        }
+
+        private void setUpRetiringFed(Federation retiringFederation) {
+            when(federatorSupport.getRetiringFederationSize()).thenReturn(retiringFederation.getSize());
+            for (int i = 0; i < retiringFederation.getSize(); i++) {
+                FederationMember member = retiringFederation.getMembers().get(i);
+                org.ethereum.crypto.ECKey btcKey = org.ethereum.crypto.ECKey.fromPublicOnly(member.getBtcPublicKey().getPubKey());
+                when(federatorSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(btcKey);
+                org.ethereum.crypto.ECKey rskKey = member.getRskPublicKey();
+                when(federatorSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(rskKey);
+                org.ethereum.crypto.ECKey mstKey = member.getMstPublicKey();
+                when(federatorSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(mstKey);
+            }
+            when(federatorSupport.getRetiringFederationCreationTime()).thenReturn(retiringFederation.getCreationTime());
+            when(federatorSupport.getRetiringFederationCreationBlockNumber()).thenReturn(retiringFederation.getCreationBlockNumber());
+            when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
+        }
+
+        private void setUpProposedFed(Federation proposedFederation) {
+            when(federatorSupport.getProposedFederationSize()).thenReturn(Optional.of(proposedFederation.getSize()));
+            for (int i = 0; i < proposedFederation.getSize(); i++) {
+                FederationMember member = proposedFederation.getMembers().get(i);
+                org.ethereum.crypto.ECKey btcKey = org.ethereum.crypto.ECKey.fromPublicOnly(member.getBtcPublicKey().getPubKey());
+                when(federatorSupport.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(Optional.of(btcKey));
+                org.ethereum.crypto.ECKey rskKey = member.getRskPublicKey();
+                when(federatorSupport.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(Optional.of(rskKey));
+                org.ethereum.crypto.ECKey mstKey = member.getMstPublicKey();
+                when(federatorSupport.getProposedFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(Optional.of(mstKey));
+            }
+            when(federatorSupport.getProposedFederationCreationTime()).thenReturn(Optional.of(proposedFederation.getCreationTime()));
+            when(federatorSupport.getProposedFederationCreationBlockNumber()).thenReturn(Optional.of(proposedFederation.getCreationBlockNumber()));
+            when(federatorSupport.getProposedFederationAddress()).thenReturn(Optional.of(proposedFederation.getAddress()));
+        }
+
+        private void setUpBitcoinWrapper(Kit kit) {
+            bitcoinWrapper = new BitcoinWrapperImpl(
+                MAINNET_CONTEXT,
+                kit
+            );
+
+            List<PeerAddress> peerAddresses = Collections.emptyList();
+            bitcoinWrapper.setup(peerAddresses);
+            bitcoinWrapper.start();
+        }
+
+        private void setUpClient(Federation federationToListen) throws Exception {
+            btcToRskClientBuilder = BtcToRskClientBuilder.builder();
+            client = btcToRskClientBuilder
+                .withBitcoinWrapper(bitcoinWrapper)
+                .withFederatorSupport(federatorSupport)
+                .withFederation(federationToListen)
+                .withBridgeConstants(BRIDGE_MAINNET_CONSTANTS)
+                .withBtcToRskClientFileStorage(btcToRskClientFileStorage)
+                .withBtcLockSenderProvider(btcLockSenderProvider)
+                .withPeginInstructionsProvider(peginInstructionsProvider)
+                .withActivationConfig(activationConfig)
+                .build();
+            bitcoinWrapper.addFederationListener(federationToListen, client);
+        }
+
+        private void setUpTx(BtcTransaction btcTx) throws Exception {
+            var tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+
+            org.bitcoinj.core.TransactionConfidence confidence = tx.getConfidence();
+            confidence.setConfidenceType(org.bitcoinj.core.TransactionConfidence.ConfidenceType.BUILDING);
+            confidence.setDepthInBlocks(BRIDGE_MAINNET_CONSTANTS.getBtc2RskMinimumAcceptableConfirmations());
+
+            final int CHAIN_HEIGHT = 4;
+            StoredBlock[] blocks = createBlockchain(CHAIN_HEIGHT);
+
+            Sha256Hash prevBlockHash = blocks[PREV_BLOCK_HEIGHT].getHeader().getHash();
+            Block blockWithTx = createBlockWithTx(prevBlockHash, tx);
+            tx.addBlockAppearance(blockWithTx.getHash(), 1);
+
+            Set<Transaction> walletTxs = new HashSet<>();
+            walletTxs.add(tx);
+            when(wallet.getTransactions(false)).thenReturn(walletTxs);
+            kit.setStore(blocks);
+
+            client.onTransaction(tx);
+            client.onBlock(blockWithTx);
+        }
+
+        // the tests will be set in this order:
+        // legacy pay-to-pub-key: p2pkh
+        // bech32 pay-to-script-pub-key: p2shP2wpkh
+        // bech32 pay-to-pub-key: p2wpkh
+        // multisig: p2sh
+        // pay-to-bech32-multisig: p2shP2wsh
+        // bech32 multisig: p2wsh
+
+        // and we will test with standard multisig and p2sh-p2wsh erp federations
+
+        private static Stream<Federation> activeFedArgs() {
+            final Federation standardMultisigFederation = TestUtils.createStandardMultisigFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
+
+            return Stream.of(standardMultisigFederation, p2shP2wshErpFederation);
+        }
+
+        // LEGACY PEGIN
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2pkh_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2pkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2wpkh_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wpkh_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wpkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2shMultiSig_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2shMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wshMultiSig_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_legacyPeginFromP2wshMultiSig_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        // PEGIN V1
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayload(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayload(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_invalidPayload_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_invalidPayload_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayload(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_invalidPayload_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayload(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_invalidPayload_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayload(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_invalidPayload_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutput(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_invalidPayload_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayload(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_invalidPayload_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        // PEGIN WITH INSTRUCTIONS - UNKNOWN PROTOCOL VERSION
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(peginBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
+            addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
+            addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(peginBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_pegoutTx_withoutChangeToFed_shouldNotBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            co.rsk.bitcoinj.core.Address userAddress = BitcoinTestUtils.createP2PKHAddress(
+                MAINNET_BTC_PARAMS,
+                "userAddress"
+            );
+            List<co.rsk.bitcoinj.core.Coin> outpointValues = Collections.singletonList(co.rsk.bitcoinj.core.Coin.COIN);
+            BtcTransaction pegoutBtcTx = createPegout(
+                MAINNET_BTC_PARAMS,
+                federation,
+                outpointValues,
+                Collections.singletonList(userAddress)
+            );
+
+            setUpTx(pegoutBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_pegoutTx_withChangeToFed_shouldBeInformed(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var userAddress = BitcoinTestUtils.createP2PKHAddress(
+                MAINNET_BTC_PARAMS,
+                "userAddress"
+            );
+            var outpointValues = Collections.singletonList(co.rsk.bitcoinj.core.Coin.COIN);
+            BtcTransaction pegoutBtcTx = createPegout(
+                MAINNET_BTC_PARAMS,
+                federation,
+                outpointValues,
+                Collections.singletonList(userAddress)
+            );
+
+            var oneSatoshi = co.rsk.bitcoinj.core.Coin.valueOf(1L);
+            var amountToSend = BRIDGE_MAINNET_CONSTANTS.getMinimumPegoutTxValue().subtract(oneSatoshi);
+            addOutputToFed(pegoutBtcTx, federation.getAddress(), amountToSend);
+
+            setUpTx(pegoutBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(pegoutBtcTx);
+        }
+
+        private static Stream<Arguments> retiringAndActiveFedsArgs() {
+            final Federation standardMultiSigFed = TestUtils.createStandardMultisigFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation firstP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation secondP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
+
+            return Stream.of(
+                Arguments.of(standardMultiSigFed, firstP2shP2wshErpFed),
+                Arguments.of(firstP2shP2wshErpFed, secondP2shP2wshErpFed)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("retiringAndActiveFedsArgs")
+        void updateBridgeBtcTransactions_migrationTx_shouldBeInformed(Federation retiringFederation, Federation activeFederation) throws Exception {
+            // arrange
+            setUpRetiringFed(retiringFederation);
+            setUpActiveFed(activeFederation);
+            var migrationBtcTx = createMigrationTx(MAINNET_BTC_PARAMS, retiringFederation, activeFederation);
+            setUpTx(migrationBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(migrationBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("retiringAndActiveFedsArgs")
+        void updateBridgeBtcTransactions_migrationTxBelowMinimumPeginValue_shouldBeInformed(Federation retiringFederation, Federation activeFederation) throws Exception {
+            // arrange
+            setUpRetiringFed(retiringFederation);
+            setUpActiveFed(activeFederation);
+            var migrationBtcTx = createMigrationTxBelowMinimumPeginValue(MAINNET_BTC_PARAMS, retiringFederation, activeFederation);
+            setUpTx(migrationBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(migrationBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("retiringAndActiveFedsArgs")
+        void updateBridgeBtcTransactions_migrationTx_clientForRetiringFed_shouldNotBeInformed(Federation retiringFederation, Federation activeFederation) throws Exception {
+            // arrange
+            setUpRetiringFed(retiringFederation);
+            setUpActiveFed(activeFederation);
+            setUpClient(retiringFederation);
+
+            var migrationBtcTx = createMigrationTx(MAINNET_BTC_PARAMS, retiringFederation, activeFederation);
+            setUpTx(migrationBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        private static Stream<Arguments> activeAndNotActiveFedsArgs() {
+            final Federation activeStandardMultiSigFed = TestUtils.createStandardMultisigFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation activeSegwitFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation notActiveFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
+
+            return Stream.of(
+                Arguments.of(activeStandardMultiSigFed, notActiveFed),
+                Arguments.of(activeSegwitFed, notActiveFed)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeAndNotActiveFedsArgs")
+        void updateBridgeBtcTransactions_svpFundTx_shouldBeInformed(Federation activeFederation, Federation notActiveFederation) throws Exception {
+            // arrange
+            setUpProposedFed(notActiveFederation);
+            setUpActiveFed(activeFederation);
+
+            var svpFundBtcTx = createSVPFundTx(BRIDGE_MAINNET_CONSTANTS, activeFederation, notActiveFederation);
+            setUpTx(svpFundBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(svpFundBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeAndNotActiveFedsArgs")
+        void updateBridgeBtcTransactions_svpSpendTx_shouldBeInformed(Federation activeFederation, Federation notActiveFederation) throws Exception {
+            // arrange
+            setUpProposedFed(notActiveFederation);
+            setUpActiveFed(activeFederation);
+
+            var svpSpendBtcTx = createSVPSpendTx(BRIDGE_MAINNET_CONSTANTS, activeFederation, notActiveFederation);
+            setUpTx(svpSpendBtcTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridge(svpSpendBtcTx);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeAndNotActiveFedsArgs")
+        void updateBridgeBtcTransactions_svpSpendTx_clientForRetiringFed_shouldNotBeInformed(Federation notActiveFederation, Federation activeFederation) throws Exception {
+            // arrange
+            setUpActiveFed(activeFederation);
+            setUpRetiringFed(notActiveFederation);
+            setUpClient(notActiveFederation);
+
+            var svpSpendTx = createSVPSpendTx(BRIDGE_MAINNET_CONSTANTS, activeFederation, notActiveFederation);
+            setUpTx(svpSpendTx);
+
+            // act
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+        }
+
+        private void assertTxSentToBridge(BtcTransaction btcTx) throws IOException {
+            var tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+
+            org.bitcoinj.core.PartialMerkleTree pmt = getPMT(tx);
+            verify(federatorSupport).sendRegisterBtcTransaction(tx, PREV_BLOCK_HEIGHT, pmt);
+        }
+
+        private org.bitcoinj.core.PartialMerkleTree getPMT(Transaction tx) throws IOException {
+            BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(MAINNET_PARAMS).getData();
+            List<Proof> proofs = fileData.getTransactionProofs().get(tx.getWTxId());
+
+            Proof proof = proofs.get(0);
+            return proof.getPartialMerkleTree();
+        }
+
+        private void assertTxNotSentToBridge() {
+            verify(federatorSupport, never()).sendRegisterBtcTransaction(any(Transaction.class), anyInt(), any(PartialMerkleTree.class));
+        }
     }
 
     @Test
@@ -2270,7 +3540,7 @@ class BtcToRskClientTest {
 
         Map<Sha256Hash, CoinbaseInformation> coinbases = spy(new HashMap<>());
         CoinbaseInformation coinbaseInformation = new CoinbaseInformation(
-                getCoinbaseTx(true, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH.getBytes()), null, null, null);
+            getCoinbaseTx(true, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH.getBytes()), null, null, null);
         coinbaseInformation.setReadyToInform(true);
 
         coinbases.put(Sha256Hash.ZERO_HASH, coinbaseInformation);
@@ -2315,7 +3585,7 @@ class BtcToRskClientTest {
 
         Map<Sha256Hash, CoinbaseInformation> coinbases = spy(new HashMap<>());
         CoinbaseInformation coinbaseInformation = new CoinbaseInformation(
-                getCoinbaseTx(true, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH.getBytes()), null, blockHash, null);
+            getCoinbaseTx(true, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH.getBytes()), null, blockHash, null);
         coinbaseInformation.setReadyToInform(true);
 
         coinbases.put(blockHash, coinbaseInformation);
@@ -2545,18 +3815,18 @@ class BtcToRskClientTest {
         NodeBlockProcessor nodeBlockProcessor = mock(NodeBlockProcessor.class);
         when(nodeBlockProcessor.hasBetterBlockToSync()).thenReturn(false);
 
-        Transaction peginTx = createSegwitTransaction();
+        Transaction peginBtcTx = createSegwitTransaction();
 
         FederatorSupport federatorSupport = mock(FederatorSupport.class);
         when(federatorSupport.getBtcBlockchainBestChainHeight()).thenReturn(1);
-        when(federatorSupport.isBtcTxHashAlreadyProcessed(peginTx.getTxId())).thenReturn(true);
-        when(federatorSupport.getBtcTxHashProcessedHeight(peginTx.getTxId())).thenReturn(1L);
+        when(federatorSupport.isBtcTxHashAlreadyProcessed(peginBtcTx.getTxId())).thenReturn(true);
+        when(federatorSupport.getBtcTxHashProcessedHeight(peginBtcTx.getTxId())).thenReturn(1L);
         when(federatorSupport.getFederationMember()).thenReturn(activeFederationMember);
 
         BitcoinWrapper bitcoinWrapper = mock(BitcoinWrapper.class);
         when(bitcoinWrapper.getBestChainHeight()).thenReturn(1);
         Map<Sha256Hash, Transaction> txsInWallet = new HashMap<>();
-        txsInWallet.put(peginTx.getWTxId(), peginTx);
+        txsInWallet.put(peginBtcTx.getWTxId(), peginBtcTx);
         when(bitcoinWrapper.getTransactionMap(bridgeRegTestConstants.getBtc2RskMinimumAcceptableConfirmations()))
             .thenReturn(txsInWallet);
 
@@ -2564,7 +3834,7 @@ class BtcToRskClientTest {
         Proof proof = mock(Proof.class);
         proofs.add(proof);
         BtcToRskClientFileData btcToRskClientFileData = new BtcToRskClientFileData();
-        btcToRskClientFileData.getTransactionProofs().put(peginTx.getWTxId(), proofs);
+        btcToRskClientFileData.getTransactionProofs().put(peginBtcTx.getWTxId(), proofs);
 
         BtcToRskClientFileStorage btcToRskClientFileStorageMock = mock(BtcToRskClientFileStorage.class);
         when(btcToRskClientFileStorageMock.read(any())).thenReturn(new BtcToRskClientFileReadResult(true, btcToRskClientFileData));
@@ -2590,14 +3860,8 @@ class BtcToRskClientTest {
 
         btcToRskClient.updateBridge();
 
-        verify(federatorSupport, times(1)).isBtcTxHashAlreadyProcessed(peginTx.getTxId());
+        verify(federatorSupport, times(1)).isBtcTxHashAlreadyProcessed(peginBtcTx.getTxId());
         verify(federatorSupport, never()).sendRegisterBtcTransaction(any(Transaction.class), anyInt(), any(PartialMerkleTree.class));
-    }
-
-    private static co.rsk.bitcoinj.script.Script createBaseInputScriptThatSpendsFromTheFederation(Federation federation) {
-        co.rsk.bitcoinj.script.Script scriptPubKey = federation.getP2SHScript();
-
-        return scriptPubKey.createEmptyInputScript(null, federation.getRedeemScript());
     }
 
     private BtcToRskClient buildWithFactory(FederatorSupport federatorSupport, NodeBlockProcessor nodeBlockProcessor) {
@@ -2615,7 +3879,7 @@ class BtcToRskClientTest {
         BtcLockSenderProvider btcLockSenderProvider,
         PeginInstructionsProvider peginInstructionsProvider,
         PowpegNodeSystemProperties fedNodeSystemProperties
-        ) throws Exception {
+    ) throws Exception {
 
         BtcToRskClient btcToRskClient = buildWithFactory(federatorSupport, nodeBlockProcessor);
 
@@ -2646,6 +3910,7 @@ class BtcToRskClientTest {
         return btcToRskClientFileStorage;
     }
 
+
     private Block createBlock(Transaction... txs) {
         return createBlock(createHash(), txs);
     }
@@ -2662,6 +3927,31 @@ class BtcToRskClientTest {
             0,
             Lists.newArrayList(txs)
         );
+    }
+
+    private Block createBlockWithTx(Sha256Hash prevBlockHash, Transaction tx) {
+        if (tx.hasWitnesses()) {
+            return createSegwitBlockWithTx(prevBlockHash, tx);
+        }
+
+        return createBlock(prevBlockHash, tx);
+    }
+
+    private Block createSegwitBlockWithTx(Sha256Hash prevBlockHash, Transaction pegInTx) {
+        Sha256Hash witnessRoot = Sha256Hash.wrapReversed(
+            Sha256Hash.hashTwice(
+                Sha256Hash.ZERO_HASH.getReversedBytes(),
+                pegInTx.getWTxId().getReversedBytes()
+            )
+        );
+        byte[] witnessReservedValue = WITNESS_RESERVED_VALUE.getBytes();
+        co.rsk.bitcoinj.core.Sha256Hash witnessCommitment = co.rsk.bitcoinj.core.Sha256Hash.twiceOf(
+            witnessRoot.getReversedBytes(),
+            witnessReservedValue
+        );
+        BtcTransaction coinbaseBtcTx = createCoinbaseTransactionWithWitnessCommitment(MAINNET_BTC_PARAMS, witnessCommitment);
+
+        return createBlock(prevBlockHash, ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, coinbaseBtcTx), pegInTx);
     }
 
     private Transaction createTransaction() {
@@ -2856,5 +4146,4 @@ class BtcToRskClientTest {
 
         return config;
     }
-
 }

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -1,5 +1,6 @@
 package co.rsk.federate;
 
+import static co.rsk.federate.BtcToRskClient.BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK;
 import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static java.util.Objects.nonNull;
@@ -3393,6 +3394,63 @@ class BtcToRskClientTest {
 
             // assert
             assertTxNotSentToBridge();
+        }
+
+        @ParameterizedTest
+        @MethodSource("activeFedArgs")
+        void updateBridgeBtcTransactions_txProcessed_afterBtcToRskMinimumAcceptableConfirmationsOnRsk_isNotSentAndRemovedFromProofsFile(Federation federation) throws Exception {
+            // arrange
+            setUpActiveFed(federation);
+            var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+            setUpTx(peginBtcTx);
+            var peginTx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, peginBtcTx);
+
+            assertWTxIdIsInProofsFile(peginTx);
+            // simulate that the bridge has processed the tx
+            var peginTxId = peginTx.getTxId();
+            when(federatorSupport.isBtcTxHashAlreadyProcessed(peginTxId)).thenReturn(true);
+            long txProcessedHeight = 1L;
+            when(federatorSupport.getBtcTxHashProcessedHeight(peginTxId)).thenReturn(txProcessedHeight);
+
+            long heightAtWhichRemoveTxFromProofs = txProcessedHeight + BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK;
+            // check that calling updateBridgeBtcTransactions right before
+            // BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK blocks have passed,
+            // the fed sends the tx to the bridge and the tx hash is still in the proofs file
+            long heightBeforeRemovingTxFromProofs = heightAtWhichRemoveTxFromProofs - 1;
+            when(federatorSupport.getRskBestChainHeight()).thenReturn(heightBeforeRemovingTxFromProofs);
+            client.updateBridgeBtcTransactions();
+            assertTxSentToBridge(peginBtcTx);
+            assertWTxIdIsInProofsFile(peginTx);
+
+            clearInvocations(federatorSupport);
+            // act
+            // now check that right when BTC_TO_RSK_MINIMUM_ACCEPTABLE_CONFIRMATIONS_ON_RSK
+            // blocks have passed, the fed does not send the tx to the bridge
+            // and the tx proof is removed from the file
+            when(federatorSupport.getRskBestChainHeight()).thenReturn(heightAtWhichRemoveTxFromProofs);
+            client.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge();
+            assertWTxIdIsNotInProofsFile();
+        }
+
+        private void assertWTxIdIsInProofsFile(Transaction tx) throws IOException {
+            BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(MAINNET_PARAMS).getData();
+            Map<Sha256Hash, List<Proof>> transactionProofs = fileData.getTransactionProofs();
+            Set<Sha256Hash> txProofsKeySet = transactionProofs.keySet();
+            assertEquals(1, txProofsKeySet.size());
+            Sha256Hash wTxId = tx.getWTxId();
+            Sha256Hash savedWTxId = txProofsKeySet.iterator().next();
+            assertEquals(wTxId, savedWTxId);
+        }
+
+        private void assertWTxIdIsNotInProofsFile() throws IOException {
+            BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(MAINNET_PARAMS).getData();
+            Map<Sha256Hash, List<Proof>> transactionProofs = fileData.getTransactionProofs();
+            Set<Sha256Hash> txProofsKeySet = transactionProofs.keySet();
+            assertEquals(0, txProofsKeySet.size());
         }
 
         private void assertTxSentToBridge(BtcTransaction btcTx) throws IOException {

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -1,22 +1,55 @@
 package co.rsk.federate.bitcoin;
 
 import static co.rsk.bitcoinj.script.ScriptBuilder.createP2SHOutputScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.extractRedeemScriptFromInput;
+import static co.rsk.federate.PegUtils.MINIMUM_PEGIN_TX_VALUE;
+import static co.rsk.peg.PegUtils.getFlyoverFederationRedeemScript;
+import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import co.rsk.core.RskAddress;
+import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.Federation;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 
 public final class BitcoinTestUtils {
+    public static final org.bitcoinj.core.Sha256Hash WITNESS_RESERVED_VALUE = org.bitcoinj.core.Sha256Hash.ZERO_HASH;
+    public static final int WITNESS_COMMITMENT_LENGTH = 36; // 4 bytes for header, 32 for hash
+
+    private static final BtcECKey SENDER_PUBLIC_KEY = getBtcEcKeyFromSeed("sender");
+    private static final List<BtcECKey> MULTISIG_KEYS = Arrays.asList(
+        getBtcEcKeyFromSeed("key1"),
+        getBtcEcKeyFromSeed("key2"),
+        getBtcEcKeyFromSeed("key3")
+    );
+    private static final Script MULTISIG_REDEEM_SCRIPT = ScriptBuilder.createRedeemScript(2, MULTISIG_KEYS);
+
+    private static final Coin OP_RETURN_OUTPUT_AMOUNT = Coin.ZERO;
+    private static final int V1_PROTOCOL_VERSION = 1;
+    private static final int UNKNOWN_PROTOCOL_VERSION = 2;
+    private static final int RSK_PREFIX_INDEX = 0;
+    private static final int RSK_PREFIX_LENGTH = 4;
+    private static final byte[] RSK_PREFIX = org.bouncycastle.util.encoders.Hex.decode("52534b54"); // 'RSKT' in hexa
+    private static final int PROTOCOL_VERSION_INDEX = RSK_PREFIX_INDEX + RSK_PREFIX_LENGTH;
+    private static final int PROTOCOL_VERSION_LENGTH = 1;
+    private static final int RSK_DESTINATION_ADDRESS_INDEX = PROTOCOL_VERSION_INDEX + PROTOCOL_VERSION_LENGTH;
+    private static final int RSK_DESTINATION_ADDRESS_LENGTH = 20;
+    private static final int PAYLOAD_WITH_REFUND_ADDRESS_LENGTH = 46;
+    private static final int INVALID_PAYLOAD_LENGTH = PAYLOAD_WITH_REFUND_ADDRESS_LENGTH + 1;
+
+    private static final RskAddress DESTINATION_ADDRESS = new RskAddress(org.ethereum.crypto.ECKey.fromPublicOnly(SENDER_PUBLIC_KEY.getPubKey()).getAddress());
+
     private BitcoinTestUtils() { }
 
     public static List<Coin> coinListOf(long... values) {
@@ -35,7 +68,7 @@ public final class BitcoinTestUtils {
         return Sha256Hash.wrap(bytes);
     }
 
-    public static BtcECKey getBtcEcKeyFromSeed(String seed) {
+    private static BtcECKey getBtcEcKeyFromSeed(String seed) {
         byte[] serializedSeed = HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8));
         return BtcECKey.fromPrivate(serializedSeed);
     }
@@ -91,13 +124,12 @@ public final class BitcoinTestUtils {
     }
 
     public static BtcTransaction createPegout(
-        NetworkParameters btcMainnetParams,
+        NetworkParameters btcParams,
         Federation fromFederation,
         List<Coin> outpointValues,
         List<Address> destinationAddresses
     ) {
-        BtcTransaction tx = new BtcTransaction(btcMainnetParams);
-
+        BtcTransaction tx = new BtcTransaction(btcParams);
         Coin fee = Coin.MILLICOIN;
         for (int inputIndex = 0; inputIndex < outpointValues.size(); inputIndex++) {
             Coin outpointValue = outpointValues.get(inputIndex);
@@ -107,17 +139,391 @@ public final class BitcoinTestUtils {
             tx.addOutput(amountToSend, destinationAddress);
 
             TransactionOutPoint transactionOutpoint = new TransactionOutPoint(
-                btcMainnetParams,
+                btcParams,
                 inputIndex,
-                BitcoinTestUtils.createHash(inputIndex)
+                createHash(inputIndex)
             );
-
-            TransactionInput txInput = new TransactionInput(btcMainnetParams, null, new byte[]{}, transactionOutpoint, outpointValue);
+            TransactionInput txInput = new TransactionInput(btcParams, null, new byte[]{}, transactionOutpoint, outpointValue);
             tx.addInput(txInput);
 
             addSpendingFederationBaseScript(tx, inputIndex, fromFederation.getRedeemScript(), fromFederation.getFormatVersion());
         }
-
         return tx;
+    }
+
+    public static BtcTransaction createMigrationTx(NetworkParameters networkParameters, Federation retiringFederation, Federation activeFederation) {
+        co.rsk.bitcoinj.core.Coin baseCoin = co.rsk.bitcoinj.core.Coin.valueOf(1_000_000L);
+        List<Coin> utxosToMigrate = new ArrayList<>();
+        var totalOfUtxosToMigrate = 10;
+
+        for (int i = 1; i <= totalOfUtxosToMigrate; i++) {
+            utxosToMigrate.add(baseCoin.multiply(i));
+        }
+
+        return createMigrationTxWithUTXOs(networkParameters, retiringFederation, activeFederation, utxosToMigrate);
+    }
+
+    public static BtcTransaction createMigrationTxBelowMinimumPeginValue(NetworkParameters networkParameters, Federation retiringFederation, Federation activeFederation) {
+        var totalValue = MINIMUM_PEGIN_TX_VALUE.minus(co.rsk.bitcoinj.core.Coin.SATOSHI);
+
+        List<co.rsk.bitcoinj.core.Coin> utxosToMigrate = new ArrayList<>();
+        var totalOfUtxosToMigrate = 10;
+        var utxoValue = totalValue.div(totalOfUtxosToMigrate);
+
+        for (int i = 1; i <= totalOfUtxosToMigrate; i++) {
+            utxosToMigrate.add(utxoValue);
+        }
+
+        return createMigrationTxWithUTXOs(networkParameters, retiringFederation, activeFederation, utxosToMigrate);
+    }
+
+    public static BtcTransaction createMigrationTxWithUTXOs(NetworkParameters networkParameters, Federation retiringFederation, Federation activeFederation, List<Coin> utxosToMigrate) {
+        co.rsk.bitcoinj.core.Address retiringFederationAddress = retiringFederation.getAddress();
+        co.rsk.bitcoinj.core.Address activeFederationAddress = activeFederation.getAddress();
+
+        List<BtcTransaction> txsToMigrate = new ArrayList<>();
+        Coin utxosTotalValue = Coin.ZERO;
+        for (Coin coin : utxosToMigrate) {
+            BtcTransaction txSentToRetiringFed = new BtcTransaction(networkParameters);
+            txSentToRetiringFed.addOutput(coin, retiringFederationAddress);
+            utxosTotalValue = utxosTotalValue.add(coin);
+
+            txsToMigrate.add(txSentToRetiringFed);
+        }
+
+        // add base script from retiring fed to all inputs
+        BtcTransaction migrationBtcTx = new BtcTransaction(networkParameters);
+        for (int i = 0; i < txsToMigrate.size(); i++) {
+            BtcTransaction txToMigrate = txsToMigrate.get(i);
+            co.rsk.bitcoinj.core.TransactionOutput output = txToMigrate.getOutput(0);
+            migrationBtcTx.addInput(output);
+
+            addSpendingFederationBaseScript(
+                migrationBtcTx,
+                i,
+                retiringFederation.getRedeemScript(),
+                retiringFederation.getFormatVersion()
+            );
+        }
+
+        // one output to the new fed with the utxos total value
+        migrationBtcTx.addOutput(utxosTotalValue, activeFederationAddress);
+
+        return migrationBtcTx;
+    }
+
+    public static BtcTransaction createSVPSpendTx(
+        BridgeConstants bridgeConstants,
+        Federation activeFederation,
+        Federation proposedFederation
+    ) {
+        BtcTransaction svpFundTransaction = createSVPFundTx(bridgeConstants, activeFederation, proposedFederation);
+
+        NetworkParameters networkParameters = bridgeConstants.getBtcParams();
+        BtcTransaction svpSpendTransaction = new BtcTransaction(networkParameters);
+        svpSpendTransaction.setVersion(BTC_TX_VERSION_2);
+
+        // add inputs from fund tx
+        Script proposedFederationRedeemScript = proposedFederation.getRedeemScript();
+        int proposedFederationFormatVersion = proposedFederation.getFormatVersion();
+
+        TransactionOutput outputToProposedFed = svpFundTransaction.getOutput(0);
+        svpSpendTransaction.addInput(outputToProposedFed);
+        int proposedFederationInputIndex = 0;
+        addSpendingFederationBaseScript(svpSpendTransaction, proposedFederationInputIndex, proposedFederationRedeemScript, proposedFederationFormatVersion);
+
+        TransactionOutput outputToFlyoverProposedFed = svpFundTransaction.getOutput(1);
+        svpSpendTransaction.addInput(outputToFlyoverProposedFed);
+        int flyoverFederationInputIndex = 1;
+        Script flyoverFederationRedeemScript = getFlyoverFederationRedeemScript(bridgeConstants.getProposedFederationFlyoverPrefix(), proposedFederation.getRedeemScript());
+        addSpendingFederationBaseScript(svpSpendTransaction, flyoverFederationInputIndex, flyoverFederationRedeemScript, proposedFederationFormatVersion);
+
+        // create output to active fed
+        Coin valueSentToProposedFed = outputToProposedFed.getValue();
+        Coin valueSentToFlyoverProposedFed = outputToFlyoverProposedFed.getValue();
+
+        Coin fees = Coin.CENT;
+        Coin valueToSend = valueSentToProposedFed
+            .plus(valueSentToFlyoverProposedFed)
+            .minus(fees);
+
+        svpSpendTransaction.addOutput(
+            valueToSend,
+            activeFederation.getAddress()
+        );
+
+        return svpSpendTransaction;
+    }
+
+    public static BtcTransaction createSVPFundTx(BridgeConstants bridgeConstants, Federation activeFederation, Federation proposedFederation) {
+        NetworkParameters networkParameters = bridgeConstants.getBtcParams();
+
+        BtcTransaction prevTx = new BtcTransaction(networkParameters);
+        Coin prevAmount = Coin.COIN;
+        addOutputToFed(prevTx, activeFederation.getAddress(), prevAmount);
+
+        BtcTransaction svpFundTransaction = new BtcTransaction(networkParameters);
+        svpFundTransaction.addInput(prevTx.getOutput(0));
+        addSpendingFederationBaseScript(svpFundTransaction, 0, activeFederation.getRedeemScript(), activeFederation.getFormatVersion());
+
+        Coin svpFundTxOutputsAmountToSend = bridgeConstants.getSvpFundTxOutputsValue();
+        addOutputToFed(svpFundTransaction, proposedFederation.getAddress(), svpFundTxOutputsAmountToSend);
+        Script flyoverProposedFederationRedeemScript = getFlyoverFederationRedeemScript(bridgeConstants.getProposedFederationFlyoverPrefix(), proposedFederation.getRedeemScript());
+        Script flyoverProposedFedScript = ScriptBuilder.createP2SHP2WSHOutputScript(flyoverProposedFederationRedeemScript);
+        Address flyoverProposedFederationAddress = Address.fromP2SHScript(networkParameters, flyoverProposedFedScript);
+        addOutputToFed(svpFundTransaction, flyoverProposedFederationAddress, svpFundTxOutputsAmountToSend);
+
+        Coin changeAmount = prevAmount
+            .minus(svpFundTxOutputsAmountToSend)
+            .minus(svpFundTxOutputsAmountToSend);
+        addOutputToFed(svpFundTransaction, activeFederation.getAddress(), changeAmount);
+
+        return svpFundTransaction;
+    }
+
+    public static BtcTransaction createTxFromP2pkh(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2pkh(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2pkh(BtcTransaction btcTx) {
+        btcTx.addInput(createHash(1), 0, ScriptBuilder.createInputScript(null, SENDER_PUBLIC_KEY));
+    }
+
+    public static BtcTransaction createTxFromP2wpkh(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2wpkh(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2wpkh(BtcTransaction btcTx) {
+        Script p2wpkhOutputScript = new ScriptBuilder()
+            .smallNum(0)
+            .data(SENDER_PUBLIC_KEY.getPubKeyHash())
+            .build();
+        addInputFromBech32(btcTx, p2wpkhOutputScript);
+
+        int numSigs = 1;
+        addWitness(btcTx, numSigs, SENDER_PUBLIC_KEY.getPubKey());
+    }
+
+    public static BtcTransaction createTxFromP2wshMultiSig(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2wshMultiSig(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2wshMultiSig(BtcTransaction btcTx) {
+        byte[] witnessScriptHash = co.rsk.bitcoinj.core.Sha256Hash.hash(MULTISIG_REDEEM_SCRIPT.getProgram());
+        Script p2wshOutputScript = new ScriptBuilder()
+            .smallNum(0)
+            .data(witnessScriptHash)
+            .build();
+        addInputFromBech32(btcTx, p2wshOutputScript);
+
+        int numSigs = 2;
+        addWitness(btcTx, numSigs, MULTISIG_REDEEM_SCRIPT.getProgram());
+    }
+
+    private static void addWitness(BtcTransaction btcTx, int numSigs, byte[] lastPush) {
+        TransactionWitness txWit = new TransactionWitness(numSigs + 1);
+        for (int i = 0; i < numSigs; i++) {
+            txWit.setPush(i, new byte[72]);
+        }
+        txWit.setPush(numSigs, lastPush);
+        btcTx.setWitness(0, txWit);
+    }
+
+    private static void addInputFromBech32(BtcTransaction btcTx, Script outputScript) {
+        BtcTransaction prevTx = new BtcTransaction(btcTx.getParams());
+        prevTx.addOutput(Coin.COIN, outputScript);
+        Script emptyScriptSig = new Script(new byte[]{});
+        btcTx.addInput(prevTx.getOutput(0)).setScriptSig(emptyScriptSig);
+    }
+
+    public static BtcTransaction createTxFromP2shP2wpkh(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2shP2wpkh(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2shP2wpkh(BtcTransaction btcTx) {
+        byte[] redeemScript = ByteUtil.merge(new byte[]{0x00, 0x14}, SENDER_PUBLIC_KEY.getPubKeyHash());
+        Script witnessScript = new ScriptBuilder()
+            .data(redeemScript)
+            .build();
+        btcTx.addInput(createHash(1), 0, witnessScript);
+
+        int numSigs = 1;
+        addWitness(btcTx, numSigs, SENDER_PUBLIC_KEY.getPubKey());
+    }
+
+    public static BtcTransaction createTxFromP2shMultiSig(NetworkParameters networkParameters) {
+        Script multiSigOutputScript = ScriptBuilder.createP2SHOutputScript(MULTISIG_REDEEM_SCRIPT);
+        return createTxFromMultiSig(networkParameters, multiSigOutputScript);
+    }
+
+    public static BtcTransaction createTxFromP2shP2wshMultiSig(NetworkParameters networkParameters) {
+        Script multiSigOutputScript = ScriptBuilder.createP2SHP2WSHOutputScript(MULTISIG_REDEEM_SCRIPT);
+        return createTxFromMultiSig(networkParameters, multiSigOutputScript);
+    }
+
+    private static BtcTransaction createTxFromMultiSig(NetworkParameters networkParameters, Script multiSigOutputScript) {
+        BtcTransaction txFromMultiSig = new BtcTransaction(networkParameters);
+        addInputFromMultiSig(txFromMultiSig, multiSigOutputScript);
+        return txFromMultiSig;
+    }
+
+    private static void addInputFromMultiSig(BtcTransaction btcTx, Script multiSigOutputScript) {
+        BtcTransaction prevTx = new BtcTransaction(btcTx.getParams());
+        prevTx.addOutput(Coin.COIN, multiSigOutputScript);
+        btcTx.addInput(prevTx.getOutput(0));
+        Script inputScript = createBaseInputScriptThatSpendsFromRedeemScript(MULTISIG_REDEEM_SCRIPT);
+        btcTx.getInput(0).setScriptSig(inputScript);
+    }
+
+    public static void addOutputToFedWithMinimumPeginValue(BtcTransaction btcTx, Address federationAddress) {
+        addOutputToFed(btcTx, federationAddress, MINIMUM_PEGIN_TX_VALUE);
+    }
+
+    public static void addOutputToFedBelowMinimumPeginValue(BtcTransaction btcTx, Address federationAddress) {
+        Coin amountBelowMinimum = MINIMUM_PEGIN_TX_VALUE.subtract(Coin.valueOf(1L));
+        addOutputToFed(btcTx, federationAddress, amountBelowMinimum);
+    }
+
+    public static void addOutputToFed(BtcTransaction btcTx, Address federationAddress, Coin amountToSend) {
+        btcTx.addOutput(amountToSend, federationAddress);
+    }
+
+    public static void addOpReturnOutput(BtcTransaction btcTx) {
+        btcTx.addOutput(OP_RETURN_OUTPUT_AMOUNT, createOpReturnScriptForRsk(V1_PROTOCOL_VERSION));
+    }
+
+    public static void addOpReturnOutputInvalidPayload(BtcTransaction btcTx) {
+        btcTx.addOutput(OP_RETURN_OUTPUT_AMOUNT, createOpReturnScriptForRskInvalidPayload());
+    }
+
+    public static void addOpReturnOutputInvalidPayloadWithRefundAddress(BtcTransaction btcTx) {
+        btcTx.addOutput(OP_RETURN_OUTPUT_AMOUNT, createOpReturnScriptForRskInvalidPayloadWithRefundAddress());
+    }
+
+    private static Script createOpReturnScriptForRskInvalidPayload() {
+        byte[] payloadBytes = new byte[INVALID_PAYLOAD_LENGTH];
+        addRskPrefix(payloadBytes);
+        addProtocolVersion(payloadBytes, V1_PROTOCOL_VERSION);
+        addDestinationAddress(payloadBytes);
+        return ScriptBuilder.createOpReturnScript(payloadBytes);
+    }
+
+    private static Script createOpReturnScriptForRskInvalidPayloadWithRefundAddress() {
+        byte[] payloadBytes = new byte[INVALID_PAYLOAD_LENGTH];
+        addDefaultPayload(payloadBytes, V1_PROTOCOL_VERSION);
+        addRefundP2pkhAddress(payloadBytes);
+        return ScriptBuilder.createOpReturnScript(payloadBytes);
+    }
+
+    public static void addOpReturnOutputWithRefundAddress(BtcTransaction btcTx) {
+        btcTx.addOutput(OP_RETURN_OUTPUT_AMOUNT, createOpReturnScriptForRskWithP2pkhRefundAddress(V1_PROTOCOL_VERSION));
+    }
+
+    public static void addOpReturnOutputUnknownProtocolVersion(BtcTransaction btcTx) {
+        btcTx.addOutput(OP_RETURN_OUTPUT_AMOUNT, createOpReturnScriptForRsk(UNKNOWN_PROTOCOL_VERSION));
+    }
+
+    public static void addOpReturnOutputUnknownProtocolVersionWithRefundAddress(BtcTransaction btcTx) {
+        btcTx.addOutput(OP_RETURN_OUTPUT_AMOUNT, createOpReturnScriptForRskWithP2pkhRefundAddress(UNKNOWN_PROTOCOL_VERSION));
+    }
+
+    private static Script createOpReturnScriptForRsk(int protocolVersion) {
+        int defaultPayloadBytesLength = RSK_PREFIX_LENGTH + PROTOCOL_VERSION_LENGTH + RSK_DESTINATION_ADDRESS_LENGTH;
+        byte[] payloadBytes = new byte[defaultPayloadBytesLength];
+        addDefaultPayload(payloadBytes, protocolVersion);
+        return ScriptBuilder.createOpReturnScript(payloadBytes);
+    }
+
+    private static Script createOpReturnScriptForRskWithP2pkhRefundAddress(int protocolVersion) {
+        byte[] payloadBytes = new byte[PAYLOAD_WITH_REFUND_ADDRESS_LENGTH];
+        addDefaultPayload(payloadBytes, protocolVersion);
+        addRefundP2pkhAddress(payloadBytes);
+        return ScriptBuilder.createOpReturnScript(payloadBytes);
+    }
+
+    private static void addRefundP2pkhAddress(byte[] payloadBytes) {
+        int refundAddressTypeIndex = 25;
+        byte p2PkhAddressType = 1;
+        payloadBytes[refundAddressTypeIndex] = p2PkhAddressType;
+        int refundAddressIndex = refundAddressTypeIndex + 1;
+        System.arraycopy(
+            SENDER_PUBLIC_KEY.getPubKeyHash(),
+            0,
+            payloadBytes,
+            refundAddressIndex,
+            SENDER_PUBLIC_KEY.getPubKeyHash().length
+        );
+    }
+
+    private static void addDefaultPayload(byte[] payloadBytes, int protocolVersion) {
+        addRskPrefix(payloadBytes);
+        addProtocolVersion(payloadBytes, protocolVersion);
+        addDestinationAddress(payloadBytes);
+    }
+
+    private static void addRskPrefix(byte[] payloadBytes) {
+        System.arraycopy(RSK_PREFIX, 0, payloadBytes, RSK_PREFIX_INDEX, RSK_PREFIX_LENGTH);
+    }
+
+    private static void addProtocolVersion(byte[] payloadBytes, int protocolVersion) {
+        var index = RSK_PREFIX.length;
+        payloadBytes[index] = (byte) protocolVersion;
+    }
+
+    private static void addDestinationAddress(byte[] payloadBytes) {
+        System.arraycopy(
+            DESTINATION_ADDRESS.getBytes(),
+            0,
+            payloadBytes,
+            RSK_DESTINATION_ADDRESS_INDEX,
+            RSK_DESTINATION_ADDRESS_LENGTH
+        );
+    }
+
+    public static BtcTransaction createCoinbaseTransactionWithWitnessCommitment(
+        co.rsk.bitcoinj.core.NetworkParameters networkParameters,
+        co.rsk.bitcoinj.core.Sha256Hash witnessCommitment
+    ) {
+        BtcTransaction coinbaseTx = createCoinbaseTxWithWitnessReservedValue(networkParameters);
+        byte[] WITNESS_COMMITMENT_HEADER = org.bouncycastle.util.encoders.Hex.decode("aa21a9ed");
+
+        byte[] witnessCommitmentWithHeader = ByteUtil.merge(
+            WITNESS_COMMITMENT_HEADER,
+            witnessCommitment.getBytes()
+        );
+        coinbaseTx.addOutput(co.rsk.bitcoinj.core.Coin.ZERO, ScriptBuilder.createOpReturnScript(witnessCommitmentWithHeader));
+        coinbaseTx.verify();
+
+        return coinbaseTx;
+    }
+
+    private static BtcTransaction createCoinbaseTxWithWitnessReservedValue(NetworkParameters rskNetworkParameters) {
+        BtcTransaction coinbaseTx = createCoinbaseTransaction(rskNetworkParameters);
+        TransactionWitness txWitness = new TransactionWitness(1);
+        txWitness.setPush(0, WITNESS_RESERVED_VALUE.getBytes());
+        coinbaseTx.setWitness(0, txWitness);
+        return coinbaseTx;
+    }
+
+    private static BtcTransaction createCoinbaseTransaction(NetworkParameters rskNetworkParameters) {
+        Address rewardAddress = createP2PKHAddress(rskNetworkParameters, "miner");
+        Script inputScript = new Script(new byte[]{1, 0});
+        BtcTransaction coinbaseTx = new BtcTransaction(rskNetworkParameters);
+        coinbaseTx.addInput(
+            co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH,
+            -1L,
+            inputScript
+        );
+        coinbaseTx.addOutput(Coin.COIN, rewardAddress);
+        coinbaseTx.verify();
+        return coinbaseTx;
     }
 }

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -1,5 +1,6 @@
 package co.rsk.federate.bitcoin;
 
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
 import static org.bitcoinj.script.ScriptOpCodes.OP_RETURN;
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,9 +45,10 @@ class BitcoinWrapperImplTest {
     private static final co.rsk.bitcoinj.core.NetworkParameters thinNetworkParameters = bridgeConstants.getBtcParams();
     private static final NetworkParameters originalNetworkParameters = ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString());
     private static final Context btcContext = new Context(originalNetworkParameters);
+    private FederatorSupport federatorSupport;
+
     private BtcToRskClientFileStorage btcToRskClientFileStorage;
     private BtcToRskClientBuilder btcToRskClientBuilder;
-    private FederatorSupport federatorSupport;
     private BitcoinWrapperImpl bitcoinWrapper;
     private TransactionListener listener;
 
@@ -56,12 +58,7 @@ class BitcoinWrapperImplTest {
     @BeforeEach
     void setUp() throws Exception {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP379)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP305)).thenReturn(true);
-
+        when(activations.isActive(any(ConsensusRule.class))).thenReturn(true);
         ActivationConfig activationConfig = mock(ActivationConfig.class);
         when(activationConfig.forBlock(any(Long.class))).thenReturn(activations);
         federatorSupport = mock(FederatorSupport.class);
@@ -81,10 +78,6 @@ class BitcoinWrapperImplTest {
         Kit kit = new KitForTests(btcContext, mock(File.class), "", mock(Wallet.class));
         bitcoinWrapper = new BitcoinWrapperImpl(
             btcContext,
-            bridgeConstants,
-            btcLockSenderProvider,
-            peginInstructionsProvider,
-            federatorSupport,
             kit
         );
 
@@ -110,10 +103,24 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.addFederationListener(federationToListen, listener);
     }
 
+    private static Stream<Federation> fedArgs() {
+        final Federation standardMultisigFederation = TestUtils.createStandardMultisigFederation(
+            thinNetworkParameters,
+            9
+        );
+        final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
+
+        return Stream.of(standardMultisigFederation, p2shP2wshErpFederation);
+    }
+
     @ParameterizedTest
     @MethodSource("fedArgs")
     void coinsReceivedOrSent_validLegacyPegIn_shouldListenTx(Federation federation) throws Exception {
         // Arrange
+        when(federatorSupport.getFederationAddress()).thenReturn(federation.getAddress());
         setUpListenerAndWrapperWithFederation(federation);
         Transaction pegin = createLegacyPegIn(federation);
 
@@ -128,6 +135,7 @@ class BitcoinWrapperImplTest {
     @MethodSource("fedArgs")
     void coinsReceivedOrSent_validPeginV1_shouldListenTx(Federation federation) throws Exception {
         // Arrange
+        when(federatorSupport.getFederationAddress()).thenReturn(federation.getAddress());
         setUpListenerAndWrapperWithFederation(federation);
         Transaction pegin = createValidPegInV1(federation.getAddress());
 
@@ -176,8 +184,9 @@ class BitcoinWrapperImplTest {
     @MethodSource("fedArgs")
     void coinsReceivedOrSent_validPegOutTx_shouldListenTx(Federation federation) throws Exception {
         // Arrange
-        final Transaction pegout = createPegOutTx(federation);
+        when(federatorSupport.getFederationAddress()).thenReturn(federation.getAddress());
         setUpListenerAndWrapperWithFederation(federation);
+        final Transaction pegout = createPegOutTx(federation);
 
         // Act
         bitcoinWrapper.coinsReceivedOrSent(pegout);
@@ -220,35 +229,54 @@ class BitcoinWrapperImplTest {
         return ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), pegout);
     }
 
-    private static Stream<Federation> fedArgs() {
-        final Federation standarMultisigFederation = TestUtils.createStandardMultisigFederation(
+    private static Stream<Arguments> retiringAndActiveFedsArgs() {
+        final Federation standardMultiSigFed = TestUtils.createStandardMultisigFederation(
             thinNetworkParameters,
             9
         );
-        final Federation p2shErpFederation = TestUtils.createP2shErpFederation(
+        final Federation firstP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             9
         );
-        final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+        final Federation secondP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             20
         );
 
-        return Stream.of(standarMultisigFederation, p2shErpFederation, p2shP2wshErpFederation);
+        return Stream.of(
+            Arguments.of(standardMultiSigFed, firstP2shP2wshErpFed),
+            Arguments.of(firstP2shP2wshErpFed, secondP2shP2wshErpFed)
+        );
     }
 
     @ParameterizedTest
     @MethodSource("retiringAndActiveFedsArgs")
-    void coinsReceivedOrSent_migrationTx_shouldListenTx(
-        Federation retiringFederation,
-        Federation activeFederation
-    ) throws Exception {
+    void coinsReceivedOrSent_migrationTx_activeFedListener_shouldListenTx(Federation retiringFederation, Federation activeFederation) throws Exception {
         // Arrange
         when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
         when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
-
         setUpListenerAndWrapperWithFederation(activeFederation);
-        Transaction migrationTx = createMigrationTx(retiringFederation, activeFederation);
+        var migrationBtcTx = createMigrationTx(thinNetworkParameters, retiringFederation, activeFederation);
+
+        // Act
+        var migrationTx = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), migrationBtcTx);
+        bitcoinWrapper.coinsReceivedOrSent(migrationTx);
+
+        // Assert
+        assertWTxIdWasAddedToProofs(migrationTx);
+    }
+
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_migrationTxBelowMinimumPeginValue_activeFedListener_shouldListenTx(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // Arrange
+        when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
+        when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
+        setUpListenerAndWrapperWithFederation(activeFederation);
+        var migrationBtcTx = createMigrationTxBelowMinimumPeginValue(thinNetworkParameters, retiringFederation, activeFederation);
+
+        // Act
+        var migrationTx = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), migrationBtcTx);
 
         // act
         bitcoinWrapper.coinsReceivedOrSent(migrationTx);
@@ -257,67 +285,67 @@ class BitcoinWrapperImplTest {
         assertWTxIdWasAddedToProofs(migrationTx);
     }
 
-    private static Stream<Arguments> retiringAndActiveFedsArgs() {
-        final Federation retiringP2shErpFed = TestUtils.createP2shErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation activeP2shErpFed = TestUtils.createP2shErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation retiringP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation activeP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
-            thinNetworkParameters,
-            9
-        );
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_migrationTx_retiringFedListener_shouldNotListenTx(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // Arrange
+        when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
+        when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
+        setUpListenerAndWrapperWithFederation(retiringFederation);
+        var migrationBtcTx = createMigrationTx(thinNetworkParameters, retiringFederation, activeFederation);
 
-        return Stream.of(
-            Arguments.of(retiringP2shErpFed, activeP2shErpFed),
-            Arguments.of(retiringP2shErpFed, activeP2shP2wshErpFed),
-            Arguments.of(retiringP2shP2wshErpFed, activeP2shP2wshErpFed)
-        );
+        // Act
+        var migrationTx = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), migrationBtcTx);
+        bitcoinWrapper.coinsReceivedOrSent(migrationTx);
+
+        // Assert
+        assertWTxIdWasNotAddedToProofs();
     }
 
-    private Transaction createMigrationTx(Federation retiringFederation, Federation activeFederation) {
-        co.rsk.bitcoinj.core.Address retiringFederationAddress = retiringFederation.getAddress();
-        co.rsk.bitcoinj.core.Address activeFederationAddress = activeFederation.getAddress();
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_peginToActiveFed_listenerForBothFeds_retiringFedListenerFirst_shouldListenTx(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // Arrange
+        when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
+        when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
 
-        List<BtcTransaction> txsToMigrate = new ArrayList<>();
-        co.rsk.bitcoinj.core.Coin baseCoin = co.rsk.bitcoinj.core.Coin.valueOf(1_000_000L);
-        for (int i = 1; i <= 10; i++) {
-            BtcTransaction txSentToRetiringFed = new BtcTransaction(thinNetworkParameters);
-            co.rsk.bitcoinj.core.Coin value = baseCoin.multiply(i);
-            txSentToRetiringFed.addOutput(value, retiringFederationAddress);
+        setUpListenerAndWrapperWithFederation(retiringFederation);
+        listener = btcToRskClientBuilder
+            .withFederation(activeFederation)
+            .build();
+        bitcoinWrapper.addFederationListener(activeFederation, listener);
 
-            txsToMigrate.add(txSentToRetiringFed);
-        }
+        var peginBtcTxToActiveFed = createPegIn(activeFederation.getAddress());
 
-        BtcTransaction thinMigrationTx = new BtcTransaction(thinNetworkParameters);
-        for (int i = 0; i < txsToMigrate.size(); i++) {
-            BtcTransaction txToMigrate = txsToMigrate.get(i);
-            co.rsk.bitcoinj.core.TransactionOutput output = txToMigrate.getOutput(0);
-            thinMigrationTx.addInput(output);
+        // Act
+        var peginTxToActiveFed = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), peginBtcTxToActiveFed);
+        bitcoinWrapper.coinsReceivedOrSent(peginTxToActiveFed);
 
-            addSpendingFederationBaseScript(
-                thinMigrationTx,
-                i,
-                retiringFederation.getRedeemScript(),
-                retiringFederation.getFormatVersion()
-            );
-        }
+        // Assert
+        assertWTxIdWasAddedToProofs(peginTxToActiveFed);
+    }
 
-        co.rsk.bitcoinj.core.Coin totalValue = co.rsk.bitcoinj.core.Coin.ZERO;
-        for (BtcTransaction txToMigrate : txsToMigrate) {
-            co.rsk.bitcoinj.core.TransactionOutput output = txToMigrate.getOutput(0);
-            totalValue = totalValue.add(output.getValue());
-        }
-        thinMigrationTx.addOutput(totalValue, activeFederationAddress);
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_peginToRetiringFed_listenerForBothFeds_activeFedListenerFirst_shouldListenTx(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // Arrange
+        when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
+        when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
 
-        return ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), thinMigrationTx);
+        setUpListenerAndWrapperWithFederation(activeFederation);
+        listener = btcToRskClientBuilder
+            .withFederation(retiringFederation)
+            .build();
+        bitcoinWrapper.addFederationListener(retiringFederation, listener);
+
+        var peginBtcTxToActiveFed = createPegIn(retiringFederation.getAddress());
+
+        // Act
+        var peginTxToActiveFed = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), peginBtcTxToActiveFed);
+        bitcoinWrapper.coinsReceivedOrSent(peginTxToActiveFed);
+
+        // Assert
+        assertWTxIdWasAddedToProofs(peginTxToActiveFed);
     }
 
     private void assertWTxIdWasAddedToProofs(Transaction tx) throws IOException {
@@ -332,35 +360,11 @@ class BitcoinWrapperImplTest {
         assertEquals(wTxId, savedWTxId);
     }
 
-    // Class that allows to override certain methods in Kit class
-    // that are inherited from WalletAppKit class and can't be mocked
-    private static class KitForTests extends Kit {
+    private void assertWTxIdWasNotAddedToProofs() throws IOException {
+        BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(originalNetworkParameters).getData();
+        Map<Sha256Hash, List<Proof>> transactionProofs = fileData.getTransactionProofs();
 
-        private final Wallet wallet;
-
-        public KitForTests(Context btcContext, File directory, String filePrefix, Wallet wallet) {
-            super(btcContext, directory, filePrefix);
-            this.wallet = wallet;
-        }
-
-        @Override
-        protected void startUp() {
-            // Not needed for tests
-        }
-
-        @Override
-        protected void shutDown() {
-            // Not needed for tests
-        }
-
-        @Override
-        protected Wallet createWallet() {
-            return wallet;
-        }
-
-        @Override
-        public Wallet wallet() {
-            return wallet;
-        }
+        Set<Sha256Hash> txProofsKeySet = transactionProofs.keySet();
+        assertEquals(0, txProofsKeySet.size());
     }
 }

--- a/src/test/java/co/rsk/federate/bitcoin/KitForTests.java
+++ b/src/test/java/co/rsk/federate/bitcoin/KitForTests.java
@@ -1,0 +1,61 @@
+package co.rsk.federate.bitcoin;
+
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.store.BlockStore;
+import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.wallet.Wallet;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Class that allows to override certain methods in Kit class
+// that are inherited from WalletAppKit class and can't be mocked
+public class KitForTests extends Kit {
+    private final Wallet wallet;
+    private BlockStore store;
+
+    public KitForTests(Context btcContext, File directory, String filePrefix, Wallet wallet) {
+        super(btcContext, directory, filePrefix);
+        this.wallet = wallet;
+    }
+
+    public void setStore(StoredBlock[] storedBlocks) throws BlockStoreException {
+        BlockStore blockStore = mock(BlockStore.class);
+        for (int i = 0; i < storedBlocks.length; i++) {
+            StoredBlock storedBlock = Arrays.stream(storedBlocks).toList().get(i);
+            when(blockStore.get(storedBlock.getHeader().getHash())).thenReturn(storedBlock);
+            when(blockStore.getChainHead()).thenReturn(storedBlock);
+        }
+
+        this.store = blockStore;
+    }
+
+    @Override
+    protected void startUp() {
+        // Not needed for tests
+    }
+
+    @Override
+    protected void shutDown() {
+        // Not needed for tests
+    }
+
+    @Override
+    protected Wallet createWallet() {
+        return wallet;
+    }
+
+    @Override
+    public Wallet wallet() {
+        return wallet;
+    }
+
+    @Override
+    public BlockStore store() {
+        return store;
+    }
+}

--- a/src/test/java/co/rsk/federate/bitcoin/KitTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/KitTest.java
@@ -5,13 +5,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import co.rsk.peg.constants.BridgeConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
-import co.rsk.federate.FederatorSupport;
-import co.rsk.federate.adapter.ThinConverter;
 import co.rsk.federate.signing.utils.TestUtils;
-import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
-import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,29 +19,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class KitTest {
-    private static BridgeConstants bridgeConstants;
+
     private static Context btcContext;
 
     @BeforeEach
     void setUpBeforeClass() {
-        bridgeConstants = new BridgeRegTestConstants();
-        NetworkParameters networkParameters = ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString());
+        NetworkParameters networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
         btcContext = new Context(networkParameters);
     }
 
     @Test
     void setupConsistentWallet() {
-        BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
-        PeginInstructionsProvider peginInstructionsProvider = mock(PeginInstructionsProvider.class);
-        FederatorSupport federatorSupport = mock(FederatorSupport.class);
         File pegDirectoryMock = mock(File.class);
 
         BitcoinWrapper bitcoinWrapper = new BitcoinWrapperImpl(
             btcContext,
-            bridgeConstants,
-            btcLockSenderProvider,
-            peginInstructionsProvider,
-            federatorSupport,
             new Kit(btcContext, pegDirectoryMock, "")
         );
         List<PeerAddress> peerAddresses = new ArrayList<>();
@@ -70,17 +56,10 @@ class KitTest {
 
     @Test
     void setupNoConsistentWallet() {
-        BtcLockSenderProvider btcLockSenderProvider = mock(BtcLockSenderProvider.class);
-        PeginInstructionsProvider peginInstructionsProvider = mock(PeginInstructionsProvider.class);
-        FederatorSupport federatorSupport = mock(FederatorSupport.class);
         File pegDirectoryMock = mock(File.class);
 
         BitcoinWrapper bitcoinWrapper = new BitcoinWrapperImpl(
             btcContext,
-            bridgeConstants,
-            btcLockSenderProvider,
-            peginInstructionsProvider,
-            federatorSupport,
             new Kit(btcContext, pegDirectoryMock, "")
         );
         List<PeerAddress> peerAddresses = new ArrayList<>();

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -139,12 +139,28 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
-        Federation fed1 = TestUtils.createStandardMultisigFederation(params, 1);
+        // keys generated with indexes from 0 to 4
+        int fed1MembersCount = 5;
+        List<BtcECKey> fed1Keys = new ArrayList<>();
+        for (int i = 0; i < fed1MembersCount; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            fed1Keys.add(key);
+        }
+        Federation fed1 = TestUtils.createStandardMultisigFederation(params, fed1Keys);
         FederationMember federationMember1 = fed1.getMembers().get(0);
         doReturn(federationMember1).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed1);
 
-        Federation fed2 = TestUtils.createStandardMultisigFederation(params, 1);
+        // keys generated with indexes from 1 to 5, making sure both feds have one member just part of them
+        int fed2MembersCount = 5;
+        List<BtcECKey> fed2Keys = new ArrayList<>();
+        for (int i = 1; i < fed2MembersCount + 1; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            fed2Keys.add(key);
+        }
+        Federation fed2 = TestUtils.createStandardMultisigFederation(params, fed2Keys);
         FederationMember federationMember2 = fed2.getMembers().get(0);
         doReturn(federationMember2).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed2);
@@ -164,12 +180,28 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
-        Federation fed1 = TestUtils.createStandardMultisigFederation(params, 1);
+        // keys generated with indexes from 0 to 4
+        int fed1MembersCount = 5;
+        List<BtcECKey> fed1Keys = new ArrayList<>();
+        for (int i = 0; i < fed1MembersCount; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            fed1Keys.add(key);
+        }
+        Federation fed1 = TestUtils.createStandardMultisigFederation(params, fed1Keys);
         FederationMember federationMember1 = fed1.getMembers().get(0);
         doReturn(federationMember1).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed1);
 
-        Federation fed2 = TestUtils.createStandardMultisigFederation(params, 1);
+        // keys generated with indexes from 1 to 5, making sure both feds have one member just part of them
+        int fed2MembersCount = 5;
+        List<BtcECKey> fed2Keys = new ArrayList<>();
+        for (int i = 1; i < fed2MembersCount + 1; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            fed2Keys.add(key);
+        }
+        Federation fed2 = TestUtils.createStandardMultisigFederation(params, fed2Keys);
         FederationMember federationMember2 = fed2.getMembers().get(0);
         doReturn(federationMember2).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed2);
@@ -192,12 +224,28 @@ class BtcReleaseClientTest {
             mock(NodeBlockProcessor.class)
         );
 
-        Federation fed1 = TestUtils.createStandardMultisigFederation(params, 1);
+        // keys generated with indexes from 0 to 4
+        int fed1MembersCount = 5;
+        List<BtcECKey> fed1Keys = new ArrayList<>();
+        for (int i = 0; i < fed1MembersCount; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            fed1Keys.add(key);
+        }
+        Federation fed1 = TestUtils.createStandardMultisigFederation(params, fed1Keys);
         FederationMember federationMember1 = fed1.getMembers().get(0);
         doReturn(federationMember1).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed1);
 
-        Federation fed2 = TestUtils.createStandardMultisigFederation(params, 1);
+        // keys generated with indexes from 1 to 5, making sure both feds have one member just part of them
+        int fed2MembersCount = 5;
+        List<BtcECKey> fed2Keys = new ArrayList<>();
+        for (int i = 1; i < fed2MembersCount + 1; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            fed2Keys.add(key);
+        }
+        Federation fed2 = TestUtils.createStandardMultisigFederation(params, fed2Keys);
         FederationMember federationMember2 = fed2.getMembers().get(0);
         doReturn(federationMember2).when(federatorSupport).getFederationMember();
         btcReleaseClient.start(fed2);
@@ -291,11 +339,11 @@ class BtcReleaseClientTest {
         // when recreating already signed pegouts
         // we need to manually add the sigs,
         // since the real signing is done by the bridge
-        
+
         private final byte[] bridgeContractAddressSerialized = PrecompiledContracts.BRIDGE_ADDR.getBytes();
         private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
         private final CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-        
+
         // feds setup
         private final BtcECKey keyFile1BtcPubKey = getBtcEcKeyFromSeed("keyFile1BtcPubKey");
         private final ECKey keyFile1RskPubKey = ECKey.fromPublicOnly(keyFile1BtcPubKey.getPubKey());
@@ -314,7 +362,7 @@ class BtcReleaseClientTest {
         private final long erpActivationDelay = federationMainnetConstants.getErpFedActivationDelay();
         private final Instant creationTime = Instant.ofEpochSecond(100_000_000L);
         private final long creationBlockNumber = 1L;
-        
+
         private final FederationArgs federationArgs = new FederationArgs(members, creationTime, creationBlockNumber, params);
         private final Federation legacyFederation =
             FederationFactory.buildP2shErpFederation(federationArgs, erpFedKeys, erpActivationDelay);
@@ -573,7 +621,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithKeyFile_legacyFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
             addReleaseTxFromFedToSet(legacyFederation);
-            
+
             int signerVersion = 1;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
             setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
@@ -594,7 +642,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithHSM_legacyFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
             addReleaseTxFromFedToSet(legacyFederation);
-            
+
             int signerVersion = 5;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
             setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
@@ -615,7 +663,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithKeyFile_whenOtherFedAlreadySigned_legacyFed_ok() throws Exception {
             // Arrange
             addReleaseTxFromFedToSet(legacyFederation);
-            
+
             int signerVersion = 1;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
             setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
@@ -624,7 +672,7 @@ class BtcReleaseClientTest {
 
             // act
             client.processReleases(releases.entrySet());
-            
+
             // assert
             BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
             verify(federatorSupport).addSignature(
@@ -637,7 +685,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithHSM_whenOtherFedAlreadySigned_legacyFed_ok() throws Exception {
             // Arrange
             addReleaseTxFromFedToSet(legacyFederation);
-            
+
             int signerVersion = 5;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
             setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
@@ -795,7 +843,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithHSM_segwitFed_ok() throws Exception {
             // Arrange
             addReleaseTxFromFedToSet(segwitFederation);
-            
+
             int signerVersion = 5;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
             setUpFederator(segwitFederation, hsm1Member, signerVersion, ethSig);
@@ -815,7 +863,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithKeyFile_segwitFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
             addReleaseTxFromFedToSet(segwitFederation);
-            
+
             int signerVersion = 1;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
             setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
@@ -858,7 +906,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithKeyFile_whenOtherFedAlreadySigned_segwitFed_ok() throws Exception {
             // arrange
             addReleaseTxFromFedToSet(segwitFederation);
-            
+
             int signerVersion = 1;
             ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
             setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
@@ -914,7 +962,7 @@ class BtcReleaseClientTest {
 
             setUpBlockchainForProcessingRelease(unprocessableTestnetPegoutRskTxCreationHash, unprocessableReleaseTx);
         }
-        
+
         private void setUpFederator(
             Federation federation,
             FederationMember member,
@@ -1212,7 +1260,7 @@ class BtcReleaseClientTest {
         field = pegoutSignedCache.getClass().getDeclaredField("clock");
         field.setAccessible(true);
         field.set(pegoutSignedCache, Clock.offset(baseClock, Duration.ofHours(1)));
-    
+
         // At this point the pegout tx is invalid in the pegouts signed cache,
         // so it should not throw an exception
         assertDoesNotThrow(
@@ -1339,7 +1387,7 @@ class BtcReleaseClientTest {
                 List.of(federationKeys.get(0))
             );
         }
-      
+
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
         Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
         StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(svpSpendTxWFS);
@@ -1406,7 +1454,7 @@ class BtcReleaseClientTest {
         ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
 
         // Assert
-        
+
         // We should have searched by the expected svp spend tx hash
         BitcoinUtils.removeSignaturesFromMultiSigTransaction(svpSpendTx);
         assertEquals(svpSpendTxHashBeforeSigning, svpSpendTx.getHash());
@@ -1422,15 +1470,32 @@ class BtcReleaseClientTest {
     void onBestBlock_whenBothPegoutAndSvpSpendTxWaitingForSignaturesAreAvailableAndFederatorIsOnlyPartOfProposedFederation_shouldOnlyAddOneSignature() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 9);
+        int federationMembersCount = 10;
+        List<BtcECKey> federationMemberKeys = new ArrayList<>();
+        // keys generated with indexes from 0 to 9
+        for (int i = 0; i < federationMembersCount; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            federationMemberKeys.add(key);
+        }
+        Federation federation = TestUtils.createStandardMultisigFederation(params, federationMemberKeys);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
         rskTxsWaitingForSignatures.put(pegoutCreationRskTxHash, pegout);
         StateForFederator stateForFederator = new StateForFederator(rskTxsWaitingForSignatures);
 
-        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, 9);
-        FederationMember federationMember = proposedFederation.getMembers().get(0);
+        int proposedFedMembersCount = 11;
+        List<BtcECKey> proposedFedMemberKeys = new ArrayList<>();
+        // keys generated with indexes from 0 to 10, making sure last member of proposed fed is just part of it
+        for (int i = 0; i < proposedFedMembersCount; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            proposedFedMemberKeys.add(key);
+        }
+        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, proposedFedMemberKeys);
+        int lastMemberIndex = proposedFedMembersCount - 1;
+        FederationMember federatorJustPartOfProposedFederation = proposedFederation.getMembers().get(lastMemberIndex);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(1);
         Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
@@ -1443,14 +1508,14 @@ class BtcReleaseClientTest {
             return null;
         }).when(ethereum).addListener(any(EthereumListener.class));
 
-        doReturn(federationMember).when(federatorSupport).getFederationMember();
+        doReturn(federatorJustPartOfProposedFederation).when(federatorSupport).getFederationMember();
         // returns pegout waiting for signatures
         doReturn(stateForFederator).when(federatorSupport).getStateForFederator();
         // return svp spend tx waiting for signatures
         doReturn(Optional.of(stateForProposedFederator)).when(federatorSupport).getStateForProposedFederator();
 
         ECKey ecKey = new ECKey();
-        ECPublicKey signerPublicKey = new ECPublicKey(federationMember.getBtcPublicKey().getPubKey());
+        ECPublicKey signerPublicKey = new ECPublicKey(federatorJustPartOfProposedFederation.getBtcPublicKey().getPubKey());
 
         doReturn(signerPublicKey).when(signer).getPublicKey(BTC.getKeyId());
         doReturn(1).when(signer).getVersionForKeyId(ArgumentMatchers.any(KeyId.class));
@@ -1690,7 +1755,7 @@ class BtcReleaseClientTest {
         );
 
         btcReleaseClient.start(proposedFederation);
-      
+
         // Act
         ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
 
@@ -1956,7 +2021,7 @@ class BtcReleaseClientTest {
 
         ECPublicKey signerPublicKey = new ECPublicKey(federator1PrivKey.getPubKey());
         Mockito.doReturn(signerPublicKey).when(signer).getPublicKey(ArgumentMatchers.any(KeyId.class));
-      
+
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         client = new BtcReleaseClient(

--- a/src/test/java/co/rsk/federate/mock/SimpleFederatorSupport.java
+++ b/src/test/java/co/rsk/federate/mock/SimpleFederatorSupport.java
@@ -1,19 +1,31 @@
 package co.rsk.federate.mock;
 
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.config.TestSystemProperties;
+
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationMember;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.PartialMerkleTree;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
+import org.ethereum.crypto.ECKey;
+
+import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 
 /**
  * Created by ajlopez on 6/2/2016.
  */
 public class SimpleFederatorSupport extends FederatorSupport {
+    private Federation federation;
     private Block[] headers;
     private int sendReceiveHeadersInvocations = 0;
     private final List<TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction = new ArrayList<>();
@@ -66,6 +78,54 @@ public class SimpleFederatorSupport extends FederatorSupport {
     @Override
     public List<PeerAddress> getBitcoinPeerAddresses() {
         return null;
+    }
+
+    public void setFederation(Federation federation) {
+        this.federation = federation;
+    }
+
+    @Override
+    public Address getFederationAddress() {
+        return federation.getAddress();
+    }
+
+    @Override
+    public Integer getFederationSize() {
+        return federation.getSize();
+    }
+
+    @Override
+    public ECKey getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
+        FederationMember member = federation.getMembers().get(index);
+        return switch (keyType) {
+            case BTC -> ECKey.fromPublicOnly(member.getBtcPublicKey().getPubKey());
+            case RSK -> member.getRskPublicKey();
+            case MST -> member.getMstPublicKey();
+        };
+    }
+    @Override
+    public Instant getFederationCreationTime() {
+        return federation.getCreationTime();
+    }
+
+    @Override
+    public long getFederationCreationBlockNumber() {
+        return federation.getCreationBlockNumber();
+    }
+
+    @Override
+    public NetworkParameters getBtcParams() {
+        return federation.getBtcParams();
+    }
+
+    @Override
+    public Integer getRetiringFederationSize() {
+        return FEDERATION_NON_EXISTENT.getCode();
+    }
+
+    @Override
+    public Optional<Integer> getProposedFederationSize() {
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -15,6 +15,7 @@ import co.rsk.federate.signing.LegacySigHashCalculatorImpl;
 import co.rsk.federate.signing.SegwitSigHashCalculatorImpl;
 import co.rsk.federate.signing.SigHashCalculator;
 import co.rsk.federate.signing.hsm.HSMVersion;
+import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.*;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
@@ -23,6 +24,8 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
+
+import co.rsk.peg.federation.constants.FederationConstants;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -32,7 +35,7 @@ import org.ethereum.crypto.HashUtil;
 
 public final class TestUtils {
     private static final long CREATION_BLOCK_NUMBER = 0;
-    private static final List<BtcECKey> erpFedPubKeysList = Stream.of(
+    private static final List<BtcECKey> ERP_FED_PUB_KEYS_LIST = Stream.of(
         "0257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d4",
         "03c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f9",
         "03cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b3",
@@ -97,10 +100,12 @@ public final class TestUtils {
     }
 
     public static Federation createStandardMultisigFederation(NetworkParameters params, int amountOfMembers) {
-        List<BtcECKey> keys = Stream
-            .generate(BtcECKey::new)
-            .limit(amountOfMembers)
-            .toList();
+        List<BtcECKey> keys = new ArrayList<>();
+        for (int i = 0; i < amountOfMembers; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            keys.add(key);
+        }
         return createStandardMultisigFederation(params, keys);
     }
 
@@ -116,27 +121,13 @@ public final class TestUtils {
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
-    public static Federation createP2shErpFederation(NetworkParameters params, int amountOfMembers) {
-        List<BtcECKey> keys = Stream
-            .generate(BtcECKey::new)
-            .limit(amountOfMembers)
-            .toList();
-        return createP2shErpFederation(params, keys);
-    }
-
-    public static Federation createP2shErpFederation(NetworkParameters params, List<BtcECKey> keys) {
-        final long CREATION_BLOCK_NUMBER = 0;
-        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
-        return FederationFactory.buildP2shErpFederation(federationArgs, erpFedPubKeysList,
-            ERP_FED_ACTIVATION_DELAY);
-    }
-
     public static Federation createP2shP2wshErpFederation(NetworkParameters params, int amountOfMembers) {
-        List<BtcECKey> keys = Stream
-            .generate(BtcECKey::new)
-            .limit(amountOfMembers)
-            .toList();
+        List<BtcECKey> keys = new ArrayList<>();
+        for (int i = 0; i < amountOfMembers; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            keys.add(key);
+        }
 
         return createP2shP2wshErpFederation(params, keys);
     }
@@ -144,8 +135,17 @@ public final class TestUtils {
     public static Federation createP2shP2wshErpFederation(NetworkParameters params, List<BtcECKey> keys) {
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
         FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
-        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, erpFedPubKeysList,
+        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, ERP_FED_PUB_KEYS_LIST,
             ERP_FED_ACTIVATION_DELAY);
+    }
+
+    public static Federation createP2shP2wshErpFederation(BridgeConstants constants, List<BtcECKey> keys) {
+        List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
+        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, constants.getBtcParams());
+
+        FederationConstants federationConstants = constants.getFederationConstants();
+        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, federationConstants.getErpFedPubKeysList(),
+            federationConstants.getErpFedActivationDelay());
     }
 
     public static List<BtcECKey> getFederationPrivateKeys(long amountOfMembers) {
@@ -156,7 +156,6 @@ public final class TestUtils {
         }
         return federationPrivateKeys;
     }
-
 
     public static BtcECKey getBtcEcKeyFromSeed(String seed) {
         byte[] serializedSeed = HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
+++ b/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.BtcToRskClient;
-import co.rsk.federate.bitcoin.BitcoinWrapper;
 import co.rsk.federate.btcreleaseclient.BtcReleaseClient;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
@@ -39,7 +38,6 @@ class FederationWatcherListenerImplTest {
     private BtcToRskClient btcToRskClientActive;
     private BtcToRskClient btcToRskClientRetiring;
     private BtcReleaseClient btcReleaseClient;
-    private BitcoinWrapper bitcoinWrapper;
     private FederationWatcherListener federationWatcherListener;
 
     @BeforeEach
@@ -47,9 +45,7 @@ class FederationWatcherListenerImplTest {
         btcToRskClientActive = mock(BtcToRskClient.class);
         btcToRskClientRetiring = mock(BtcToRskClient.class);
         btcReleaseClient = mock(BtcReleaseClient.class);
-        bitcoinWrapper = mock(BitcoinWrapper.class);
-        federationWatcherListener = new FederationWatcherListenerImpl(
-            btcToRskClientActive, btcToRskClientRetiring, btcReleaseClient);
+        federationWatcherListener = new FederationWatcherListenerImpl(btcToRskClientActive, btcToRskClientRetiring, btcReleaseClient);
     }
 
     @Test
@@ -102,7 +98,8 @@ class FederationWatcherListenerImplTest {
 
         // Assert
         verify(btcReleaseClient, never()).start(any(Federation.class));
-        verify(bitcoinWrapper, never()).addFederationListener(any(Federation.class), any(BtcToRskClient.class));
+        verify(btcToRskClientActive, never()).start(FEDERATION);
+        verify(btcToRskClientRetiring, never()).start(FEDERATION);
     }
 
     @Test
@@ -112,7 +109,8 @@ class FederationWatcherListenerImplTest {
 
         // Assert
         verify(btcReleaseClient).start(FEDERATION);
-        verify(bitcoinWrapper, never()).addFederationListener(any(Federation.class), any(BtcToRskClient.class));
+        verify(btcToRskClientActive, never()).start(FEDERATION);
+        verify(btcToRskClientRetiring, never()).start(FEDERATION);
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
+++ b/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
@@ -28,7 +28,7 @@ class FederationWatcherListenerImplTest {
 
     private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
-    private static final List<FederationMember> FEDERATION_MEMBERS = 
+    private static final List<FederationMember> FEDERATION_MEMBERS =
         getFederationMembersFromPksForBtc(1000, 2000, 3000, 4000);
     private static final long CREATION_BLOCK_NUMBER = 0L;
     private static final Instant FEDERATION_CREATION_TIME = Instant.ofEpochMilli(5005L);
@@ -49,9 +49,9 @@ class FederationWatcherListenerImplTest {
         btcReleaseClient = mock(BtcReleaseClient.class);
         bitcoinWrapper = mock(BitcoinWrapper.class);
         federationWatcherListener = new FederationWatcherListenerImpl(
-            btcToRskClientActive, btcToRskClientRetiring, btcReleaseClient, bitcoinWrapper);
+            btcToRskClientActive, btcToRskClientRetiring, btcReleaseClient);
     }
-   
+
     @Test
     void onActiveFederationChange_whenFederationIsValid_shouldTriggerClientChange() {
         // Act
@@ -106,13 +106,13 @@ class FederationWatcherListenerImplTest {
     }
 
     @Test
-    void onProposedFederationChange_whenNewProposedFederationIsValid_shouldStartClient() {
+    void onProposedFederationChange_whenNewProposedFederationIsValid_shouldStartReleaseClient_shouldNotStartListener() {
         // Act
         federationWatcherListener.onProposedFederationChange(FEDERATION);
 
         // Assert
         verify(btcReleaseClient).start(FEDERATION);
-        verify(bitcoinWrapper).addFederationListener(FEDERATION, btcToRskClientActive);
+        verify(bitcoinWrapper, never()).addFederationListener(any(Federation.class), any(BtcToRskClient.class));
     }
 
     @Test


### PR DESCRIPTION
`rit:refactor-btc-to-rsk-client`
`fed:refactor-btc-to-rsk-client`

RITs ran successfully: https://github.com/rsksmart/rootstock-integration-tests/actions/runs/23594985458/job/68709301194