### PR TITLE
Different proofs file for different clients

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -578,7 +578,9 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
             null
         );
 
-        for (Sha256Hash txHash : txsToSendToRskHashes) {
+        Iterator<Sha256Hash> txHashIterator = txsToSendToRskHashes.iterator();
+        while (txHashIterator.hasNext()) {
+            Sha256Hash txHash = txHashIterator.next();
             try {
                 Transaction tx = federatorWalletTxMap.get(txHash);
                 logger.debug("[updateBridgeBtcTransactions] Evaluating Btc Tx {}", txHash);
@@ -724,7 +726,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                     // with K = BridgeConstants.getBtc2RskMinimumAcceptableConfirmationsOnRsk()
                     // then remove the transaction from the list
                     if ((bestChainHeight - txProcessedHeight) >= bridgeConstants.getBtc2RskMinimumAcceptableConfirmationsOnRsk()) {
-                        txsToSendToRskHashes.remove(txHash);
+                        removeTxHashFromFile(txHashIterator);
                         logger.debug(
                             "[updateBridgeBtcTransactions] Btc Tx {} was processed at height {}, current height is {}. Tx removed from pending lock list",
                             txHash,
@@ -739,6 +741,22 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                     txHash,
                     e.getMessage()
                 );
+            }
+        }
+    }
+
+    private void removeTxHashFromFile(Iterator<Sha256Hash> txHashIterator) {
+        txHashIterator.remove();
+        writeToStorage();
+    }
+
+    private void writeToStorage() {
+        synchronized (this) {
+            try {
+                this.btcToRskClientFileStorage.write(this.fileData);
+                logger.debug("[writeToStorage] Persisted fileData to storage.");
+            } catch (IOException e) {
+                logger.error("[writeToStorage] Error {} persisting fileData to storage.", e.getMessage(), e);
             }
         }
     }

--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -282,13 +282,13 @@ public class FedNodeRunner implements NodeRunner {
                 bridgeConstants.getFederationConstants()
             );
 
+            directoryStorageInfo = new BtcToRskClientDirectoryStorageInfo(config);
+
             BtcLockSenderProvider btcLockSenderProvider = new BtcLockSenderProvider();
             PeginInstructionsProvider peginInstructionsProvider = new PeginInstructionsProvider();
             bitcoinWrapper = createAndSetupBitcoinWrapper(btcLockSenderProvider, peginInstructionsProvider);
 
-            directoryStorageInfo = new BtcToRskClientDirectoryStorageInfo(config);
             BtcToRskClientFileStorageFactory fileStorageFactory = new BtcToRskClientFileStorageFactory(directoryStorageInfo);
-
             BtcToRskClientFileStorage btcToRskActiveClientFileStorage = fileStorageFactory.forActive();
             btcToRskClientActive.setup(
                 bitcoinWrapper,

--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -83,8 +83,8 @@ public class FedNodeRunner implements NodeRunner {
     private final HSMClientProtocolFactory hsmClientProtocolFactory;
     private final HSMBookKeepingClientProvider hsmBookKeepingClientProvider;
 
+    private DirectoryStorageInfo directoryStorageInfo;
     private BitcoinWrapper bitcoinWrapper;
-    private BtcToRskClientFileStorage btcToRskClientFileStorage;
     private FederationMember member;
     private ECDSASigner signer;
     private HSMBookkeepingClient hsmBookkeepingClient;
@@ -284,21 +284,25 @@ public class FedNodeRunner implements NodeRunner {
 
             BtcLockSenderProvider btcLockSenderProvider = new BtcLockSenderProvider();
             PeginInstructionsProvider peginInstructionsProvider = new PeginInstructionsProvider();
-            btcToRskClientFileStorage = new BtcToRskClientFileStorageImpl(new BtcToRskClientFileStorageInfo(config));
             bitcoinWrapper = createAndSetupBitcoinWrapper(btcLockSenderProvider, peginInstructionsProvider);
 
+            directoryStorageInfo = new BtcToRskClientDirectoryStorageInfo(config);
+            BtcToRskClientFileStorageFactory fileStorageFactory = new BtcToRskClientFileStorageFactory(directoryStorageInfo);
+
+            BtcToRskClientFileStorage btcToRskActiveClientFileStorage = fileStorageFactory.forActive();
             btcToRskClientActive.setup(
                 bitcoinWrapper,
                 bridgeConstants,
-                btcToRskClientFileStorage,
+                btcToRskActiveClientFileStorage,
                 btcLockSenderProvider,
                 peginInstructionsProvider,
                 config
             );
+            BtcToRskClientFileStorage btcToRskRetiringClientFileStorage = fileStorageFactory.forRetiring();
             btcToRskClientRetiring.setup(
                 bitcoinWrapper,
                 bridgeConstants,
-                btcToRskClientFileStorage,
+                btcToRskRetiringClientFileStorage,
                 btcLockSenderProvider,
                 peginInstructionsProvider,
                 config
@@ -382,11 +386,13 @@ public class FedNodeRunner implements NodeRunner {
 
     private BitcoinWrapper createAndSetupBitcoinWrapper(
         BtcLockSenderProvider btcLockSenderProvider,
-        PeginInstructionsProvider peginInstructionsProvider) throws UnknownHostException {
+        PeginInstructionsProvider peginInstructionsProvider
+    ) throws UnknownHostException {
+        final String BTC_TO_RSK_CLIENT_FILE_PREFIX = "BtcToRskClient";
 
         Context btcContext = new Context(ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString()));
-        File pegDirectory = new File(this.btcToRskClientFileStorage.getInfo().getPegDirectoryPath());
-        Kit kit = new Kit(btcContext, pegDirectory, "BtcToRskClient");
+        File pegDirectory = new File(directoryStorageInfo.getPath());
+        Kit kit = new Kit(btcContext, pegDirectory, BTC_TO_RSK_CLIENT_FILE_PREFIX);
 
         BitcoinWrapper wrapper = new BitcoinWrapperImpl(
             btcContext,

--- a/src/main/java/co/rsk/federate/io/BtcToRskClientDirectoryStorageInfo.java
+++ b/src/main/java/co/rsk/federate/io/BtcToRskClientDirectoryStorageInfo.java
@@ -1,0 +1,19 @@
+package co.rsk.federate.io;
+
+import co.rsk.federate.config.PowpegNodeSystemProperties;
+
+import java.io.File;
+
+public final class BtcToRskClientDirectoryStorageInfo implements DirectoryStorageInfo {
+    private static final String PEG_SUFFIX = "peg";
+    private final String path;
+
+    public BtcToRskClientDirectoryStorageInfo(PowpegNodeSystemProperties config) {
+        this.path = config.databaseDir() + File.separator + PEG_SUFFIX;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/java/co/rsk/federate/io/BtcToRskClientFileData.java
+++ b/src/main/java/co/rsk/federate/io/BtcToRskClientFileData.java
@@ -10,9 +10,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class BtcToRskClientFileData {
 
-    private Map<Sha256Hash, List<Proof>> transactionsProofs;
+    private final Map<Sha256Hash, List<Proof>> transactionsProofs;
 
-    private Map<Sha256Hash, CoinbaseInformation> coinbaseInformationMap;
+    private final Map<Sha256Hash, CoinbaseInformation> coinbaseInformationMap;
 
     public BtcToRskClientFileData() {
         this.transactionsProofs = new ConcurrentHashMap<>();

--- a/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageFactory.java
+++ b/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageFactory.java
@@ -1,0 +1,21 @@
+package co.rsk.federate.io;
+
+public class BtcToRskClientFileStorageFactory {
+    private final DirectoryStorageInfo directoryStorageInfo;
+
+    public BtcToRskClientFileStorageFactory(DirectoryStorageInfo directoryStorageInfo) {
+        this.directoryStorageInfo = directoryStorageInfo;
+    }
+
+    public BtcToRskClientFileStorage forActive() {
+        return create("active");
+    }
+    public BtcToRskClientFileStorage forRetiring() {
+        return create("retiring");
+    }
+
+    private BtcToRskClientFileStorage create(String filePathCustomizer) {
+        BtcToRskClientFileStorageInfo btcToRskClientFileStorageInfo = new BtcToRskClientFileStorageInfo(directoryStorageInfo, filePathCustomizer);
+        return new BtcToRskClientFileStorageImpl(btcToRskClientFileStorageInfo);
+    }
+}

--- a/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageImpl.java
+++ b/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageImpl.java
@@ -33,7 +33,7 @@ public class BtcToRskClientFileStorageImpl implements BtcToRskClientFileStorage 
         if (data == null) {
             throw new IOException("Data is null");
         }
-        File directory = new File(storageInfo.getPegDirectoryPath());
+        File directory = new File(storageInfo.getDirectoryPath());
         if (!directory.exists() && !directory.mkdirs()) {
             throw new IOException("Could not create directory " + directory.getAbsolutePath());
         }

--- a/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageInfo.java
+++ b/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageInfo.java
@@ -3,18 +3,18 @@ package co.rsk.federate.io;
 import java.io.File;
 
 public final class BtcToRskClientFileStorageInfo implements FileStorageInfo {
-    private final String pegDirectoryPath;
+    private final String directoryPath;
 
     private final String filePath;
 
     public BtcToRskClientFileStorageInfo(DirectoryStorageInfo directoryStorageInfo, String fileCustomizer) {
-        this.pegDirectoryPath = directoryStorageInfo.getPath();
-        this.filePath = this.pegDirectoryPath + File.separator + "btcToRskClient" + "-" + fileCustomizer + ".rlp";
+        this.directoryPath = directoryStorageInfo.getPath();
+        this.filePath = this.directoryPath + File.separator + "btcToRskClient" + "-" + fileCustomizer + ".rlp";
     }
 
     @Override
-    public String getPegDirectoryPath() {
-        return pegDirectoryPath;
+    public String getDirectoryPath() {
+        return directoryPath;
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageInfo.java
+++ b/src/main/java/co/rsk/federate/io/BtcToRskClientFileStorageInfo.java
@@ -1,18 +1,15 @@
 package co.rsk.federate.io;
 
-import co.rsk.federate.config.PowpegNodeSystemProperties;
-
 import java.io.File;
 
-public class BtcToRskClientFileStorageInfo implements FileStorageInfo {
+public final class BtcToRskClientFileStorageInfo implements FileStorageInfo {
+    private final String pegDirectoryPath;
 
-    private String pegDirectoryPath;
+    private final String filePath;
 
-    private String filePath;
-
-    public BtcToRskClientFileStorageInfo(PowpegNodeSystemProperties config) {
-        this.pegDirectoryPath = config.databaseDir() + File.separator + "peg";
-        this.filePath = this.pegDirectoryPath + File.separator + "btcToRskClient2.rlp";
+    public BtcToRskClientFileStorageInfo(DirectoryStorageInfo directoryStorageInfo, String fileCustomizer) {
+        this.pegDirectoryPath = directoryStorageInfo.getPath();
+        this.filePath = this.pegDirectoryPath + File.separator + "btcToRskClient" + "-" + fileCustomizer + ".rlp";
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/io/DirectoryStorageInfo.java
+++ b/src/main/java/co/rsk/federate/io/DirectoryStorageInfo.java
@@ -1,0 +1,5 @@
+package co.rsk.federate.io;
+
+public interface DirectoryStorageInfo {
+    String getPath();
+}

--- a/src/main/java/co/rsk/federate/io/FileStorageInfo.java
+++ b/src/main/java/co/rsk/federate/io/FileStorageInfo.java
@@ -1,7 +1,7 @@
 package co.rsk.federate.io;
 
 public interface FileStorageInfo {
-    String getPegDirectoryPath();
+    String getDirectoryPath();
 
     String getFilePath();
 }

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -1,5 +1,8 @@
 package co.rsk.federate;
 
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
+import static co.rsk.federate.utils.ClientProofsAssertions.*;
+import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
 import static java.util.Objects.nonNull;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -15,6 +18,7 @@ import co.rsk.config.*;
 import co.rsk.federate.adapter.ThinConverter;
 import co.rsk.federate.bitcoin.BitcoinWrapper;
 import co.rsk.federate.bitcoin.BitcoinWrapperImpl;
+import co.rsk.federate.bitcoin.KitStub;
 import co.rsk.federate.config.PowpegNodeSystemProperties;
 import co.rsk.federate.io.*;
 import co.rsk.federate.mock.*;
@@ -31,18 +35,28 @@ import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import com.google.common.collect.Lists;
+
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
 import org.bitcoinj.core.*;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.wallet.Wallet;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.internal.util.MockUtil;
 import org.spongycastle.util.encoders.Hex;
 
@@ -2145,6 +2159,426 @@ class BtcToRskClientTest {
         assertTrue(txsSentToRegisterBtcTransaction.isEmpty());
     }
 
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+    class UpdateBridgeBtcTransactionsTests {
+        private static final BridgeConstants BRIDGE_MAINNET_CONSTANTS = BridgeMainNetConstants.getInstance();
+        private static final String MAINNET_BTC_PARAMS_STRING = BRIDGE_MAINNET_CONSTANTS.getBtcParamsString();
+        private static final co.rsk.bitcoinj.core.NetworkParameters MAINNET_BTC_PARAMS = BRIDGE_MAINNET_CONSTANTS.getBtcParams();
+        private static final NetworkParameters MAINNET_PARAMS = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING);
+        private static final Context MAINNET_CONTEXT = new Context(MAINNET_PARAMS);
+
+        private StoredBlock[] blocks;
+        private int blockWithTxIndex;
+
+        @TempDir
+        private Path tempDir;
+        private File directory;
+        private DirectoryStorageInfo directoryStorageInfo;
+        private BtcToRskClientFileStorage btcToRskActiveFedClientFileStorage;
+        private BtcToRskClientFileStorage btcToRskRetiringFedClientFileStorage;
+
+        private Wallet wallet;
+        private Set<Transaction> walletTxs;
+        private KitStub kit;
+        private BitcoinWrapperImpl bitcoinWrapper;
+        private BtcToRskClient activeFedClient;
+        private BtcToRskClient retiringFedClient;
+        private FederatorSupport federatorSupport;
+        private BtcLockSenderProvider btcLockSenderProvider;
+        private PeginInstructionsProvider peginInstructionsProvider;
+        private PowpegNodeSystemProperties config;
+
+        @BeforeEach
+        void setUp() throws BlockStoreException {
+            co.rsk.bitcoinj.core.Context.propagate(new co.rsk.bitcoinj.core.Context(MAINNET_BTC_PARAMS));
+
+            ForBlock activations = mock(ForBlock.class);
+            when(activations.isActive(any(ConsensusRule.class))).thenReturn(true);
+            when(activationConfig.forBlock(anyLong())).thenReturn(activations);
+            when(activationConfig.isActive(any(ConsensusRule.class), anyLong())).thenReturn(true);
+
+            config = mock(PowpegNodeSystemProperties.class);
+            when(config.getActivationConfig()).thenReturn(activationConfig);
+            when(config.shouldUpdateCollections()).thenReturn(true);
+            when(config.shouldUpdateBridgeBtcBlockchain()).thenReturn(true);
+            when(config.shouldUpdateBridgeBtcTransactions()).thenReturn(true);
+            when(config.shouldUpdateBridgeBtcCoinbaseTransactions()).thenReturn(true);
+            when(config.isUpdateBridgeTimerEnabled()).thenReturn(true);
+            when(config.getAmountOfHeadersToSend()).thenReturn(100);
+
+            federatorSupport = mock(FederatorSupport.class);
+            when(federatorSupport.getConfigForBestBlock()).thenReturn(activations);
+            // assuming no retiring fed for general setup
+            when(federatorSupport.getRetiringFederationSize()).thenReturn(FEDERATION_NON_EXISTENT.getCode());
+
+            btcLockSenderProvider = new BtcLockSenderProvider();
+            peginInstructionsProvider = new PeginInstructionsProvider();
+
+            // using a temporary directory for testing
+            directoryStorageInfo = mock(DirectoryStorageInfo.class);
+            when(directoryStorageInfo.getPath()).thenReturn(tempDir.toString());
+            directory = new File(directoryStorageInfo.getPath());
+
+            int chainHeight = 4;
+            blocks = createBlockchain(chainHeight);
+            blockWithTxIndex = 0;
+
+            walletTxs = new HashSet<>();
+            wallet = mock(Wallet.class);
+            when(wallet.getTransactions(false)).thenReturn(walletTxs);
+
+            setUpKit();
+            setUpBitcoinWrapper();
+        }
+
+        private void setUpKit() throws BlockStoreException {
+            String btcToRskClientFilePrefix = "BtcToRskClient";
+            kit = new KitStub(MAINNET_CONTEXT, directory, btcToRskClientFilePrefix, wallet);
+            kit.setStore(blocks);
+        }
+
+        private void setUpBitcoinWrapper() {
+            bitcoinWrapper = new BitcoinWrapperImpl(
+                MAINNET_CONTEXT,
+                BRIDGE_MAINNET_CONSTANTS,
+                btcLockSenderProvider,
+                peginInstructionsProvider,
+                federatorSupport,
+                kit
+            );
+
+            List<PeerAddress> peerAddresses = Collections.emptyList();
+            bitcoinWrapper.setup(peerAddresses);
+            bitcoinWrapper.start();
+        }
+
+        private void setUpActiveFed(Federation activeFederation) {
+            when(federatorSupport.getFederationSize()).thenReturn(activeFederation.getSize());
+            for (int i = 0; i < activeFederation.getSize(); i++) {
+                FederationMember member = activeFederation.getMembers().get(i);
+                org.ethereum.crypto.ECKey btcKey = org.ethereum.crypto.ECKey.fromPublicOnly(member.getBtcPublicKey().getPubKey());
+                when(federatorSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(btcKey);
+                org.ethereum.crypto.ECKey rskKey = member.getRskPublicKey();
+                when(federatorSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(rskKey);
+                org.ethereum.crypto.ECKey mstKey = member.getMstPublicKey();
+                when(federatorSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(mstKey);
+            }
+            when(federatorSupport.getFederationCreationTime()).thenReturn(activeFederation.getCreationTime());
+            when(federatorSupport.getFederationCreationBlockNumber()).thenReturn(activeFederation.getCreationBlockNumber());
+            when(federatorSupport.getBtcParams()).thenReturn(MAINNET_BTC_PARAMS);
+            when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
+        }
+
+        private void setUpRetiringFed(Federation retiringFederation) {
+            when(federatorSupport.getRetiringFederationSize()).thenReturn(retiringFederation.getSize());
+            for (int i = 0; i < retiringFederation.getSize(); i++) {
+                FederationMember member = retiringFederation.getMembers().get(i);
+                org.ethereum.crypto.ECKey btcKey = org.ethereum.crypto.ECKey.fromPublicOnly(member.getBtcPublicKey().getPubKey());
+                when(federatorSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)).thenReturn(btcKey);
+                org.ethereum.crypto.ECKey rskKey = member.getRskPublicKey();
+                when(federatorSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)).thenReturn(rskKey);
+                org.ethereum.crypto.ECKey mstKey = member.getMstPublicKey();
+                when(federatorSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)).thenReturn(mstKey);
+            }
+            when(federatorSupport.getRetiringFederationCreationTime()).thenReturn(retiringFederation.getCreationTime());
+            when(federatorSupport.getRetiringFederationCreationBlockNumber()).thenReturn(retiringFederation.getCreationBlockNumber());
+            when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
+        }
+
+        private BtcToRskClientFileStorage buildClientFileStorageInfo(String fileCustomizer) {
+            FileStorageInfo fileStorageInfo = new BtcToRskClientFileStorageInfo(directoryStorageInfo, fileCustomizer);
+            return new BtcToRskClientFileStorageImpl(fileStorageInfo);
+        }
+
+        private BtcToRskClient buildClient(BtcToRskClientFileStorage btcToRskClientFileStorage, Federation federationToListen) throws Exception {
+            btcToRskClientBuilder = BtcToRskClientBuilder.builder();
+            return btcToRskClientBuilder
+                .withBitcoinWrapper(bitcoinWrapper)
+                .withFederatorSupport(federatorSupport)
+                .withFederation(federationToListen)
+                .withBridgeConstants(BRIDGE_MAINNET_CONSTANTS)
+                .withBtcToRskClientFileStorage(btcToRskClientFileStorage)
+                .withBtcLockSenderProvider(btcLockSenderProvider)
+                .withPeginInstructionsProvider(peginInstructionsProvider)
+                .withActivationConfig(activationConfig)
+                .build();
+        }
+
+        private void addListener(Federation federationToListen, BtcToRskClient client) {
+            bitcoinWrapper.addFederationListener(federationToListen, client);
+        }
+
+        private void setUpTx(BtcToRskClient client, BtcTransaction btcTx) {
+            var tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+
+            setUpTxConfidence(tx);
+            listenTx(client, tx);
+            listenBlockWithTx(client, tx);
+        }
+
+        private void setUpTxConfidence(Transaction tx) {
+            org.bitcoinj.core.TransactionConfidence confidence = tx.getConfidence();
+            confidence.setConfidenceType(org.bitcoinj.core.TransactionConfidence.ConfidenceType.BUILDING);
+            confidence.setDepthInBlocks(BRIDGE_MAINNET_CONSTANTS.getBtc2RskMinimumAcceptableConfirmations());
+        }
+
+        private void listenTx(BtcToRskClient client, Transaction tx) {
+            client.onTransaction(tx);
+            walletTxs.add(tx);
+        }
+
+        private void listenBlockWithTx(BtcToRskClient client, Transaction tx) {
+            Block blockWithTx = buildBlockWithTx(tx);
+            client.onBlock(blockWithTx);
+        }
+
+        private Block buildBlockWithTx(Transaction tx) {
+            Sha256Hash blockHash = blocks[blockWithTxIndex].getHeader().getHash();
+            Block blockWithTx = createBlockWithTx(blockHash, tx);
+            tx.addBlockAppearance(blockWithTx.getHash(), 1);
+
+            blockWithTxIndex++;
+            return blockWithTx;
+        }
+
+        private Block createBlockWithTx(Sha256Hash blockHash, Transaction tx) {
+            if (tx.hasWitnesses()) {
+                return createSegwitBlockWithTx(blockHash, tx);
+            }
+
+            return createBlock(blockHash, tx);
+        }
+
+        private Block createSegwitBlockWithTx(Sha256Hash blockHash, Transaction tx) {
+            Sha256Hash witnessRoot = Sha256Hash.wrapReversed(
+                Sha256Hash.hashTwice(
+                    Sha256Hash.ZERO_HASH.getReversedBytes(),
+                    tx.getWTxId().getReversedBytes()
+                )
+            );
+            byte[] witnessReservedValue = WITNESS_RESERVED_VALUE.getBytes();
+            co.rsk.bitcoinj.core.Sha256Hash witnessCommitment = co.rsk.bitcoinj.core.Sha256Hash.twiceOf(
+                witnessRoot.getReversedBytes(),
+                witnessReservedValue
+            );
+            BtcTransaction coinbaseBtcTx = createCoinbaseTransactionWithWitnessCommitment(MAINNET_BTC_PARAMS, witnessCommitment);
+
+            return createBlock(blockHash, ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, coinbaseBtcTx), tx);
+        }
+
+        private static Stream<Arguments> retiringAndActiveFedsArgs() {
+            final Federation standardMultiSigFed = TestUtils.createStandardMultisigFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation firstP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            final Federation secondP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
+
+            return Stream.of(
+                Arguments.of(standardMultiSigFed, firstP2shP2wshErpFed),
+                Arguments.of(firstP2shP2wshErpFed, secondP2shP2wshErpFed)
+            );
+        }
+
+        /**
+         * When two {@link BtcToRskClient} instances shared a single {@link BtcToRskClientFileStorage}
+         * (same on-disk RLP), the retiring client's onBlock could write the file with in-memory state
+         * that did not include txs only the active client had listened to, overwriting
+         * the file and dropping those txs from persistence when a restart of the node is performed.
+         * With separate proof files per client, both federations' pending txs must remain stored
+         * after both clients process the same block
+         */
+        @ParameterizedTest
+        @MethodSource("retiringAndActiveFedsArgs")
+        void updateBridgeBtcTransactions_clientForBothFeds_sharedStorage_shouldNotSendTx(Federation retiringFed, Federation activeFed) throws Exception {
+            // arrange
+            // 1. Set up clients with shared storage
+            String fileCustomizer = "shared";
+            btcToRskActiveFedClientFileStorage = buildClientFileStorageInfo(fileCustomizer);
+            btcToRskRetiringFedClientFileStorage = buildClientFileStorageInfo(fileCustomizer);
+            // 2. Create a tx that both clients will know about
+            var btcTx1 = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(btcTx1, activeFed.getAddress());
+            addOutputToFedWithMinimumPeginValue(btcTx1, retiringFed.getAddress());
+            // 3. Create a tx just for the active federation
+            var btcTx2 = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(btcTx2, activeFed.getAddress());
+
+            setUpForFileStorageTests(retiringFed, activeFed, btcTx1, btcTx2);
+
+            // act & assert
+            // the new tx is LOST from the file and won't be sent because retiringFedClient overwrote it
+            assertWTxIdIsNotInActiveFedClientProofsFile(btcTx2);
+            assertWTxIdIsNotInActiveFedClientTxsToBeSentMap(btcTx2);
+            // calling to update bridge txs will not send it to the bridge
+            activeFedClient.updateBridgeBtcTransactions();
+            assertTxNotSentToBridge(btcTx2);
+        }
+
+        @ParameterizedTest
+        @MethodSource("retiringAndActiveFedsArgs")
+        void updateBridgeBtcTransactions_clientForBothFeds_separateStorage_shouldSendTx(Federation retiringFed, Federation activeFed) throws Exception {
+            // arrange
+            // 1. Set up clients with separate storage
+            String fileCustomizerForActiveFed = "active";
+            btcToRskActiveFedClientFileStorage = buildClientFileStorageInfo(fileCustomizerForActiveFed);
+            String fileCustomizerForRetiringFed = "retiring";
+            btcToRskRetiringFedClientFileStorage = buildClientFileStorageInfo(fileCustomizerForRetiringFed);
+            // 2. Create a tx that both clients will know about
+            var btcTx1 = createTxFromP2pkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(btcTx1, activeFed.getAddress());
+            addOutputToFedWithMinimumPeginValue(btcTx1, retiringFed.getAddress());
+            // 3. Create a tx just for the active federation
+            var btcTx2 = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(btcTx2, activeFed.getAddress());
+
+            // act
+            setUpForFileStorageTests(retiringFed, activeFed, btcTx1, btcTx2);
+
+            // assert
+            // the new tx is still in active fed client proofs file and txs to be sent map
+            assertWTxIdIsInActiveFedClientProofsFile(btcTx2);
+            assertWTxIdIsInActiveFedClientTxsToBeSentMap(btcTx2);
+            // calling to update bridge txs will send it to the bridge
+            activeFedClient.updateBridgeBtcTransactions();
+            assertTxSentToBridge(btcToRskActiveFedClientFileStorage, btcTx2, 1);
+        }
+
+        private void setUpForFileStorageTests(Federation retiringFed, Federation activeFed, BtcTransaction btcTx1, BtcTransaction btcTx2) throws Exception {
+            // active fed client
+            setUpActiveFed(activeFed);
+            activeFedClient = buildClient(btcToRskActiveFedClientFileStorage, activeFed);
+            addListener(activeFed, activeFedClient);
+            // retiring fed client
+            setUpRetiringFed(retiringFed);
+            retiringFedClient = buildClient(btcToRskRetiringFedClientFileStorage, retiringFed);
+            addListener(retiringFed, retiringFedClient);
+
+            // listen to tx1 and block that contains it
+            var tx1 = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx1);
+            setUpTxConfidence(tx1);
+            listenTx(activeFedClient, tx1);
+            listenTx(retiringFedClient, tx1);
+            // both clients should listen to the same block containing the tx
+            Block blockWithTx1 = buildBlockWithTx(tx1);
+            activeFedClient.onBlock(blockWithTx1);
+            retiringFedClient.onBlock(blockWithTx1);
+
+            // Both clients should have tx1 in their proofs file and their in-memory fileData
+            assertWTxIdIsInActiveFedClientProofsFile(btcTx1);
+            assertWTxIdIsInActiveFedClientTxsToBeSentMap(btcTx1);
+
+            assertWTxIdIsInRetiringFedClientProofsFile(btcTx1);
+            assertWTxIdIsInRetiringFedClientTxsToBeSentMap(btcTx1);
+
+            // listen to tx2 and block that contains it
+            // in real life, it would be listened just by the active fed client
+            setUpTx(activeFedClient, btcTx2);
+            // active fed client should have tx2 in its proofs file and its in-memory fileData
+            assertWTxIdIsInActiveFedClientProofsFile(btcTx2);
+            assertWTxIdIsInActiveFedClientTxsToBeSentMap(btcTx2);
+
+            // act
+            // A new Bitcoin block is mined containing the tx1
+            Block newBlockWithTx1 = buildBlockWithTx(tx1);
+            // Both clients listen to the block since both have the tx1 saved
+            // -to simulate overwriting scenario, the active fed client should listen to it first-
+            activeFedClient.onBlock(newBlockWithTx1);
+            retiringFedClient.onBlock(newBlockWithTx1);
+
+            // active fed client should still have tx2 in its txs-to-be-sent map
+            assertWTxIdIsInActiveFedClientTxsToBeSentMap(btcTx2);
+
+            // now simulate a restart of the node:
+            // perform FedNodeRunner.stop() actions
+            bitcoinWrapper.stop();
+            activeFedClient.stop();
+            retiringFedClient.stop();
+
+            // perform FedNodeRunner.startFederate() actions
+            setUpKit();
+            setUpBitcoinWrapper();
+            activeFedClient.setup(
+                bitcoinWrapper,
+                BRIDGE_MAINNET_CONSTANTS,
+                btcToRskActiveFedClientFileStorage,
+                btcLockSenderProvider,
+                peginInstructionsProvider,
+                config
+            );
+            retiringFedClient.setup(
+                bitcoinWrapper,
+                BRIDGE_MAINNET_CONSTANTS,
+                btcToRskRetiringFedClientFileStorage,
+                btcLockSenderProvider,
+                peginInstructionsProvider,
+                config
+            );
+            // start clients again
+            when(federatorSupport.getFederationMember()).thenReturn(activeFed.getMembers().get(0));
+            activeFedClient.start(activeFed);
+            when(federatorSupport.getFederationMember()).thenReturn(retiringFed.getMembers().get(0));
+            retiringFedClient.start(retiringFed);
+        }
+
+        private void assertWTxIdIsInActiveFedClientProofsFile(BtcTransaction btcTx) throws IOException {
+            Transaction tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            assertWTxIdIsInProofsFile(MAINNET_PARAMS, btcToRskActiveFedClientFileStorage, tx);
+        }
+
+        private void assertWTxIdIsInActiveFedClientTxsToBeSentMap(BtcTransaction btcTx) {
+            Transaction tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            assertWTxIdIsInTxsToBeSentMap(activeFedClient, tx);
+        }
+
+        private void assertWTxIdIsNotInActiveFedClientTxsToBeSentMap(BtcTransaction btcTx) {
+            Transaction tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            assertWTxIdIsNotInTxsToBeSentMap(activeFedClient, tx);
+        }
+
+        private void assertWTxIdIsNotInActiveFedClientProofsFile(BtcTransaction btcTx) throws IOException {
+            Transaction tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            assertWTxIdIsNotInProofsFile(MAINNET_PARAMS, btcToRskActiveFedClientFileStorage, tx);
+        }
+
+        private void assertWTxIdIsInRetiringFedClientProofsFile(BtcTransaction btcTx) throws IOException {
+            Transaction tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            assertWTxIdIsInProofsFile(MAINNET_PARAMS, btcToRskRetiringFedClientFileStorage, tx);
+        }
+
+        private void assertWTxIdIsInRetiringFedClientTxsToBeSentMap(BtcTransaction btcTx) {
+            Transaction tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            assertWTxIdIsInTxsToBeSentMap(retiringFedClient, tx);
+        }
+
+        private void assertTxSentToBridge(BtcToRskClientFileStorage btcToRskClientFileStorage, BtcTransaction btcTx, int blockWithTxHeight) throws IOException {
+            var tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+
+            org.bitcoinj.core.PartialMerkleTree pmt = getPMT(btcToRskClientFileStorage, tx);
+            verify(federatorSupport).sendRegisterBtcTransaction(tx, blockWithTxHeight, pmt);
+        }
+
+        private org.bitcoinj.core.PartialMerkleTree getPMT(BtcToRskClientFileStorage btcToRskClientFileStorage, Transaction tx) throws IOException {
+            BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(MAINNET_PARAMS).getData();
+            List<Proof> proofs = fileData.getTransactionProofs().get(tx.getWTxId());
+
+            Proof proof = proofs.get(0);
+            return proof.getPartialMerkleTree();
+        }
+
+        private void assertTxNotSentToBridge(BtcTransaction btcTx) {
+            var tx = ThinConverter.toOriginalInstance(MAINNET_BTC_PARAMS_STRING, btcTx);
+            verify(federatorSupport, never()).sendRegisterBtcTransaction(eq(tx), anyInt(), any(PartialMerkleTree.class));
+        }
+    }
+
     @Test
     void restoreFileData_with_invalid_BtcToRskClient_file_data() throws Exception {
         BtcToRskClientFileStorage btcToRskClientFileStorageMock = mock(BtcToRskClientFileStorage.class);
@@ -2856,5 +3290,4 @@ class BtcToRskClientTest {
 
         return config;
     }
-
 }

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinTestUtils.java
@@ -1,22 +1,34 @@
 package co.rsk.federate.bitcoin;
 
 import static co.rsk.bitcoinj.script.ScriptBuilder.createP2SHOutputScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.extractRedeemScriptFromInput;
+import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import co.rsk.peg.federation.Federation;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.util.ByteUtil;
 
 public final class BitcoinTestUtils {
+    public static final Coin MINIMUM_PEGIN_TX_VALUE = Coin.valueOf(500_000);
+    public static final org.bitcoinj.core.Sha256Hash WITNESS_RESERVED_VALUE = org.bitcoinj.core.Sha256Hash.ZERO_HASH;
+
+    private static final BtcECKey SENDER_PUBLIC_KEY = getBtcEcKeyFromSeed("sender");
+    private static final List<BtcECKey> MULTISIG_KEYS = Arrays.asList(
+        getBtcEcKeyFromSeed("key1"),
+        getBtcEcKeyFromSeed("key2"),
+        getBtcEcKeyFromSeed("key3")
+    );
+    private static final Script MULTISIG_REDEEM_SCRIPT = ScriptBuilder.createRedeemScript(2, MULTISIG_KEYS);
+
     private BitcoinTestUtils() { }
 
     public static List<Coin> coinListOf(long... values) {
@@ -35,7 +47,7 @@ public final class BitcoinTestUtils {
         return Sha256Hash.wrap(bytes);
     }
 
-    public static BtcECKey getBtcEcKeyFromSeed(String seed) {
+    private static BtcECKey getBtcEcKeyFromSeed(String seed) {
         byte[] serializedSeed = HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8));
         return BtcECKey.fromPrivate(serializedSeed);
     }
@@ -91,13 +103,12 @@ public final class BitcoinTestUtils {
     }
 
     public static BtcTransaction createPegout(
-        NetworkParameters btcMainnetParams,
+        NetworkParameters btcParams,
         Federation fromFederation,
         List<Coin> outpointValues,
         List<Address> destinationAddresses
     ) {
-        BtcTransaction tx = new BtcTransaction(btcMainnetParams);
-
+        BtcTransaction tx = new BtcTransaction(btcParams);
         Coin fee = Coin.MILLICOIN;
         for (int inputIndex = 0; inputIndex < outpointValues.size(); inputIndex++) {
             Coin outpointValue = outpointValues.get(inputIndex);
@@ -107,17 +118,201 @@ public final class BitcoinTestUtils {
             tx.addOutput(amountToSend, destinationAddress);
 
             TransactionOutPoint transactionOutpoint = new TransactionOutPoint(
-                btcMainnetParams,
+                btcParams,
                 inputIndex,
-                BitcoinTestUtils.createHash(inputIndex)
+                createHash(inputIndex)
             );
-
-            TransactionInput txInput = new TransactionInput(btcMainnetParams, null, new byte[]{}, transactionOutpoint, outpointValue);
+            TransactionInput txInput = new TransactionInput(btcParams, null, new byte[]{}, transactionOutpoint, outpointValue);
             tx.addInput(txInput);
 
             addSpendingFederationBaseScript(tx, inputIndex, fromFederation.getRedeemScript(), fromFederation.getFormatVersion());
         }
-
         return tx;
+    }
+
+    public static BtcTransaction createMigrationTx(NetworkParameters networkParameters, Federation retiringFederation, Federation activeFederation) {
+        co.rsk.bitcoinj.core.Coin baseCoin = co.rsk.bitcoinj.core.Coin.valueOf(1_000_000L);
+        List<Coin> utxosToMigrate = new ArrayList<>();
+        var totalOfUtxosToMigrate = 10;
+
+        for (int i = 1; i <= totalOfUtxosToMigrate; i++) {
+            utxosToMigrate.add(baseCoin.multiply(i));
+        }
+
+        return createMigrationTxWithUTXOs(networkParameters, retiringFederation, activeFederation, utxosToMigrate);
+    }
+
+    public static BtcTransaction createMigrationTxBelowMinimumPeginValue(NetworkParameters networkParameters, Federation retiringFederation, Federation activeFederation) {
+        var totalValue = MINIMUM_PEGIN_TX_VALUE.minus(co.rsk.bitcoinj.core.Coin.SATOSHI);
+
+        List<co.rsk.bitcoinj.core.Coin> utxosToMigrate = new ArrayList<>();
+        var totalOfUtxosToMigrate = 10;
+        var utxoValue = totalValue.div(totalOfUtxosToMigrate);
+
+        for (int i = 1; i <= totalOfUtxosToMigrate; i++) {
+            utxosToMigrate.add(utxoValue);
+        }
+
+        return createMigrationTxWithUTXOs(networkParameters, retiringFederation, activeFederation, utxosToMigrate);
+    }
+
+    public static BtcTransaction createMigrationTxWithUTXOs(NetworkParameters networkParameters, Federation retiringFederation, Federation activeFederation, List<Coin> utxosToMigrate) {
+        co.rsk.bitcoinj.core.Address retiringFederationAddress = retiringFederation.getAddress();
+        co.rsk.bitcoinj.core.Address activeFederationAddress = activeFederation.getAddress();
+
+        List<BtcTransaction> txsToMigrate = new ArrayList<>();
+        Coin utxosTotalValue = Coin.ZERO;
+        for (Coin coin : utxosToMigrate) {
+            BtcTransaction txSentToRetiringFed = new BtcTransaction(networkParameters);
+            txSentToRetiringFed.addOutput(coin, retiringFederationAddress);
+            utxosTotalValue = utxosTotalValue.add(coin);
+
+            txsToMigrate.add(txSentToRetiringFed);
+        }
+
+        // add base script from retiring fed to all inputs
+        BtcTransaction migrationBtcTx = new BtcTransaction(networkParameters);
+        for (int i = 0; i < txsToMigrate.size(); i++) {
+            BtcTransaction txToMigrate = txsToMigrate.get(i);
+            co.rsk.bitcoinj.core.TransactionOutput output = txToMigrate.getOutput(0);
+            migrationBtcTx.addInput(output);
+
+            addSpendingFederationBaseScript(
+                migrationBtcTx,
+                i,
+                retiringFederation.getRedeemScript(),
+                retiringFederation.getFormatVersion()
+            );
+        }
+
+        // one output to the new fed with the utxos total value
+        migrationBtcTx.addOutput(utxosTotalValue, activeFederationAddress);
+
+        return migrationBtcTx;
+    }
+
+    public static BtcTransaction createTxFromP2pkh(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2pkh(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2pkh(BtcTransaction btcTx) {
+        btcTx.addInput(createHash(1), 0, ScriptBuilder.createInputScript(null, SENDER_PUBLIC_KEY));
+    }
+
+    public static BtcTransaction createTxFromP2wpkh(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2wpkh(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2wpkh(BtcTransaction btcTx) {
+        Script p2wpkhOutputScript = new ScriptBuilder()
+            .smallNum(0)
+            .data(SENDER_PUBLIC_KEY.getPubKeyHash())
+            .build();
+        addInputFromBech32(btcTx, p2wpkhOutputScript);
+
+        int numSigs = 1;
+        addWitness(btcTx, numSigs, SENDER_PUBLIC_KEY.getPubKey());
+    }
+
+    public static BtcTransaction createTxFromP2wshMultiSig(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2wshMultiSig(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2wshMultiSig(BtcTransaction btcTx) {
+        byte[] witnessScriptHash = co.rsk.bitcoinj.core.Sha256Hash.hash(MULTISIG_REDEEM_SCRIPT.getProgram());
+        Script p2wshOutputScript = new ScriptBuilder()
+            .smallNum(0)
+            .data(witnessScriptHash)
+            .build();
+        addInputFromBech32(btcTx, p2wshOutputScript);
+
+        int numSigs = 2;
+        addWitness(btcTx, numSigs, MULTISIG_REDEEM_SCRIPT.getProgram());
+    }
+
+    private static void addWitness(BtcTransaction btcTx, int numSigs, byte[] lastPush) {
+        TransactionWitness txWit = new TransactionWitness(numSigs + 1);
+        for (int i = 0; i < numSigs; i++) {
+            txWit.setPush(i, new byte[72]);
+        }
+        txWit.setPush(numSigs, lastPush);
+        btcTx.setWitness(0, txWit);
+    }
+
+    private static void addInputFromBech32(BtcTransaction btcTx, Script outputScript) {
+        BtcTransaction prevTx = new BtcTransaction(btcTx.getParams());
+        prevTx.addOutput(Coin.COIN, outputScript);
+        Script emptyScriptSig = new Script(new byte[]{});
+        btcTx.addInput(prevTx.getOutput(0)).setScriptSig(emptyScriptSig);
+    }
+
+    public static BtcTransaction createTxFromP2shP2wpkh(NetworkParameters networkParameters) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+        addInputFromP2shP2wpkh(btcTx);
+        return btcTx;
+    }
+
+    private static void addInputFromP2shP2wpkh(BtcTransaction btcTx) {
+        byte[] redeemScript = ByteUtil.merge(new byte[]{0x00, 0x14}, SENDER_PUBLIC_KEY.getPubKeyHash());
+        Script witnessScript = new ScriptBuilder()
+            .data(redeemScript)
+            .build();
+        btcTx.addInput(createHash(1), 0, witnessScript);
+
+        int numSigs = 1;
+        addWitness(btcTx, numSigs, SENDER_PUBLIC_KEY.getPubKey());
+    }
+
+    public static void addOutputToFedWithMinimumPeginValue(BtcTransaction btcTx, Address federationAddress) {
+        addOutputToFed(btcTx, federationAddress, MINIMUM_PEGIN_TX_VALUE);
+    }
+
+    public static void addOutputToFed(BtcTransaction btcTx, Address federationAddress, Coin amountToSend) {
+        btcTx.addOutput(amountToSend, federationAddress);
+    }
+
+    public static BtcTransaction createCoinbaseTransactionWithWitnessCommitment(
+        co.rsk.bitcoinj.core.NetworkParameters networkParameters,
+        co.rsk.bitcoinj.core.Sha256Hash witnessCommitment
+    ) {
+        BtcTransaction coinbaseTx = createCoinbaseTxWithWitnessReservedValue(networkParameters);
+        byte[] WITNESS_COMMITMENT_HEADER = org.bouncycastle.util.encoders.Hex.decode("aa21a9ed");
+
+        byte[] witnessCommitmentWithHeader = ByteUtil.merge(
+            WITNESS_COMMITMENT_HEADER,
+            witnessCommitment.getBytes()
+        );
+        coinbaseTx.addOutput(co.rsk.bitcoinj.core.Coin.ZERO, ScriptBuilder.createOpReturnScript(witnessCommitmentWithHeader));
+        coinbaseTx.verify();
+
+        return coinbaseTx;
+    }
+
+    private static BtcTransaction createCoinbaseTxWithWitnessReservedValue(NetworkParameters rskNetworkParameters) {
+        BtcTransaction coinbaseTx = createCoinbaseTransaction(rskNetworkParameters);
+        TransactionWitness txWitness = new TransactionWitness(1);
+        txWitness.setPush(0, WITNESS_RESERVED_VALUE.getBytes());
+        coinbaseTx.setWitness(0, txWitness);
+        return coinbaseTx;
+    }
+
+    private static BtcTransaction createCoinbaseTransaction(NetworkParameters rskNetworkParameters) {
+        Address rewardAddress = createP2PKHAddress(rskNetworkParameters, "miner");
+        Script inputScript = new Script(new byte[]{1, 0});
+        BtcTransaction coinbaseTx = new BtcTransaction(rskNetworkParameters);
+        coinbaseTx.addInput(
+            co.rsk.bitcoinj.core.Sha256Hash.ZERO_HASH,
+            -1L,
+            inputScript
+        );
+        coinbaseTx.addOutput(Coin.COIN, rewardAddress);
+        coinbaseTx.verify();
+        return coinbaseTx;
     }
 }

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -71,7 +71,7 @@ class BitcoinWrapperImplTest {
         FileStorageInfo fileStorageInfo = mock(BtcToRskClientFileStorageInfo.class);
         String pegDir = tempDir.toString();
         String filePath = tempDir.resolve("btcToRskClient2.rlp").toString();
-        when(fileStorageInfo.getPegDirectoryPath()).thenReturn(pegDir);
+        when(fileStorageInfo.getDirectoryPath()).thenReturn(pegDir);
         when(fileStorageInfo.getFilePath()).thenReturn(filePath);
         btcToRskClientFileStorage = new BtcToRskClientFileStorageImpl(fileStorageInfo);
 

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -1,8 +1,10 @@
 package co.rsk.federate.bitcoin;
 
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
+import static co.rsk.federate.utils.ClientProofsAssertions.assertProofsFileIsEmpty;
+import static co.rsk.federate.utils.ClientProofsAssertions.assertWTxIdIsInProofsFile;
 import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
 import static org.bitcoinj.script.ScriptOpCodes.OP_RETURN;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -10,7 +12,7 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.federate.BtcToRskClientBuilder;
-import co.rsk.federate.Proof;
+import co.rsk.federate.config.PowpegNodeSystemProperties;
 import co.rsk.federate.io.*;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.constants.BridgeConstants;
@@ -44,9 +46,10 @@ class BitcoinWrapperImplTest {
     private static final co.rsk.bitcoinj.core.NetworkParameters thinNetworkParameters = bridgeConstants.getBtcParams();
     private static final NetworkParameters originalNetworkParameters = ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString());
     private static final Context btcContext = new Context(originalNetworkParameters);
-    private BtcToRskClientFileStorage btcToRskClientFileStorage;
-    private BtcToRskClientBuilder btcToRskClientBuilder;
     private FederatorSupport federatorSupport;
+
+    private BtcToRskClientFileStorage btcToRskActiveFedClientFileStorage;
+    private BtcToRskClientFileStorage btcToRskRetiringFedClientFileStorage;
     private BitcoinWrapperImpl bitcoinWrapper;
     private TransactionListener listener;
 
@@ -54,31 +57,33 @@ class BitcoinWrapperImplTest {
     private Path tempDir;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP379)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP305)).thenReturn(true);
-
+        when(activations.isActive(any(ConsensusRule.class))).thenReturn(true);
         ActivationConfig activationConfig = mock(ActivationConfig.class);
         when(activationConfig.forBlock(any(Long.class))).thenReturn(activations);
+
         federatorSupport = mock(FederatorSupport.class);
         when(federatorSupport.getConfigForBestBlock()).thenReturn(activations);
 
         // using a temporary directory for testing
-        FileStorageInfo fileStorageInfo = mock(BtcToRskClientFileStorageInfo.class);
-        String pegDir = tempDir.toString();
-        String filePath = tempDir.resolve("btcToRskClient2.rlp").toString();
-        when(fileStorageInfo.getDirectoryPath()).thenReturn(pegDir);
-        when(fileStorageInfo.getFilePath()).thenReturn(filePath);
-        btcToRskClientFileStorage = new BtcToRskClientFileStorageImpl(fileStorageInfo);
+        PowpegNodeSystemProperties config = mock(PowpegNodeSystemProperties.class);
+        when(config.databaseDir()).thenReturn(tempDir.toAbsolutePath().toString());
+        BtcToRskClientDirectoryStorageInfo directoryStorageInfo = new BtcToRskClientDirectoryStorageInfo(config);
+        File directory = new File(directoryStorageInfo.getPath());
+        BtcToRskClientFileStorageFactory btcToRskClientFileStorageFactory = new BtcToRskClientFileStorageFactory(directoryStorageInfo);
+        btcToRskActiveFedClientFileStorage = btcToRskClientFileStorageFactory.forActive();
+        btcToRskRetiringFedClientFileStorage = btcToRskClientFileStorageFactory.forRetiring();
 
+        String btcToRskClientFilePrefix = "BtcToRskClient";
+        Kit kit = new KitStub(btcContext, directory, btcToRskClientFilePrefix, mock(Wallet.class));
+        setUpBitcoinWrapper(kit);
+    }
+
+    private void setUpBitcoinWrapper(Kit kit) {
         BtcLockSenderProvider btcLockSenderProvider = new BtcLockSenderProvider();
         PeginInstructionsProvider peginInstructionsProvider = new PeginInstructionsProvider();
 
-        Kit kit = new KitForTests(btcContext, mock(File.class), "", mock(Wallet.class));
         bitcoinWrapper = new BitcoinWrapperImpl(
             btcContext,
             bridgeConstants,
@@ -91,8 +96,22 @@ class BitcoinWrapperImplTest {
         List<PeerAddress> peerAddresses = Collections.emptyList();
         bitcoinWrapper.setup(peerAddresses);
         bitcoinWrapper.start();
+    }
 
-        btcToRskClientBuilder = BtcToRskClientBuilder.builder();
+    private void setUpActiveFedListener(Federation activeFed) throws Exception {
+        when(federatorSupport.getFederationAddress()).thenReturn(activeFed.getAddress());
+        setUpFederationListener(btcToRskActiveFedClientFileStorage, activeFed);
+    }
+
+    private void setUpRetiringFedListener(Federation retiringFed) throws Exception {
+        when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFed.getAddress()));
+        setUpFederationListener(btcToRskRetiringFedClientFileStorage, retiringFed);
+    }
+
+    private void setUpFederationListener(BtcToRskClientFileStorage btcToRskClientFileStorage, Federation federationToListen) throws Exception {
+        BtcToRskClientBuilder btcToRskClientBuilder = BtcToRskClientBuilder.builder();
+        BtcLockSenderProvider btcLockSenderProvider = new BtcLockSenderProvider();
+        PeginInstructionsProvider peginInstructionsProvider = new PeginInstructionsProvider();
         listener = btcToRskClientBuilder
             .withBitcoinWrapper(bitcoinWrapper)
             .withFederatorSupport(federatorSupport)
@@ -100,42 +119,54 @@ class BitcoinWrapperImplTest {
             .withBtcToRskClientFileStorage(btcToRskClientFileStorage)
             .withBtcLockSenderProvider(btcLockSenderProvider)
             .withPeginInstructionsProvider(peginInstructionsProvider)
-            .build();
-    }
-
-    private void setUpListenerAndWrapperWithFederation(Federation federationToListen) throws Exception {
-        listener = btcToRskClientBuilder
             .withFederation(federationToListen)
             .build();
+        addListener(federationToListen);
+    }
+
+    private void addListener(Federation federationToListen) {
         bitcoinWrapper.addFederationListener(federationToListen, listener);
+    }
+
+    private static Stream<Federation> fedArgs() {
+        final Federation standardMultisigFederation = TestUtils.createStandardMultisigFederation(
+            thinNetworkParameters,
+            9
+        );
+        final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
+
+        return Stream.of(standardMultisigFederation, p2shP2wshErpFederation);
     }
 
     @ParameterizedTest
     @MethodSource("fedArgs")
     void coinsReceivedOrSent_validLegacyPegIn_shouldListenTx(Federation federation) throws Exception {
-        // Arrange
-        setUpListenerAndWrapperWithFederation(federation);
+        // arrange
+        setUpActiveFedListener(federation);
         Transaction pegin = createLegacyPegIn(federation);
 
-        // Act
+        // act
         bitcoinWrapper.coinsReceivedOrSent(pegin);
 
         // assert
-        assertWTxIdWasAddedToProofs(pegin);
+        assertWTxIdIsInActiveFedClientProofsFile(pegin);
     }
 
     @ParameterizedTest
     @MethodSource("fedArgs")
     void coinsReceivedOrSent_validPeginV1_shouldListenTx(Federation federation) throws Exception {
-        // Arrange
-        setUpListenerAndWrapperWithFederation(federation);
+        // arrange
+        setUpActiveFedListener(federation);
         Transaction pegin = createValidPegInV1(federation.getAddress());
 
-        // Act
+        // act
         bitcoinWrapper.coinsReceivedOrSent(pegin);
 
         // assert
-        assertWTxIdWasAddedToProofs(pegin);
+        assertWTxIdIsInActiveFedClientProofsFile(pegin);
     }
 
     private Transaction createLegacyPegIn(Federation federation) {
@@ -175,15 +206,15 @@ class BitcoinWrapperImplTest {
     @ParameterizedTest
     @MethodSource("fedArgs")
     void coinsReceivedOrSent_validPegOutTx_shouldListenTx(Federation federation) throws Exception {
-        // Arrange
+        // arrange
+        setUpActiveFedListener(federation);
         final Transaction pegout = createPegOutTx(federation);
-        setUpListenerAndWrapperWithFederation(federation);
 
-        // Act
+        // act
         bitcoinWrapper.coinsReceivedOrSent(pegout);
 
-        // Assert
-        assertWTxIdWasAddedToProofs(pegout);
+        // assert
+        assertWTxIdIsInActiveFedClientProofsFile(pegout);
     }
 
     private Transaction createPegOutTx(Federation federation) {
@@ -220,147 +251,101 @@ class BitcoinWrapperImplTest {
         return ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), pegout);
     }
 
-    private static Stream<Federation> fedArgs() {
-        final Federation standarMultisigFederation = TestUtils.createStandardMultisigFederation(
+    private static Stream<Arguments> retiringAndActiveFedsArgs() {
+        final Federation standardMultiSigFed = TestUtils.createStandardMultisigFederation(
             thinNetworkParameters,
             9
         );
-        final Federation p2shErpFederation = TestUtils.createP2shErpFederation(
+        final Federation firstP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             9
         );
-        final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+        final Federation secondP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             20
         );
 
-        return Stream.of(standarMultisigFederation, p2shErpFederation, p2shP2wshErpFederation);
+        return Stream.of(
+            Arguments.of(standardMultiSigFed, firstP2shP2wshErpFed),
+            Arguments.of(firstP2shP2wshErpFed, secondP2shP2wshErpFed)
+        );
     }
 
     @ParameterizedTest
     @MethodSource("retiringAndActiveFedsArgs")
-    void coinsReceivedOrSent_migrationTx_shouldListenTx(
-        Federation retiringFederation,
-        Federation activeFederation
-    ) throws Exception {
-        // Arrange
-        when(federatorSupport.getFederationAddress()).thenReturn(activeFederation.getAddress());
-        when(federatorSupport.getRetiringFederationAddress()).thenReturn(Optional.of(retiringFederation.getAddress()));
-
-        setUpListenerAndWrapperWithFederation(activeFederation);
-        Transaction migrationTx = createMigrationTx(retiringFederation, activeFederation);
+    void coinsReceivedOrSent_migrationTx_listenerForBothFeds_shouldBeSavedInBothFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // arrange
+        setUpActiveFedListener(activeFederation);
+        setUpRetiringFedListener(retiringFederation);
+        var migrationBtcTx = createMigrationTx(thinNetworkParameters, retiringFederation, activeFederation);
 
         // act
+        var migrationTx = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), migrationBtcTx);
         bitcoinWrapper.coinsReceivedOrSent(migrationTx);
 
         // assert
-        assertWTxIdWasAddedToProofs(migrationTx);
+        assertWTxIdIsInActiveFedClientProofsFile(migrationTx);
+        assertWTxIdIsInRetiringFedClientProofsFile(migrationTx);
     }
 
-    private static Stream<Arguments> retiringAndActiveFedsArgs() {
-        final Federation retiringP2shErpFed = TestUtils.createP2shErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation activeP2shErpFed = TestUtils.createP2shErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation retiringP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation activeP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
-            thinNetworkParameters,
-            9
-        );
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_migrationTxBelowMinimumPeginValue_listenerForBothFeds_shouldBeSavedJustInRetiringFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // arrange
+        setUpActiveFedListener(activeFederation);
+        setUpRetiringFedListener(retiringFederation);
+        var migrationBtcTx = createMigrationTxBelowMinimumPeginValue(thinNetworkParameters, retiringFederation, activeFederation);
 
-        return Stream.of(
-            Arguments.of(retiringP2shErpFed, activeP2shErpFed),
-            Arguments.of(retiringP2shErpFed, activeP2shP2wshErpFed),
-            Arguments.of(retiringP2shP2wshErpFed, activeP2shP2wshErpFed)
-        );
+        // act
+        var migrationTx = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), migrationBtcTx);
+        bitcoinWrapper.coinsReceivedOrSent(migrationTx);
+
+        // assert
+        assertWTxIdIsInRetiringFedClientProofsFile(migrationTx);
+        assertProofsFileIsEmpty(originalNetworkParameters, btcToRskActiveFedClientFileStorage);
     }
 
-    private Transaction createMigrationTx(Federation retiringFederation, Federation activeFederation) {
-        co.rsk.bitcoinj.core.Address retiringFederationAddress = retiringFederation.getAddress();
-        co.rsk.bitcoinj.core.Address activeFederationAddress = activeFederation.getAddress();
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_peginToActiveFed_listenerForBothFeds_shouldBeSavedInBothFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // arrange
+        setUpActiveFedListener(activeFederation);
+        setUpRetiringFedListener(retiringFederation);
 
-        List<BtcTransaction> txsToMigrate = new ArrayList<>();
-        co.rsk.bitcoinj.core.Coin baseCoin = co.rsk.bitcoinj.core.Coin.valueOf(1_000_000L);
-        for (int i = 1; i <= 10; i++) {
-            BtcTransaction txSentToRetiringFed = new BtcTransaction(thinNetworkParameters);
-            co.rsk.bitcoinj.core.Coin value = baseCoin.multiply(i);
-            txSentToRetiringFed.addOutput(value, retiringFederationAddress);
+        var peginBtcTxToActiveFed = createPegIn(activeFederation.getAddress());
 
-            txsToMigrate.add(txSentToRetiringFed);
-        }
+        // act
+        var peginTxToActiveFed = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), peginBtcTxToActiveFed);
+        bitcoinWrapper.coinsReceivedOrSent(peginTxToActiveFed);
 
-        BtcTransaction thinMigrationTx = new BtcTransaction(thinNetworkParameters);
-        for (int i = 0; i < txsToMigrate.size(); i++) {
-            BtcTransaction txToMigrate = txsToMigrate.get(i);
-            co.rsk.bitcoinj.core.TransactionOutput output = txToMigrate.getOutput(0);
-            thinMigrationTx.addInput(output);
-
-            addSpendingFederationBaseScript(
-                thinMigrationTx,
-                i,
-                retiringFederation.getRedeemScript(),
-                retiringFederation.getFormatVersion()
-            );
-        }
-
-        co.rsk.bitcoinj.core.Coin totalValue = co.rsk.bitcoinj.core.Coin.ZERO;
-        for (BtcTransaction txToMigrate : txsToMigrate) {
-            co.rsk.bitcoinj.core.TransactionOutput output = txToMigrate.getOutput(0);
-            totalValue = totalValue.add(output.getValue());
-        }
-        thinMigrationTx.addOutput(totalValue, activeFederationAddress);
-
-        return ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), thinMigrationTx);
+        // assert
+        assertWTxIdIsInActiveFedClientProofsFile(peginTxToActiveFed);
+        assertWTxIdIsInRetiringFedClientProofsFile(peginTxToActiveFed);
     }
 
-    private void assertWTxIdWasAddedToProofs(Transaction tx) throws IOException {
-        BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(originalNetworkParameters).getData();
-        Map<Sha256Hash, List<Proof>> transactionProofs = fileData.getTransactionProofs();
+    @ParameterizedTest
+    @MethodSource("retiringAndActiveFedsArgs")
+    void coinsReceivedOrSent_peginToRetiringFed_listenerForBothFeds_shouldBeSavedInBothFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+        // arrange
+        setUpActiveFedListener(activeFederation);
+        setUpRetiringFedListener(retiringFederation);
 
-        Set<Sha256Hash> txProofsKeySet = transactionProofs.keySet();
-        assertEquals(1, txProofsKeySet.size());
+        var peginBtcTxToRetiringFed = createPegIn(retiringFederation.getAddress());
 
-        Sha256Hash wTxId = tx.getWTxId();
-        Sha256Hash savedWTxId = txProofsKeySet.iterator().next();
-        assertEquals(wTxId, savedWTxId);
+        // act
+        var peginTxToRetiringFed = ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), peginBtcTxToRetiringFed);
+        bitcoinWrapper.coinsReceivedOrSent(peginTxToRetiringFed);
+
+        // assert
+        assertWTxIdIsInActiveFedClientProofsFile(peginTxToRetiringFed);
+        assertWTxIdIsInRetiringFedClientProofsFile(peginTxToRetiringFed);
     }
 
-    // Class that allows to override certain methods in Kit class
-    // that are inherited from WalletAppKit class and can't be mocked
-    private static class KitForTests extends Kit {
+    private void assertWTxIdIsInActiveFedClientProofsFile(Transaction tx) throws IOException {
+        assertWTxIdIsInProofsFile(originalNetworkParameters, btcToRskActiveFedClientFileStorage, tx);
+    }
 
-        private final Wallet wallet;
-
-        public KitForTests(Context btcContext, File directory, String filePrefix, Wallet wallet) {
-            super(btcContext, directory, filePrefix);
-            this.wallet = wallet;
-        }
-
-        @Override
-        protected void startUp() {
-            // Not needed for tests
-        }
-
-        @Override
-        protected void shutDown() {
-            // Not needed for tests
-        }
-
-        @Override
-        protected Wallet createWallet() {
-            return wallet;
-        }
-
-        @Override
-        public Wallet wallet() {
-            return wallet;
-        }
+    private void assertWTxIdIsInRetiringFedClientProofsFile(Transaction tx) throws IOException {
+        assertWTxIdIsInProofsFile(originalNetworkParameters, btcToRskRetiringFedClientFileStorage, tx);
     }
 }

--- a/src/test/java/co/rsk/federate/bitcoin/KitStub.java
+++ b/src/test/java/co/rsk/federate/bitcoin/KitStub.java
@@ -1,0 +1,61 @@
+package co.rsk.federate.bitcoin;
+
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.store.BlockStore;
+import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.wallet.Wallet;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Class that allows to override certain methods in Kit class
+// that are inherited from WalletAppKit class and can't be mocked
+public class KitStub extends Kit {
+    private final Wallet wallet;
+    private BlockStore store;
+
+    public KitStub(Context btcContext, File directory, String filePrefix, Wallet wallet) {
+        super(btcContext, directory, filePrefix);
+        this.wallet = wallet;
+    }
+
+    public void setStore(StoredBlock[] storedBlocks) throws BlockStoreException {
+        BlockStore blockStore = mock(BlockStore.class);
+        for (int i = 0; i < storedBlocks.length; i++) {
+            StoredBlock storedBlock = Arrays.stream(storedBlocks).toList().get(i);
+            when(blockStore.get(storedBlock.getHeader().getHash())).thenReturn(storedBlock);
+            when(blockStore.getChainHead()).thenReturn(storedBlock);
+        }
+
+        this.store = blockStore;
+    }
+
+    @Override
+    protected void startUp() {
+        // Not needed for tests
+    }
+
+    @Override
+    protected void shutDown() {
+        // Not needed for tests
+    }
+
+    @Override
+    protected Wallet createWallet() {
+        return wallet;
+    }
+
+    @Override
+    public Wallet wallet() {
+        return wallet;
+    }
+
+    @Override
+    public BlockStore store() {
+        return store;
+    }
+}

--- a/src/test/java/co/rsk/federate/io/BtcToRskClientFileStorageImplTest.java
+++ b/src/test/java/co/rsk/federate/io/BtcToRskClientFileStorageImplTest.java
@@ -51,7 +51,7 @@ class BtcToRskClientFileStorageImplTest {
     @Test
     void read_no_file() throws IOException {
         FileStorageInfo storageInfo = mock(FileStorageInfo.class);
-        when(storageInfo.getPegDirectoryPath()).thenReturn(DIRECTORY_PATH);
+        when(storageInfo.getDirectoryPath()).thenReturn(DIRECTORY_PATH);
         when(storageInfo.getFilePath()).thenReturn(FILE_PATH);
 
         BtcToRskClientFileStorageImpl storage = getBtcToRskClientFileStorage(storageInfo);
@@ -66,7 +66,7 @@ class BtcToRskClientFileStorageImplTest {
     @Test
     void read_empty_file() throws IOException {
         BtcToRskClientFileStorageInfo storageInfo = mock(BtcToRskClientFileStorageInfo.class);
-        when(storageInfo.getPegDirectoryPath()).thenReturn(DIRECTORY_PATH);
+        when(storageInfo.getDirectoryPath()).thenReturn(DIRECTORY_PATH);
         when(storageInfo.getFilePath()).thenReturn(FILE_PATH);
 
         createFile(storageInfo, new byte[]{});
@@ -83,7 +83,7 @@ class BtcToRskClientFileStorageImplTest {
     @Test
     void read_trash_file() throws IOException {
         BtcToRskClientFileStorageInfo storageInfo = mock(BtcToRskClientFileStorageInfo.class);
-        when(storageInfo.getPegDirectoryPath()).thenReturn(DIRECTORY_PATH);
+        when(storageInfo.getDirectoryPath()).thenReturn(DIRECTORY_PATH);
         when(storageInfo.getFilePath()).thenReturn(FILE_PATH);
 
         createFile(storageInfo, new byte[]{ 6, 6, 6 });
@@ -98,7 +98,7 @@ class BtcToRskClientFileStorageImplTest {
     @Test
     void write_null_data() {
         BtcToRskClientFileStorageInfo storageInfo = mock(BtcToRskClientFileStorageInfo.class);
-        when(storageInfo.getPegDirectoryPath()).thenReturn(DIRECTORY_PATH);
+        when(storageInfo.getDirectoryPath()).thenReturn(DIRECTORY_PATH);
         when(storageInfo.getFilePath()).thenReturn(FILE_PATH);
 
         BtcToRskClientFileStorageImpl storage = getBtcToRskClientFileStorage(storageInfo);
@@ -109,7 +109,7 @@ class BtcToRskClientFileStorageImplTest {
     @Test
     void write_empty_data() throws Exception {
         BtcToRskClientFileStorageInfo storageInfo = mock(BtcToRskClientFileStorageInfo.class);
-        when(storageInfo.getPegDirectoryPath()).thenReturn(DIRECTORY_PATH);
+        when(storageInfo.getDirectoryPath()).thenReturn(DIRECTORY_PATH);
         when(storageInfo.getFilePath()).thenReturn(FILE_PATH);
 
         BtcToRskClientFileStorageImpl storage = getBtcToRskClientFileStorage(storageInfo);
@@ -128,7 +128,7 @@ class BtcToRskClientFileStorageImplTest {
     @Test
     void write_and_read_ok() throws Exception {
         BtcToRskClientFileStorageInfo storageInfo = mock(BtcToRskClientFileStorageInfo.class);
-        when(storageInfo.getPegDirectoryPath()).thenReturn(DIRECTORY_PATH);
+        when(storageInfo.getDirectoryPath()).thenReturn(DIRECTORY_PATH);
         when(storageInfo.getFilePath()).thenReturn(FILE_PATH);
 
         BtcToRskClientFileData fileData = new BtcToRskClientFileData();

--- a/src/test/java/co/rsk/federate/utils/ClientProofsAssertions.java
+++ b/src/test/java/co/rsk/federate/utils/ClientProofsAssertions.java
@@ -1,0 +1,49 @@
+package co.rsk.federate.utils;
+
+import co.rsk.federate.BtcToRskClient;
+import co.rsk.federate.Proof;
+import co.rsk.federate.io.BtcToRskClientFileData;
+import co.rsk.federate.io.BtcToRskClientFileStorage;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Transaction;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ClientProofsAssertions {
+
+    public static void assertWTxIdIsInTxsToBeSentMap(BtcToRskClient btcToRskClient, Transaction tx) {
+        assertTrue(btcToRskClient.getTransactionsToSendToRsk().containsKey(tx.getWTxId()));
+    }
+
+    public static void assertWTxIdIsNotInTxsToBeSentMap(BtcToRskClient btcToRskClient, Transaction tx) {
+        assertFalse(btcToRskClient.getTransactionsToSendToRsk().containsKey(tx.getWTxId()));
+    }
+
+    public static void assertWTxIdIsInProofsFile(NetworkParameters networkParameters, BtcToRskClientFileStorage btcToRskClientFileStorage, Transaction tx) throws IOException {
+        Set<Sha256Hash> txProofsKeySet = getTxProofsKeySet(networkParameters, btcToRskClientFileStorage);
+        assertTrue(txProofsKeySet.contains(tx.getWTxId()));
+    }
+
+    public static void assertWTxIdIsNotInProofsFile(NetworkParameters networkParameters, BtcToRskClientFileStorage btcToRskClientFileStorage, Transaction tx) throws IOException {
+        Set<Sha256Hash> txProofsKeySet = getTxProofsKeySet(networkParameters, btcToRskClientFileStorage);
+        assertFalse(txProofsKeySet.contains(tx.getWTxId()));
+    }
+
+    public static void assertProofsFileIsEmpty(NetworkParameters networkParameters, BtcToRskClientFileStorage btcToRskClientFileStorage) throws IOException {
+        Set<Sha256Hash> txProofsKeySet = getTxProofsKeySet(networkParameters, btcToRskClientFileStorage);
+        assertEquals(0, txProofsKeySet.size());
+    }
+
+    private static Set<Sha256Hash> getTxProofsKeySet(NetworkParameters networkParameters, BtcToRskClientFileStorage btcToRskClientFileStorage) throws IOException {
+        BtcToRskClientFileData fileData = btcToRskClientFileStorage.read(networkParameters).getData();
+        Map<Sha256Hash, List<Proof>> transactionProofs = fileData.getTransactionProofs();
+
+        return transactionProofs.keySet();
+    }
+}


### PR DESCRIPTION
- Separate proof/storage paths for active and retiring clients
- Persist fileData to storage right after modifying it and use iterator to avoid ConcurrentModificationException