### PR TITLE
Enhance logging in BtcToRskClient and FederatorSupport

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -55,10 +55,6 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Manages the process of informing the RSK bridge news about the bitcoin blockchain
- * @author Oscar Guindzberg
- */
 public class BtcToRskClient implements BlockListener, TransactionListener {
     protected static final int MAXIMUM_REGISTER_BTC_LOCK_TXS_PER_TURN = 40;
 
@@ -733,7 +729,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     }
 
     private boolean shouldSendTx(Transaction tx, Wallet federationWallet, Optional<Federation> proposedFederation, Optional<Federation> retiringFederation, Federation activeFederation) {
-        logger.debug("[shouldSendTx] Checking if tx should be sent {}", tx.getWTxId());
+        logger.debug("[shouldSendTx] Checking if tx should be sent {} (wtxid: {})", tx.getTxId(), tx.getWTxId());
         BtcTransaction btcTx = ThinConverter.toThinInstance(federationWallet.getNetworkParameters(), tx);
 
         co.rsk.bitcoinj.core.Coin valueSentToMe = btcTx.getValueSentToMe(federationWallet);
@@ -762,25 +758,21 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
     }
 
     private void sendTx(Transaction tx, StoredBlock txStoredBlock, PartialMerkleTree pmt) {
-        logger.debug(
-            "[sendTx] Will send btc tx {} (wtxid: {}) with enough confirmations",
-            tx.getTxId(),
-            tx.getWTxId()
-        );
-
-        Sha256Hash txHash = tx.getWTxId();
         int blockHeight = txStoredBlock.getHeight();
+
         logger.debug(
-            "[sendTx] Tx {} belongs to block {} at height {}",
-            txHash,
+            "[sendTx] Will send btc tx {} (wtxid: {}) with enough confirmations. Belongs to block {} at height {}",
+            tx.getTxId(),
+            tx.getWTxId(),
             txStoredBlock.getHeader().getHash(),
             blockHeight
         );
 
         federatorSupport.sendRegisterBtcTransaction(tx, blockHeight, pmt);
         logger.debug(
-            "[sendTx] Invoked registerBtcTransaction for tx {}",
-            txHash
+            "[sendTx] Invoked registerBtcTransaction for tx {} (wtxid: {})",
+            tx.getTxId(),
+            tx.getWTxId()
         );
     }
 

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -9,9 +9,16 @@ import co.rsk.federate.bitcoin.BitcoinPeerFactory;
 import co.rsk.federate.config.PowpegNodeSystemProperties;
 import co.rsk.federate.signing.ECDSASigner;
 import co.rsk.peg.Bridge;
-import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.StateForFederator;
 import co.rsk.peg.StateForProposedFederator;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.federation.FederationMember;
+import java.math.BigInteger;
+import java.net.UnknownHostException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.bitcoinj.core.PartialMerkleTree;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.Sha256Hash;
@@ -20,19 +27,8 @@ import org.ethereum.core.Blockchain;
 import org.ethereum.crypto.ECKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.math.BigInteger;
-import java.net.UnknownHostException;
-import java.time.Instant;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
-/**
- * Helps the federator communication with the RSK blockchain.
- * @author Oscar Guindzberg
- */
 public class FederatorSupport {
-
     private static final Logger logger = LoggerFactory.getLogger(FederatorSupport.class);
 
     private final Blockchain blockchain;
@@ -45,9 +41,10 @@ public class FederatorSupport {
     private RskAddress federatorAddress;
 
     public FederatorSupport(
-            Blockchain blockchain,
-            PowpegNodeSystemProperties config,
-            BridgeTransactionSender bridgeTransactionSender) {
+        Blockchain blockchain,
+        PowpegNodeSystemProperties config,
+        BridgeTransactionSender bridgeTransactionSender
+    ) {
         this.blockchain = blockchain;
         this.config = config;
         this.parameters = config.getNetworkConstants().getBridgeConstants().getBtcParams();
@@ -68,21 +65,36 @@ public class FederatorSupport {
     }
 
     public List<PeerAddress> getBitcoinPeerAddresses() throws UnknownHostException {
-        return BitcoinPeerFactory.buildBitcoinPeerAddresses(ThinConverter.toOriginalInstance(config.getNetworkConstants().getBridgeConstants().getBtcParamsString()), this.config.getNetworkConstants().getBridgeConstants().getBtcParams().getPort(), this.config.bitcoinPeerAddresses());
+        BridgeConstants bridgeConstants = this.config.getNetworkConstants().getBridgeConstants();
+        return BitcoinPeerFactory.buildBitcoinPeerAddresses(
+            ThinConverter.toOriginalInstance(bridgeConstants.getBtcParamsString()),
+            bridgeConstants.getBtcParams().getPort(),
+            this.config.bitcoinPeerAddresses()
+        );
     }
 
     public int getBtcBlockchainBestChainHeight() {
-        BigInteger btcBlockchainBestChainHeight = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT);
+        BigInteger btcBlockchainBestChainHeight = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_BTC_BLOCKCHAIN_BEST_CHAIN_HEIGHT
+        );
         return btcBlockchainBestChainHeight.intValue();
     }
 
     public int getBtcBlockchainInitialBlockHeight() {
-        BigInteger btcBlockchainInitialBlockHeight = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_INITIAL_BLOCK_HEIGHT);
+        BigInteger btcBlockchainInitialBlockHeight = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_BTC_BLOCKCHAIN_INITIAL_BLOCK_HEIGHT
+        );
         return btcBlockchainInitialBlockHeight.intValue();
     }
 
     public Sha256Hash getBtcBlockchainBlockHashAtDepth(int depth) {
-        byte[] blockHashBytes = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_BLOCK_HASH_AT_DEPTH, new Object[]{depth});
+        byte[] blockHashBytes = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_BTC_BLOCKCHAIN_BLOCK_HASH_AT_DEPTH,
+            new Object[]{depth}
+        );
         return Sha256Hash.wrap(blockHashBytes);
     }
 
@@ -95,51 +107,90 @@ public class FederatorSupport {
     }
 
     public void sendReceiveHeaders(org.bitcoinj.core.Block[] headers) {
-        logger.debug("About to send to the bridge headers from {} to {}", headers[0].getHash(), headers[headers.length - 1].getHash());
+        logger.debug(
+            "[sendReceiveHeaders] About to send to the bridge headers from {} to {}",
+            headers[0].getHash(),
+            headers[headers.length - 1].getHash()
+        );
 
         Object[] objectArray = new Object[headers.length];
 
         for (int i = 0; i < headers.length; i++) {
             objectArray[i] = headers[i].cloneAsHeader().bitcoinSerialize();
         }
-        this.bridgeTransactionSender.sendRskTx(federatorAddress, signer, Bridge.RECEIVE_HEADERS, new Object[]{objectArray});
+        this.bridgeTransactionSender.sendRskTx(
+            federatorAddress,
+            signer,
+            Bridge.RECEIVE_HEADERS,
+            new Object[]{objectArray}
+        );
     }
 
     public Boolean isBtcTxHashAlreadyProcessed(Sha256Hash btcTxHash) {
-        return this.bridgeTransactionSender.callTx(federatorAddress, Bridge.IS_BTC_TX_HASH_ALREADY_PROCESSED, new Object[]{btcTxHash.toString()});
+        return this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.IS_BTC_TX_HASH_ALREADY_PROCESSED,
+            new Object[]{btcTxHash.toString()}
+        );
     }
 
     public Long getBtcTxHashProcessedHeight(Sha256Hash btcTxHash) {
-        BigInteger btcTxHashProcessedHeight = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_TX_HASH_PROCESSED_HEIGHT, new Object[]{btcTxHash.toString()});
+        BigInteger btcTxHashProcessedHeight = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_BTC_TX_HASH_PROCESSED_HEIGHT,
+            new Object[]{btcTxHash.toString()}
+        );
         return btcTxHashProcessedHeight.longValue();
     }
 
     public void sendRegisterBtcTransaction(org.bitcoinj.core.Transaction tx, int blockHeight, PartialMerkleTree pmt) {
-        logger.debug("About to send to the bridge btc tx hash {}. Block height {}", tx.getWTxId(), blockHeight);
+        logger.debug(
+            "[sendRegisterBtcTransaction] About to send to the bridge btc tx {} (wtxid: {}). Block height {}",
+            tx.getTxId(),
+            tx.getWTxId(),
+            blockHeight
+        );
 
         byte[] txSerialized = tx.bitcoinSerialize();
         byte[] pmtSerialized = pmt.bitcoinSerialize();
-        this.bridgeTransactionSender.sendRskTx(federatorAddress, signer, Bridge.REGISTER_BTC_TRANSACTION, txSerialized, blockHeight, pmtSerialized);
+        this.bridgeTransactionSender.sendRskTx(
+            federatorAddress,
+            signer,
+            Bridge.REGISTER_BTC_TRANSACTION,
+            txSerialized,
+            blockHeight,
+            pmtSerialized
+        );
     }
 
     public void sendRegisterCoinbaseTransaction(CoinbaseInformation coinbaseInformation) {
-        logger.debug("About to send to the bridge btc coinbase tx hash {}. Block hash {}", coinbaseInformation.getCoinbaseTransaction().getTxId(), coinbaseInformation.getBlockHash());
+        logger.debug(
+            "[sendRegisterCoinbaseTransaction] About to send to the bridge btc coinbase tx hash {}. Block hash {}",
+            coinbaseInformation.getCoinbaseTransaction().getTxId(),
+            coinbaseInformation.getBlockHash()
+        );
 
         byte[] txSerialized = coinbaseInformation.getSerializedCoinbaseTransactionWithoutWitness();
         byte[] pmtSerialized = coinbaseInformation.getPmt().bitcoinSerialize();
 
-        this.bridgeTransactionSender.sendRskTx(federatorAddress, signer,
-                Bridge.REGISTER_BTC_COINBASE_TRANSACTION,
-                txSerialized, coinbaseInformation.getBlockHash().getBytes(), pmtSerialized,
-                coinbaseInformation.getWitnessRoot().getBytes(), coinbaseInformation.getCoinbaseWitnessReservedValue()
-                );
+        this.bridgeTransactionSender.sendRskTx(
+            federatorAddress,
+            signer,
+            Bridge.REGISTER_BTC_COINBASE_TRANSACTION,
+            txSerialized,
+            coinbaseInformation.getBlockHash().getBytes(),
+            pmtSerialized,
+            coinbaseInformation.getWitnessRoot().getBytes(),
+            coinbaseInformation.getCoinbaseWitnessReservedValue()
+        );
     }
 
     public boolean hasBlockCoinbaseInformed(Sha256Hash blockHash) {
         return this.bridgeTransactionSender.callTx(
-                federatorAddress,
-                Bridge.HAS_BTC_BLOCK_COINBASE_TRANSACTION_INFORMATION,
-                new Object[] { blockHash.getBytes() });
+            federatorAddress,
+            Bridge.HAS_BTC_BLOCK_COINBASE_TRANSACTION_INFORMATION,
+            new Object[] { blockHash.getBytes() }
+        );
     }
 
     public StateForFederator getStateForFederator() {
@@ -148,16 +199,27 @@ public class FederatorSupport {
     }
 
     public Optional<StateForProposedFederator> getStateForProposedFederator() {
-        byte[] result = bridgeTransactionSender.callTx(
-            federatorAddress, Bridge.GET_STATE_FOR_SVP_CLIENT);
+        byte[] result = bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_STATE_FOR_SVP_CLIENT);
 
         return Optional.ofNullable(result)
             .map(rlpData -> new StateForProposedFederator(rlpData, parameters));
     }
 
     public void addSignature(List<byte[]> signatures, byte[] rskTxHash) {
+        logger.debug(
+            "[addSignature] About to send to the bridge signatures {} for pegout created in rsk tx {}",
+            signatures,
+            rskTxHash
+        );
         byte[] federatorPublicKeyBytes = federationMember.getBtcPublicKey().getPubKey();
-        this.bridgeTransactionSender.sendRskTx(federatorAddress, signer, Bridge.ADD_SIGNATURE, federatorPublicKeyBytes, signatures, rskTxHash);
+        this.bridgeTransactionSender.sendRskTx(
+            federatorAddress,
+            signer,
+            Bridge.ADD_SIGNATURE,
+            federatorPublicKeyBytes,
+            signatures,
+            rskTxHash
+        );
     }
 
     public void sendUpdateCollections() {
@@ -165,7 +227,8 @@ public class FederatorSupport {
     }
 
     public Address getFederationAddress() {
-        return Address.fromBase58(getBtcParams(), this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_FEDERATION_ADDRESS));
+        String federationAddress = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_FEDERATION_ADDRESS);
+        return Address.fromBase58(getBtcParams(), federationAddress);
     }
 
     public Integer getFederationSize() {
@@ -184,7 +247,12 @@ public class FederatorSupport {
     }
 
     public ECKey getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
-        byte[] federatorPublicKey = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE, new Object[]{index, keyType.getValue()});
+        byte[] federatorPublicKey = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_FEDERATOR_PUBLIC_KEY_OF_TYPE,
+            new Object[]{index, keyType.getValue()}
+        );
+
         return ECKey.fromPublicOnly(federatorPublicKey);
     }
 
@@ -194,7 +262,11 @@ public class FederatorSupport {
     }
 
     public long getFederationCreationBlockNumber() {
-        BigInteger federationCreationBlockNumber = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_FEDERATION_CREATION_BLOCK_NUMBER);
+        BigInteger federationCreationBlockNumber = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_FEDERATION_CREATION_BLOCK_NUMBER
+        );
+
         return federationCreationBlockNumber.longValue();
     }
 
@@ -209,7 +281,11 @@ public class FederatorSupport {
     }
 
     public long getRetiringFederationCreationBlockNumber() {
-        BigInteger retiringFederationCreationBlockNumber = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_RETIRING_FEDERATION_CREATION_BLOCK_NUMBER);
+        BigInteger retiringFederationCreationBlockNumber = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_RETIRING_FEDERATION_CREATION_BLOCK_NUMBER
+        );
+
         return retiringFederationCreationBlockNumber.longValue();
     }
 
@@ -220,6 +296,7 @@ public class FederatorSupport {
 
     public Integer getRetiringFederationThreshold() {
         BigInteger threshold = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_RETIRING_FEDERATION_THRESHOLD);
+
         if (threshold == null) {
             return null;
         }
@@ -238,7 +315,11 @@ public class FederatorSupport {
     }
 
     public ECKey getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
-        byte[] publicKeyBytes = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE, new Object[]{index, keyType.getValue()});
+        byte[] publicKeyBytes = this.bridgeTransactionSender.callTx(
+            federatorAddress,
+            Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY_OF_TYPE,
+            new Object[]{index, keyType.getValue()}
+        );
 
         if (publicKeyBytes == null) {
             return null;
@@ -252,12 +333,15 @@ public class FederatorSupport {
         if (creationTime == null) {
             return null;
         }
+
         return Instant.ofEpochSecond(creationTime.longValue());
     }
 
     public Optional<Address> getProposedFederationAddress() {
         String proposedFederationAddress = bridgeTransactionSender.callTx(
-            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_ADDRESS);
+            federatorAddress,
+            Bridge.GET_PROPOSED_FEDERATION_ADDRESS
+        );
 
         return Optional.ofNullable(proposedFederationAddress)
             .filter(addr -> !addr.isEmpty())
@@ -265,8 +349,7 @@ public class FederatorSupport {
     }
 
     public Optional<Integer> getProposedFederationSize() {
-        BigInteger size = bridgeTransactionSender.callTx(
-            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_SIZE);
+        BigInteger size = bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_PROPOSED_FEDERATION_SIZE);
 
         return Optional.ofNullable(size)
             .map(BigInteger::intValue);
@@ -278,7 +361,8 @@ public class FederatorSupport {
         byte[] publicKeyBytes = bridgeTransactionSender.callTx(
             federatorAddress,
             Bridge.GET_PROPOSED_FEDERATOR_PUBLIC_KEY_OF_TYPE,
-            new Object[]{ index, keyType.getValue() });
+            new Object[]{ index, keyType.getValue() }
+        );
        
         return Optional.ofNullable(publicKeyBytes)
             .map(ECKey::fromPublicOnly);
@@ -286,7 +370,9 @@ public class FederatorSupport {
 
     public Optional<Instant> getProposedFederationCreationTime() {
         BigInteger creationTime = bridgeTransactionSender.callTx(
-            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_CREATION_TIME);
+            federatorAddress,
+            Bridge.GET_PROPOSED_FEDERATION_CREATION_TIME
+        );
 
         return Optional.ofNullable(creationTime)
             .map(BigInteger::longValue)
@@ -295,7 +381,9 @@ public class FederatorSupport {
 
     public Optional<Long> getProposedFederationCreationBlockNumber() {
         BigInteger creationBlockNumber = bridgeTransactionSender.callTx(
-            federatorAddress, Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER);
+            federatorAddress,
+            Bridge.GET_PROPOSED_FEDERATION_CREATION_BLOCK_NUMBER
+        );
 
         return Optional.ofNullable(creationBlockNumber)
             .map(BigInteger::longValue);

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import org.bitcoinj.core.PartialMerkleTree;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.Sha256Hash;
+import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Blockchain;
 import org.ethereum.crypto.ECKey;
@@ -201,10 +202,11 @@ public class FederatorSupport {
     }
 
     public void addSignature(List<byte[]> signatures, byte[] rskTxHash) {
+        String releaseCreationRskTxHash = Hex.toHexString(rskTxHash);
         logger.debug(
-            "[addSignature] About to send to the bridge signatures {} for pegout created in rsk tx {}",
-            signatures,
-            rskTxHash
+            "[addSignature] About to send to the bridge {} signatures for pegout created in rsk tx {}",
+            signatures.size(),
+            releaseCreationRskTxHash
         );
         byte[] federatorPublicKeyBytes = federationMember.getBtcPublicKey().getPubKey();
         this.bridgeTransactionSender.sendRskTx(

--- a/src/main/java/co/rsk/federate/FederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederatorSupport.java
@@ -1,7 +1,6 @@
 package co.rsk.federate;
 
 import co.rsk.bitcoinj.core.Address;
-import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.core.RskAddress;
 import co.rsk.federate.adapter.ThinConverter;
@@ -96,10 +95,6 @@ public class FederatorSupport {
             new Object[]{depth}
         );
         return Sha256Hash.wrap(blockHashBytes);
-    }
-
-    public Object[] getBtcBlockchainBlockLocator() {
-        return this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_BTC_BLOCKCHAIN_BLOCK_LOCATOR);
     }
 
     public Long getRskBestChainHeight() {
@@ -241,11 +236,6 @@ public class FederatorSupport {
         return federationThreshold.intValue();
     }
 
-    public BtcECKey getFederatorPublicKey(int index) {
-        byte[] federatorPublicKey = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_FEDERATOR_PUBLIC_KEY, new Object[]{index});
-        return BtcECKey.fromPublicOnly(federatorPublicKey);
-    }
-
     public ECKey getFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         byte[] federatorPublicKey = this.bridgeTransactionSender.callTx(
             federatorAddress,
@@ -302,16 +292,6 @@ public class FederatorSupport {
         }
 
         return threshold.intValue();
-    }
-
-    public BtcECKey getRetiringFederatorPublicKey(int index) {
-        byte[] publicKeyBytes = this.bridgeTransactionSender.callTx(federatorAddress, Bridge.GET_RETIRING_FEDERATOR_PUBLIC_KEY, new Object[]{index});
-
-        if (publicKeyBytes == null) {
-            return null;
-        }
-
-        return BtcECKey.fromPublicOnly(publicKeyBytes);
     }
 
     public ECKey getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {

--- a/src/test/java/co/rsk/federate/mock/SimpleFederatorSupport.java
+++ b/src/test/java/co/rsk/federate/mock/SimpleFederatorSupport.java
@@ -1,17 +1,17 @@
 package co.rsk.federate.mock;
 
+import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
+
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.config.TestSystemProperties;
-
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationMember;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationMember;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.PartialMerkleTree;
 import org.bitcoinj.core.PeerAddress;
@@ -19,20 +19,13 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.ethereum.crypto.ECKey;
 
-import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
-
-/**
- * Created by ajlopez on 6/2/2016.
- */
 public class SimpleFederatorSupport extends FederatorSupport {
     private Federation federation;
     private Block[] headers;
     private int sendReceiveHeadersInvocations = 0;
     private final List<TransactionSentToRegisterBtcTransaction> txsSentToRegisterBtcTransaction = new ArrayList<>();
     private int height = 0;
-    private Object[] locator;
     private Sha256Hash[] blockHashes;
-    private Long bestChainHeight = 1L;
     private int initialChainHeight = 0;
 
     public SimpleFederatorSupport() {
@@ -64,15 +57,6 @@ public class SimpleFederatorSupport extends FederatorSupport {
 
     public void setBlockHashes(Sha256Hash[] hashes) {
         blockHashes = hashes;
-    }
-
-    @Override
-    public Object[] getBtcBlockchainBlockLocator() {
-        return this.locator;
-    }
-
-    public void setBtcBlockchainBlockLocator(Object[] locator) {
-        this.locator = locator;
     }
 
     @Override
@@ -179,11 +163,7 @@ public class SimpleFederatorSupport extends FederatorSupport {
 
     @Override
     public Long getRskBestChainHeight() {
-        return this.bestChainHeight;
-    }
-
-    public void setRskBestChainHeight(Long height) {
-        this.bestChainHeight = height;
+        return 1L;
     }
 
     public List<TransactionSentToRegisterBtcTransaction> getTxsSentToRegisterBtcTransaction() {


### PR DESCRIPTION
This pull request primarily refactors and improves the logging, readability, and maintainability of the `BtcToRskClient` and `FederatorSupport` classes. The changes focus on enhancing debug messages, consistently formatting method calls, and removing unused or redundant code. No core logic is altered, but the codebase is now easier to follow and debug.

### Logging Improvements

* Enhanced debug logging throughout `BtcToRskClient` and `FederatorSupport` to provide more context (such as including both `txId` and `wtxid` in transaction logs) and to standardize log message formats for easier tracing. [[1]](diffhunk://#diff-66d9da7d6fb52a1b0467b1e5f6ea16676b5932449ddb9888a103905cac4fd661L736-R732) [[2]](diffhunk://#diff-66d9da7d6fb52a1b0467b1e5f6ea16676b5932449ddb9888a103905cac4fd661L765-R775) [[3]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L71-R188) [[4]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L151-R226)

### Code Quality and Readability

* Refactored multi-argument method calls to use one argument per line, improving readability and maintainability. [[1]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L71-R188) [[2]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L151-R226) [[3]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L197-R259) [[4]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L212-R278) [[5]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99R289-R302) [[6]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99R316-R332) [[7]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L281-R355) [[8]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L298-R366)
* Removed unused imports and outdated Javadoc comments from both classes. [[1]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L4-R20) [[2]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L23-L35) [[3]](diffhunk://#diff-66d9da7d6fb52a1b0467b1e5f6ea16676b5932449ddb9888a103905cac4fd661L58-L61)

### Code Simplification

* Removed unused or redundant methods, such as `getBtcBlockchainBlockLocator`, `getFederatorPublicKey`, and `getRetiringFederatorPublicKey`, streamlining the API surface. [[1]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L71-R188) [[2]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L181-R245) [[3]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99R289-R302)

### Consistency

* Standardized how calls to `bridgeTransactionSender` are performed, ensuring consistent usage and argument formatting across the class. [[1]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L71-R188) [[2]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L151-R226) [[3]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L197-R259) [[4]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L212-R278) [[5]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99R289-R302) [[6]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99R316-R332) [[7]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L281-R355) [[8]](diffhunk://#diff-bcb1f64ee999bc68783ddc9443e31f95e420a79441dd27746bfbc28c0cc00a99L298-R366)

These changes collectively make the codebase more maintainable and easier to debug, without affecting core functionality.