### PR TITLE
Add connection timeout config and enhance logging for Bitcoin peers

### DIFF
--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -417,7 +417,7 @@ public class FedNodeRunner implements NodeRunner {
             kit
         );
         wrapper.setup(federatorSupport.getBitcoinPeerAddresses());
-        wrapper.start(config.getBitcoinWrapperStartupTimeout());
+        wrapper.start(config.getBitcoinWrapperStartupCheckInterval());
 
         return wrapper;
     }

--- a/src/main/java/co/rsk/federate/FedNodeRunner.java
+++ b/src/main/java/co/rsk/federate/FedNodeRunner.java
@@ -417,7 +417,7 @@ public class FedNodeRunner implements NodeRunner {
             kit
         );
         wrapper.setup(federatorSupport.getBitcoinPeerAddresses());
-        wrapper.start();
+        wrapper.start(config.getBitcoinWrapperStartupTimeout());
 
         return wrapper;
     }

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapper.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapper.java
@@ -1,18 +1,21 @@
 package co.rsk.federate.bitcoin;
 
 import co.rsk.peg.federation.Federation;
-import org.bitcoinj.core.*;
-import org.bitcoinj.core.listeners.NewBestBlockListener;
-import org.bitcoinj.store.BlockStoreException;
-
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.bitcoinj.core.PeerAddress;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.listeners.NewBestBlockListener;
+import org.bitcoinj.store.BlockStoreException;
 
 public interface BitcoinWrapper {
     void setup(List<PeerAddress> peerAddresses);
 
-    void start();
+    void start(Duration timeout);
 
     void stop();
 

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapper.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapper.java
@@ -15,7 +15,7 @@ import org.bitcoinj.store.BlockStoreException;
 public interface BitcoinWrapper {
     void setup(List<PeerAddress> peerAddresses);
 
-    void start(Duration timeout);
+    void start(Duration progressCheckInterval);
 
     void stop();
 

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -109,7 +109,7 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
             try {
                 service.awaitRunning(timeoutMinutes, TimeUnit.MINUTES);
             } catch (TimeoutException e) {
-                logger.warn("[start] BitcoinWrapper not yet running after {} minutes", timeoutMinutes, e);
+                logger.warn("[start] BitcoinWrapper not yet running after {} minutes. {}", timeoutMinutes, e.getMessage());
                 // If no peers after the timeout value, then probably the peer address is wrong or the network is not reachable
                 checkPeers();
                 checkChainHeight();

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -102,12 +102,11 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
         Context.propagate(btcContext);
 
         long timeoutMinutes = timeout.toMinutes();
-
         logger.info("[start] Starting BitcoinWrapper. Will check progress every {} minutes.", timeoutMinutes);
         com.google.common.util.concurrent.Service service = kit.startAsync();
         while (!service.isRunning()) {
             try {
-                service.awaitRunning(timeoutMinutes, TimeUnit.MINUTES);
+                service.awaitRunning(timeout.toMillis(), TimeUnit.MILLISECONDS); // Passing as milliseconds so it can be tested with < 1 minute values
             } catch (TimeoutException e) {
                 logger.warn("[start] BitcoinWrapper not yet running after {} minutes. {}", timeoutMinutes, e.getMessage());
                 // If no peers after the timeout value, then probably the peer address is wrong or the network is not reachable

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -103,36 +103,42 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
     public void start(Duration progressCheckInterval) {
         Context.propagate(btcContext);
 
-        long progressCheckIntervalMillis = progressCheckInterval.toMillis();
-        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} milliseconds.", progressCheckIntervalMillis);
+        long progressCheckIntervalMinutes = progressCheckInterval.toMinutes();
+        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} minutes.", progressCheckIntervalMinutes);
         Service service = kit.startAsync();
         while (!service.isRunning()) {
             try {
-                service.awaitRunning(progressCheckIntervalMillis, TimeUnit.MILLISECONDS); // Passing as milliseconds, so it can be tested with < 1 minute values
+                service.awaitRunning(progressCheckInterval.toMillis(), TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
-                logger.warn("[start] BitcoinWrapper not yet running after {} milliseconds. {}", progressCheckIntervalMillis, e.getMessage());
-                checkConnection();
+                logger.warn("[start] BitcoinWrapper not yet running after {} minutes. {}", progressCheckIntervalMinutes, e.getMessage());
+                checkPeers();
             }
         }
         running = true;
         logger.info("[start] BitcoinWrapper started successfully");
+        logBestChainHeight();
     }
 
-    private void checkConnection() {
+    private void checkPeers() {
         PeerGroup peerGroup = kit.peerGroup();
         int connectedPeers = peerGroup != null ? peerGroup.numConnectedPeers() : 0;
         // If no peers after the waiting interval, then probably the peer address is wrong or the network is not reachable
         if (connectedPeers == 0) {
             String message = "No Bitcoin peers connected. Check peer address and network parameters";
-            logger.error("[checkConnection] {}", message);
+            logger.error("[checkPeers] {}", message);
             throw new IllegalStateException(message);
         }
-        logger.debug("[checkConnection] {} Bitcoin peers connected", connectedPeers);
+        logger.info("[checkPeers] {} Bitcoin peers connected", connectedPeers);
+        logBestChainHeight();
+    }
 
-        int currentChainHeight = kit.chain() != null ? kit.chain().getBestChainHeight() : -1;
-        int peerChainHeight = peerGroup.getMostCommonChainHeight();
-        logger.debug(
-            "[checkConnection] Syncing... local height: {}, peer height: {}",
+    private void logBestChainHeight() {
+        BlockChain chain = kit.chain();
+        int currentChainHeight = chain != null ? chain.getBestChainHeight() : -1;
+        PeerGroup peerGroup = kit.peerGroup();
+        int peerChainHeight = peerGroup != null ? peerGroup.getMostCommonChainHeight() : -1;
+        logger.info(
+            "[logBestChainHeight] Syncing... local height: {}, peer most common height: {}",
             currentChainHeight,
             peerChainHeight
         );

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -100,17 +100,17 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
     }
 
     @Override
-    public void start(Duration timeout) {
+    public void start(Duration progressCheckInterval) {
         Context.propagate(btcContext);
 
-        long timeoutMillis = timeout.toMillis();
-        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} milliseconds.", timeoutMillis);
+        long progressCheckIntervalMillis = progressCheckInterval.toMillis();
+        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} milliseconds.", progressCheckIntervalMillis);
         Service service = kit.startAsync();
         while (!service.isRunning()) {
             try {
-                service.awaitRunning(timeoutMillis, TimeUnit.MILLISECONDS); // Passing as milliseconds, so it can be tested with < 1 minute values
+                service.awaitRunning(progressCheckIntervalMillis, TimeUnit.MILLISECONDS); // Passing as milliseconds, so it can be tested with < 1 minute values
             } catch (TimeoutException e) {
-                logger.warn("[start] BitcoinWrapper not yet running after {} milliseconds. {}", timeoutMillis, e.getMessage());
+                logger.warn("[start] BitcoinWrapper not yet running after {} milliseconds. {}", progressCheckIntervalMillis, e.getMessage());
                 checkConnection();
             }
         }
@@ -121,7 +121,7 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
     private void checkConnection() {
         PeerGroup peerGroup = kit.peerGroup();
         int connectedPeers = peerGroup != null ? peerGroup.numConnectedPeers() : 0;
-        // If no peers after the timeout value, then probably the peer address is wrong or the network is not reachable
+        // If no peers after the waiting interval, then probably the peer address is wrong or the network is not reachable
         if (connectedPeers == 0) {
             String message = "No Bitcoin peers connected. Check peer address and network parameters";
             logger.error("[checkConnection] {}", message);

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -9,6 +9,8 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import com.google.common.util.concurrent.Service;
 import org.bitcoinj.core.*;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
@@ -101,38 +103,36 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
     public void start(Duration timeout) {
         Context.propagate(btcContext);
 
-        long timeoutMinutes = timeout.toMinutes();
-        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} minutes.", timeoutMinutes);
-        com.google.common.util.concurrent.Service service = kit.startAsync();
+        long timeoutMillis = timeout.toMillis();
+        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} milliseconds.", timeoutMillis);
+        Service service = kit.startAsync();
         while (!service.isRunning()) {
             try {
-                service.awaitRunning(timeout.toMillis(), TimeUnit.MILLISECONDS); // Passing as milliseconds so it can be tested with < 1 minute values
+                service.awaitRunning(timeoutMillis, TimeUnit.MILLISECONDS); // Passing as milliseconds, so it can be tested with < 1 minute values
             } catch (TimeoutException e) {
-                logger.warn("[start] BitcoinWrapper not yet running after {} minutes. {}", timeoutMinutes, e.getMessage());
-                // If no peers after the timeout value, then probably the peer address is wrong or the network is not reachable
-                checkPeers();
-                checkChainHeight();
+                logger.warn("[start] BitcoinWrapper not yet running after {} milliseconds. {}", timeoutMillis, e.getMessage());
+                checkConnection();
             }
         }
         running = true;
         logger.info("[start] BitcoinWrapper started successfully");
     }
 
-    private void checkPeers() {
-        int connectedPeers = kit.peerGroup() != null ? kit.peerGroup().numConnectedPeers() : 0;
-        logger.debug("[checkPeers] {} Bitcoin peers connected", connectedPeers);
+    private void checkConnection() {
+        PeerGroup peerGroup = kit.peerGroup();
+        int connectedPeers = peerGroup != null ? peerGroup.numConnectedPeers() : 0;
+        // If no peers after the timeout value, then probably the peer address is wrong or the network is not reachable
         if (connectedPeers == 0) {
             String message = "No Bitcoin peers connected. Check peer address and network parameters";
-            logger.error("[checkPeers] {}", message);
-            throw new RuntimeException(message);
+            logger.error("[checkConnection] {}", message);
+            throw new IllegalStateException(message);
         }
-    }
+        logger.debug("[checkConnection] {} Bitcoin peers connected", connectedPeers);
 
-    private void checkChainHeight() {
         int currentChainHeight = kit.chain() != null ? kit.chain().getBestChainHeight() : -1;
-        int peerChainHeight = kit.peerGroup().getMostCommonChainHeight();
+        int peerChainHeight = peerGroup.getMostCommonChainHeight();
         logger.debug(
-            "[checkChainHeight] Syncing... local height: {}, peer height: {}",
+            "[checkConnection] Syncing... local height: {}, peer height: {}",
             currentChainHeight,
             peerChainHeight
         );

--- a/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
+++ b/src/main/java/co/rsk/federate/bitcoin/BitcoinWrapperImpl.java
@@ -5,7 +5,10 @@ import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.federate.adapter.ThinConverter;
 import co.rsk.peg.*;
 import co.rsk.peg.federation.Federation;
+import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.bitcoinj.core.*;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
@@ -95,11 +98,45 @@ public class BitcoinWrapperImpl implements BitcoinWrapper {
     }
 
     @Override
-    public void start() {
+    public void start(Duration timeout) {
         Context.propagate(btcContext);
-        kit.startAsync().awaitRunning();
+
+        long timeoutMinutes = timeout.toMinutes();
+
+        logger.info("[start] Starting BitcoinWrapper. Will check progress every {} minutes.", timeoutMinutes);
+        com.google.common.util.concurrent.Service service = kit.startAsync();
+        while (!service.isRunning()) {
+            try {
+                service.awaitRunning(timeoutMinutes, TimeUnit.MINUTES);
+            } catch (TimeoutException e) {
+                logger.warn("[start] BitcoinWrapper not yet running after {} minutes", timeoutMinutes, e);
+                // If no peers after the timeout value, then probably the peer address is wrong or the network is not reachable
+                checkPeers();
+                checkChainHeight();
+            }
+        }
         running = true;
-        logger.debug("[start] BitcoinWrapper started");
+        logger.info("[start] BitcoinWrapper started successfully");
+    }
+
+    private void checkPeers() {
+        int connectedPeers = kit.peerGroup() != null ? kit.peerGroup().numConnectedPeers() : 0;
+        logger.debug("[checkPeers] {} Bitcoin peers connected", connectedPeers);
+        if (connectedPeers == 0) {
+            String message = "No Bitcoin peers connected. Check peer address and network parameters";
+            logger.error("[checkPeers] {}", message);
+            throw new RuntimeException(message);
+        }
+    }
+
+    private void checkChainHeight() {
+        int currentChainHeight = kit.chain() != null ? kit.chain().getBestChainHeight() : -1;
+        int peerChainHeight = kit.peerGroup().getMostCommonChainHeight();
+        logger.debug(
+            "[checkChainHeight] Syncing... local height: {}, peer height: {}",
+            currentChainHeight,
+            peerChainHeight
+        );
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/bitcoin/Kit.java
+++ b/src/main/java/co/rsk/federate/bitcoin/Kit.java
@@ -45,8 +45,14 @@ public class Kit extends WalletAppKit {
 
     @Override
     protected void onSetupCompleted() {
-        logger.debug("[onSetupCompleted] Setup completed");
+        logger.debug("[onSetupCompleted] Completing setup");
         Context.propagate(btcContext);
+        vPeerGroup.addConnectedEventListener((peer, peerCount) ->
+            logger.info("[onSetupCompleted] Bitcoin peer connected: {} ({} connected)", peer.getAddress(), peerCount)
+        );
+        vPeerGroup.addDisconnectedEventListener((peer, peerCount) ->
+            logger.warn("[onSetupCompleted] Bitcoin peer disconnected: {} ({} remaining)", peer.getAddress(), peerCount)
+        );
         vPeerGroup.addBlocksDownloadedEventListener(blockListener);
         if(!vWallet.isConsistent()) {
             logger.warn("[onSetupCompleted] Wallet database is in an inconsistent state, starting to reset it");
@@ -56,6 +62,7 @@ public class Kit extends WalletAppKit {
         vWallet.addCoinsSentEventListener(coinsSentListener);
         vPeerGroup.setDownloadTxDependencies(0);
         vChain.addNewBestBlockListener(newBestBlockListener);
+        logger.debug("[onSetupCompleted] Setup completed");
     }
 
     @Override

--- a/src/main/java/co/rsk/federate/config/PowpegNodeConfigParameter.java
+++ b/src/main/java/co/rsk/federate/config/PowpegNodeConfigParameter.java
@@ -22,6 +22,7 @@ public enum PowpegNodeConfigParameter {
     // periods, most likely the transaction was signed by other pegnatories.
     BTC_INIT_MAX_DEPTH("federator.pegoutStorageInitializationDepth", "6000"),
     BTC_PEER_ADDRESSES("federator.bitcoinPeerAddresses", ""),
+    BTC_WRAPPER_STARTUP_TIMEOUT("federator.bitcoinWrapperStartupTimeoutMinutes", "10"),
     // The time to live (TTL) duration for the peg-out signed cache,
     // specifies the validity period for the signed peg-outs.
     PEGOUT_CACHE_TTL("federator.pegoutSignedCacheTtlInMinutes", "30"),

--- a/src/main/java/co/rsk/federate/config/PowpegNodeConfigParameter.java
+++ b/src/main/java/co/rsk/federate/config/PowpegNodeConfigParameter.java
@@ -22,7 +22,7 @@ public enum PowpegNodeConfigParameter {
     // periods, most likely the transaction was signed by other pegnatories.
     BTC_INIT_MAX_DEPTH("federator.pegoutStorageInitializationDepth", "6000"),
     BTC_PEER_ADDRESSES("federator.bitcoinPeerAddresses", ""),
-    BTC_WRAPPER_STARTUP_TIMEOUT("federator.bitcoinWrapperStartupTimeoutMinutes", "10"),
+    BTC_WRAPPER_STARTUP_CHECK_INTERVAL("federator.bitcoinWrapperStartupCheckIntervalMinutes", "10"),
     // The time to live (TTL) duration for the peg-out signed cache,
     // specifies the validity period for the signed peg-outs.
     PEGOUT_CACHE_TTL("federator.pegoutSignedCacheTtlInMinutes", "30"),

--- a/src/main/java/co/rsk/federate/config/PowpegNodeSystemProperties.java
+++ b/src/main/java/co/rsk/federate/config/PowpegNodeSystemProperties.java
@@ -88,6 +88,13 @@ public class PowpegNodeSystemProperties extends RskSystemProperties {
             : new ArrayList<>();
     }
 
+    public Duration getBitcoinWrapperStartupTimeout() {
+        return Duration.ofMinutes(getInt(
+            BTC_WRAPPER_STARTUP_TIMEOUT.getPath(),
+            BTC_WRAPPER_STARTUP_TIMEOUT.getDefaultValue(Integer::parseInt)
+        ));
+    }
+
     public Duration getPegoutSignedCacheTtl() {
         return Duration.ofMinutes(getInt(
             PEGOUT_CACHE_TTL.getPath(),

--- a/src/main/java/co/rsk/federate/config/PowpegNodeSystemProperties.java
+++ b/src/main/java/co/rsk/federate/config/PowpegNodeSystemProperties.java
@@ -88,10 +88,10 @@ public class PowpegNodeSystemProperties extends RskSystemProperties {
             : new ArrayList<>();
     }
 
-    public Duration getBitcoinWrapperStartupTimeout() {
+    public Duration getBitcoinWrapperStartupCheckInterval() {
         return Duration.ofMinutes(getInt(
-            BTC_WRAPPER_STARTUP_TIMEOUT.getPath(),
-            BTC_WRAPPER_STARTUP_TIMEOUT.getDefaultValue(Integer::parseInt)
+            BTC_WRAPPER_STARTUP_CHECK_INTERVAL.getPath(),
+            BTC_WRAPPER_STARTUP_CHECK_INTERVAL.getDefaultValue(Integer::parseInt)
         ));
     }
 

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -33,6 +33,7 @@ import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -1718,7 +1719,7 @@ class BtcToRskClientTest {
 
             List<PeerAddress> peerAddresses = Collections.emptyList();
             bitcoinWrapper.setup(peerAddresses);
-            bitcoinWrapper.start();
+            bitcoinWrapper.start(Duration.ofMinutes(10));
         }
 
         private void setUpActiveFedClient(Federation activeFederation) throws Exception {
@@ -4534,7 +4535,6 @@ class BtcToRskClientTest {
     }
 
     private PowpegNodeSystemProperties getMockedFedNodeSystemProperties(boolean defaultBooleanConfigValue) {
-
         PowpegNodeSystemProperties config = mock(PowpegNodeSystemProperties.class);
         when(config.getAmountOfHeadersToSend()).thenReturn(100);
         when(config.isUpdateBridgeTimerEnabled()).thenReturn(defaultBooleanConfigValue);

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
@@ -1,0 +1,99 @@
+package co.rsk.federate.bitcoin;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import co.rsk.federate.adapter.ThinConverter;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.wallet.Wallet;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+class BitcoinWrapperImplStartTest {
+
+    private static final BridgeConstants BRIDGE_CONSTANTS = BridgeMainNetConstants.getInstance();
+    private static final NetworkParameters NETWORK_PARAMS =
+        ThinConverter.toOriginalInstance(BRIDGE_CONSTANTS.getBtcParamsString());
+    private static final Context BTC_CONTEXT = new Context(NETWORK_PARAMS);
+
+    @TempDir
+    private Path tempDir;
+
+    private BlockingKitStub blockingKit;
+
+    @BeforeEach
+    void setUp() {
+        File directory = tempDir.toFile();
+        blockingKit = new BlockingKitStub(BTC_CONTEXT, directory, "test", mock(Wallet.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Release the latch so blocked service threads can exit cleanly after each test.
+        blockingKit.release();
+    }
+
+    @Test
+    void start_kitStartsImmediately_completesWithoutException() {
+        // Arrange: KitStub has a no-op startUp(), so the service reaches RUNNING instantly.
+        KitStub instantKit = new KitStub(BTC_CONTEXT, tempDir.toFile(), "test-instant", mock(Wallet.class));
+        BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, instantKit);
+        wrapper.setup(Collections.emptyList());
+
+        // Act & Assert
+        assertDoesNotThrow(() -> wrapper.start(Duration.ofMillis(100)));
+    }
+
+    @Test
+    void start_noPeersAfterTimeout_throwsRuntimeException() {
+        // Arrange: kit blocks and peerGroup() returns null → checkPeers() counts 0 peers.
+        blockingKit.setMockPeerGroup(null);
+        BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, blockingKit);
+        wrapper.setup(Collections.emptyList());
+
+        // Act & Assert
+        RuntimeException ex = assertThrows(
+            RuntimeException.class,
+            () -> wrapper.start(Duration.ofMillis(100))
+        );
+        assertTrue(
+            ex.getMessage().contains("No Bitcoin peers connected"),
+            "Expected 'No Bitcoin peers connected' in message but got: " + ex.getMessage()
+        );
+    }
+
+    @Test
+    void start_peersConnectedAndSyncing_eventuallyCompletes() throws Exception {
+        // Arrange: kit blocks initially; peerGroup shows 1 connected peer.
+        PeerGroup mockPeerGroup = mock(PeerGroup.class);
+        when(mockPeerGroup.numConnectedPeers()).thenReturn(1);
+        when(mockPeerGroup.getMostCommonChainHeight()).thenReturn(800_000);
+        blockingKit.setMockPeerGroup(mockPeerGroup);
+
+        BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, blockingKit);
+        wrapper.setup(Collections.emptyList());
+
+        // Run start() on a background thread so we can release the kit mid-flight.
+        CompletableFuture<Void> startFuture = CompletableFuture.runAsync(
+            () -> wrapper.start(Duration.ofMillis(100))
+        );
+
+        // Let at least one timeout cycle fire (checkPeers passes, checkChainHeight logs),
+        // then release the kit to simulate block download completing.
+        Thread.sleep(250);
+        blockingKit.release();
+
+        // Assert: start() completes without throwing within a generous bound.
+        assertDoesNotThrow(() -> startFuture.get(5, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
@@ -29,6 +29,7 @@ class BitcoinWrapperImplStartTest {
     private static final NetworkParameters NETWORK_PARAMS =
         ThinConverter.toOriginalInstance(BRIDGE_CONSTANTS.getBtcParamsString());
     private static final Context BTC_CONTEXT = new Context(NETWORK_PARAMS);
+    private final Duration PROGRESS_CHECK_INTERVAL = Duration.ofMillis(100);
 
     @TempDir
     private Path tempDir;
@@ -55,7 +56,7 @@ class BitcoinWrapperImplStartTest {
         wrapper.setup(Collections.emptyList());
 
         // Act & Assert
-        assertDoesNotThrow(() -> wrapper.start(Duration.ofMillis(100)));
+        assertDoesNotThrow(() -> wrapper.start(PROGRESS_CHECK_INTERVAL));
     }
 
     @Test
@@ -67,8 +68,7 @@ class BitcoinWrapperImplStartTest {
         wrapper.setup(peers);
 
         // Act & Assert
-        Duration duration = Duration.ofMillis(100);
-        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> wrapper.start(duration));
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> wrapper.start(PROGRESS_CHECK_INTERVAL));
         assertTrue(
             ex.getMessage().contains("No Bitcoin peers connected"),
             "Expected 'No Bitcoin peers connected' in message but got: " + ex.getMessage()
@@ -88,9 +88,8 @@ class BitcoinWrapperImplStartTest {
 
         // Run start() on a background thread, so we can release the kit mid-flight.
         // since node has connected peers, it won't throw
-        Duration checkInterval = Duration.ofMillis(100);
         CompletableFuture<Void> startFuture = CompletableFuture.runAsync(
-            () -> wrapper.start(checkInterval)
+            () -> wrapper.start(PROGRESS_CHECK_INTERVAL)
         );
 
         // start() must still be blocked in the timeout loop while the kit is unreleased.

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
@@ -29,7 +29,7 @@ class BitcoinWrapperImplStartTest {
     private static final NetworkParameters NETWORK_PARAMS =
         ThinConverter.toOriginalInstance(BRIDGE_CONSTANTS.getBtcParamsString());
     private static final Context BTC_CONTEXT = new Context(NETWORK_PARAMS);
-    private final Duration PROGRESS_CHECK_INTERVAL = Duration.ofMillis(100);
+    private static final Duration PROGRESS_CHECK_INTERVAL = Duration.ofMillis(100);
 
     @TempDir
     private Path tempDir;
@@ -61,7 +61,7 @@ class BitcoinWrapperImplStartTest {
 
     @Test
     void start_noPeersAfterCheckInterval_throwsISE() {
-        // Arrange: kit blocks and peerGroup() returns null → checkConnection() counts 0 peers.
+        // Arrange: kit blocks and peerGroup() returns null → checkPeers() counts 0 peers.
         blockingKit.setMockPeerGroup(null);
         BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, blockingKit);
         List<PeerAddress> peers = Collections.emptyList();

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
@@ -29,12 +29,12 @@ class BitcoinWrapperImplStartTest {
     @TempDir
     private Path tempDir;
 
-    private BlockingKitStub blockingKit;
+    private KitStubLatched blockingKit;
 
     @BeforeEach
     void setUp() {
         File directory = tempDir.toFile();
-        blockingKit = new BlockingKitStub(BTC_CONTEXT, directory, "test", mock(Wallet.class));
+        blockingKit = new KitStubLatched(BTC_CONTEXT, directory, "test", mock(Wallet.class));
     }
 
     @AfterEach
@@ -55,17 +55,15 @@ class BitcoinWrapperImplStartTest {
     }
 
     @Test
-    void start_noPeersAfterTimeout_throwsRuntimeException() {
-        // Arrange: kit blocks and peerGroup() returns null → checkPeers() counts 0 peers.
+    void start_noPeersAfterTimeout_throwsISE() {
+        // Arrange: kit blocks and peerGroup() returns null → checkConnection() counts 0 peers.
         blockingKit.setMockPeerGroup(null);
         BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, blockingKit);
         wrapper.setup(Collections.emptyList());
 
         // Act & Assert
-        RuntimeException ex = assertThrows(
-            RuntimeException.class,
-            () -> wrapper.start(Duration.ofMillis(100))
-        );
+        Duration duration = Duration.ofMillis(100);
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> wrapper.start(duration));
         assertTrue(
             ex.getMessage().contains("No Bitcoin peers connected"),
             "Expected 'No Bitcoin peers connected' in message but got: " + ex.getMessage()
@@ -83,7 +81,7 @@ class BitcoinWrapperImplStartTest {
         BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, blockingKit);
         wrapper.setup(Collections.emptyList());
 
-        // Run start() on a background thread so we can release the kit mid-flight.
+        // Run start() on a background thread, so we can release the kit mid-flight.
         CompletableFuture<Void> startFuture = CompletableFuture.runAsync(
             () -> wrapper.start(Duration.ofMillis(100))
         );

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
@@ -12,6 +12,8 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerGroup;
@@ -71,7 +73,7 @@ class BitcoinWrapperImplStartTest {
     }
 
     @Test
-    void start_peersConnectedAndSyncing_eventuallyCompletes() throws Exception {
+    void start_peersConnectedAndSyncing_eventuallyCompletes() {
         // Arrange: kit blocks initially; peerGroup shows 1 connected peer.
         PeerGroup mockPeerGroup = mock(PeerGroup.class);
         when(mockPeerGroup.numConnectedPeers()).thenReturn(1);
@@ -86,12 +88,14 @@ class BitcoinWrapperImplStartTest {
             () -> wrapper.start(Duration.ofMillis(100))
         );
 
-        // Let at least one timeout cycle fire (checkPeers passes, checkChainHeight logs),
-        // then release the kit to simulate block download completing.
-        Thread.sleep(250);
+        // start() must still be blocked in the timeout loop while the kit is unreleased.
+        // This also proves the wrapper is genuinely waiting, not completing instantly.
+        assertThrows(TimeoutException.class, () -> startFuture.get(300, TimeUnit.MILLISECONDS));
+
+        // Act: service can now reach RUNNING
         blockingKit.release();
 
-        // Assert: start() completes without throwing within a generous bound.
+        // Assert
         assertDoesNotThrow(() -> startFuture.get(5, TimeUnit.SECONDS));
     }
 }

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplStartTest.java
@@ -10,12 +10,14 @@ import java.io.File;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.wallet.Wallet;
 import org.junit.jupiter.api.*;
@@ -57,11 +59,12 @@ class BitcoinWrapperImplStartTest {
     }
 
     @Test
-    void start_noPeersAfterTimeout_throwsISE() {
+    void start_noPeersAfterCheckInterval_throwsISE() {
         // Arrange: kit blocks and peerGroup() returns null → checkConnection() counts 0 peers.
         blockingKit.setMockPeerGroup(null);
         BitcoinWrapperImpl wrapper = new BitcoinWrapperImpl(BTC_CONTEXT, blockingKit);
-        wrapper.setup(Collections.emptyList());
+        List<PeerAddress> peers = Collections.emptyList();
+        wrapper.setup(peers);
 
         // Act & Assert
         Duration duration = Duration.ofMillis(100);
@@ -84,12 +87,13 @@ class BitcoinWrapperImplStartTest {
         wrapper.setup(Collections.emptyList());
 
         // Run start() on a background thread, so we can release the kit mid-flight.
+        // since node has connected peers, it won't throw
+        Duration checkInterval = Duration.ofMillis(100);
         CompletableFuture<Void> startFuture = CompletableFuture.runAsync(
-            () -> wrapper.start(Duration.ofMillis(100))
+            () -> wrapper.start(checkInterval)
         );
 
         // start() must still be blocked in the timeout loop while the kit is unreleased.
-        // This also proves the wrapper is genuinely waiting, not completing instantly.
         assertThrows(TimeoutException.class, () -> startFuture.get(300, TimeUnit.MILLISECONDS));
 
         // Act: service can now reach RUNNING

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -94,7 +95,7 @@ class BitcoinWrapperImplTest {
 
         List<PeerAddress> peerAddresses = Collections.emptyList();
         bitcoinWrapper.setup(peerAddresses);
-        bitcoinWrapper.start();
+        bitcoinWrapper.start(Duration.ofMinutes(10));
     }
 
     private void setUpActiveFedListener(Federation activeFed) throws Exception {

--- a/src/test/java/co/rsk/federate/bitcoin/BlockingKitStub.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BlockingKitStub.java
@@ -1,0 +1,55 @@
+package co.rsk.federate.bitcoin;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.wallet.Wallet;
+
+/**
+ * A KitStub variant whose startUp() blocks until released, allowing tests to
+ * trigger the timeout logic in BitcoinWrapperImpl.start().
+ */
+public class BlockingKitStub extends KitStub {
+
+    private static final int STARTUP_LATCH_TIMEOUT_SECONDS = 10;
+
+    private final CountDownLatch startLatch = new CountDownLatch(1);
+    private PeerGroup mockPeerGroup;
+    private BlockChain mockChain;
+
+    public BlockingKitStub(Context btcContext, File directory, String filePrefix, Wallet wallet) {
+        super(btcContext, directory, filePrefix, wallet);
+    }
+
+    /** Unblocks startUp() so the service can transition to RUNNING. */
+    public void release() {
+        startLatch.countDown();
+    }
+
+    public void setMockPeerGroup(PeerGroup peerGroup) {
+        this.mockPeerGroup = peerGroup;
+    }
+
+    public void setMockChain(BlockChain chain) {
+        this.mockChain = chain;
+    }
+
+    @Override
+    protected void startUp() throws InterruptedException {
+        // Bounded wait so a leaked service thread does not hang the test suite.
+        startLatch.await(STARTUP_LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public PeerGroup peerGroup() {
+        return mockPeerGroup;
+    }
+
+    @Override
+    public BlockChain chain() {
+        return mockChain;
+    }
+}

--- a/src/test/java/co/rsk/federate/bitcoin/KitStubLatched.java
+++ b/src/test/java/co/rsk/federate/bitcoin/KitStubLatched.java
@@ -12,7 +12,7 @@ import org.bitcoinj.wallet.Wallet;
  * A KitStub variant whose startUp() blocks until released, allowing tests to
  * trigger the timeout logic in BitcoinWrapperImpl.start().
  */
-public class BlockingKitStub extends KitStub {
+public class KitStubLatched extends KitStub {
 
     private static final int STARTUP_LATCH_TIMEOUT_SECONDS = 10;
 
@@ -20,7 +20,7 @@ public class BlockingKitStub extends KitStub {
     private PeerGroup mockPeerGroup;
     private BlockChain mockChain;
 
-    public BlockingKitStub(Context btcContext, File directory, String filePrefix, Wallet wallet) {
+    public KitStubLatched(Context btcContext, File directory, String filePrefix, Wallet wallet) {
         super(btcContext, directory, filePrefix, wallet);
     }
 
@@ -38,9 +38,13 @@ public class BlockingKitStub extends KitStub {
     }
 
     @Override
-    protected void startUp() throws InterruptedException {
-        // Bounded wait so a leaked service thread does not hang the test suite.
-        startLatch.await(STARTUP_LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    protected void startUp() {
+        try {
+            // Bounded wait so a leaked service thread does not hang the test suite.
+            startLatch.await(STARTUP_LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // restore interrupt status
+        }
     }
 
     @Override

--- a/src/test/java/co/rsk/federate/bitcoin/KitStubLatched.java
+++ b/src/test/java/co/rsk/federate/bitcoin/KitStubLatched.java
@@ -9,8 +9,8 @@ import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.wallet.Wallet;
 
 /**
- * A KitStub variant whose startUp() blocks until released, allowing tests to
- * trigger the timeout logic in BitcoinWrapperImpl.start().
+ * A KitStub variant whose startUp() blocks until released (or until a safety timeout elapses),
+ * allowing tests to trigger the timeout logic in BitcoinWrapperImpl.start().
  */
 public class KitStubLatched extends KitStub {
 

--- a/src/test/java/co/rsk/federate/config/PowpegNodeSystemPropertiesTest.java
+++ b/src/test/java/co/rsk/federate/config/PowpegNodeSystemPropertiesTest.java
@@ -10,17 +10,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import co.rsk.config.ConfigLoader;
+import co.rsk.federate.signing.config.SignerConfig;
 import co.rsk.federate.signing.config.SignerType;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigObject;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import co.rsk.config.ConfigLoader;
-import co.rsk.federate.signing.config.SignerConfig;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigObject;
 import org.bitcoinj.core.NetworkParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +56,10 @@ class PowpegNodeSystemPropertiesTest {
     @ParameterizedTest
     @MethodSource("updateBridgeTimerEnabledProvider")
     void isUpdateBridgeTimerEnabled_whenGivenNetworkConfigNameAndCustomConfigVariations_shouldReturnEnabled(
-            String networkConfigName, boolean hasPath, boolean customValue) {
+        String networkConfigName,
+        boolean hasPath,
+        boolean customValue
+    ) {
         when(config.getString("blockchain.config.name")).thenReturn(networkConfigName);
         when(config.hasPath(UPDATE_BRIDGE_TIMER_ENABLED.getPath())).thenReturn(hasPath);
         if (hasPath) {
@@ -155,7 +158,7 @@ class PowpegNodeSystemPropertiesTest {
     }
 
     @Test
-    void shouldUpdateBridgeBtcBlockchain_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+    void shouldUpdateBridgeBtcBlockchain_whenCustomConfigNotAvailabe_shouldReturnDefaultConfig() {
         when(config.hasPath(UPDATE_BRIDGE_BTC_BLOCKCHAIN.getPath())).thenReturn(false);
 
         assertTrue(powpegNodeSystemProperties.shouldUpdateBridgeBtcBlockchain());
@@ -172,7 +175,7 @@ class PowpegNodeSystemPropertiesTest {
 
     @Test
     void shouldUpdateBridgeBtcCoinbaseTransactions_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(UPDATE_BRIDGE_BTC_COINBASE_TRANSACTIONS.getPath())).thenReturn(false);
+        when(config.hasPath(UPDATE_BRIDGE_BTC_BLOCKCHAIN.getPath())).thenReturn(false);
 
         assertTrue(powpegNodeSystemProperties.shouldUpdateBridgeBtcCoinbaseTransactions());
     }
@@ -188,7 +191,7 @@ class PowpegNodeSystemPropertiesTest {
 
     @Test
     void shouldUpdateBridgeBtcTransactions_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(UPDATE_BRIDGE_BTC_TRANSACTIONS.getPath())).thenReturn(false);
+        when(config.hasPath(UPDATE_BRIDGE_BTC_BLOCKCHAIN.getPath())).thenReturn(false);
 
         assertTrue(powpegNodeSystemProperties.shouldUpdateBridgeBtcTransactions());
     }
@@ -237,7 +240,7 @@ class PowpegNodeSystemPropertiesTest {
 
     @Test
     void federatorGasPrice_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(GAS_PRICE.getPath())).thenReturn(false);
+        when(config.hasPath(GAS_PRICE.getPath())).thenReturn(true);
 
         long defaultValue = GAS_PRICE.getDefaultValue(Long::parseLong);
         assertEquals(defaultValue, powpegNodeSystemProperties.federatorGasPrice());
@@ -258,6 +261,23 @@ class PowpegNodeSystemPropertiesTest {
 
         List<String> defaultValue = new ArrayList<>();
         assertEquals(defaultValue, powpegNodeSystemProperties.bitcoinPeerAddresses());
+    }
+
+    @Test
+    void bitcoinWrapperStartTimeout_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+        int customValue = 60;
+        when(config.hasPath(BTC_WRAPPER_STARTUP_TIMEOUT.getPath())).thenReturn(true);
+        when(config.getInt(BTC_WRAPPER_STARTUP_TIMEOUT.getPath())).thenReturn(customValue);
+
+        assertEquals(Duration.ofMinutes(customValue), powpegNodeSystemProperties.getBitcoinWrapperStartupTimeout());
+    }
+
+    @Test
+    void bitcoinWrapperStartTimeout_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath(BTC_WRAPPER_STARTUP_TIMEOUT.getPath())).thenReturn(false);
+
+        int defaultValue = BTC_WRAPPER_STARTUP_TIMEOUT.getDefaultValue(Integer::parseInt);
+        assertEquals(Duration.ofMinutes(defaultValue), powpegNodeSystemProperties.getBitcoinWrapperStartupTimeout());
     }
 
     @Test
@@ -354,6 +374,7 @@ class PowpegNodeSystemPropertiesTest {
     private static Stream<Arguments> powpegNodeConfigParameterProvider() {
         return Stream.of(
             Arguments.of(SIGNERS),
-            Arguments.of(GAS_PRICE_PROVIDER));
+            Arguments.of(GAS_PRICE_PROVIDER)
+        );
     }
 }

--- a/src/test/java/co/rsk/federate/config/PowpegNodeSystemPropertiesTest.java
+++ b/src/test/java/co/rsk/federate/config/PowpegNodeSystemPropertiesTest.java
@@ -264,20 +264,20 @@ class PowpegNodeSystemPropertiesTest {
     }
 
     @Test
-    void bitcoinWrapperStartTimeout_whenCustomConfigAvailable_shouldReturnCustomConfig() {
+    void bitcoinWrapperStartupCheckInterval_whenCustomConfigAvailable_shouldReturnCustomConfig() {
         int customValue = 60;
-        when(config.hasPath(BTC_WRAPPER_STARTUP_TIMEOUT.getPath())).thenReturn(true);
-        when(config.getInt(BTC_WRAPPER_STARTUP_TIMEOUT.getPath())).thenReturn(customValue);
+        when(config.hasPath(BTC_WRAPPER_STARTUP_CHECK_INTERVAL.getPath())).thenReturn(true);
+        when(config.getInt(BTC_WRAPPER_STARTUP_CHECK_INTERVAL.getPath())).thenReturn(customValue);
 
-        assertEquals(Duration.ofMinutes(customValue), powpegNodeSystemProperties.getBitcoinWrapperStartupTimeout());
+        assertEquals(Duration.ofMinutes(customValue), powpegNodeSystemProperties.getBitcoinWrapperStartupCheckInterval());
     }
 
     @Test
-    void bitcoinWrapperStartTimeout_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(BTC_WRAPPER_STARTUP_TIMEOUT.getPath())).thenReturn(false);
+    void bitcoinWrapperStartupCheckInterval_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
+        when(config.hasPath(BTC_WRAPPER_STARTUP_CHECK_INTERVAL.getPath())).thenReturn(false);
 
-        int defaultValue = BTC_WRAPPER_STARTUP_TIMEOUT.getDefaultValue(Integer::parseInt);
-        assertEquals(Duration.ofMinutes(defaultValue), powpegNodeSystemProperties.getBitcoinWrapperStartupTimeout());
+        int defaultValue = BTC_WRAPPER_STARTUP_CHECK_INTERVAL.getDefaultValue(Integer::parseInt);
+        assertEquals(Duration.ofMinutes(defaultValue), powpegNodeSystemProperties.getBitcoinWrapperStartupCheckInterval());
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/config/PowpegNodeSystemPropertiesTest.java
+++ b/src/test/java/co/rsk/federate/config/PowpegNodeSystemPropertiesTest.java
@@ -158,7 +158,7 @@ class PowpegNodeSystemPropertiesTest {
     }
 
     @Test
-    void shouldUpdateBridgeBtcBlockchain_whenCustomConfigNotAvailabe_shouldReturnDefaultConfig() {
+    void shouldUpdateBridgeBtcBlockchain_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
         when(config.hasPath(UPDATE_BRIDGE_BTC_BLOCKCHAIN.getPath())).thenReturn(false);
 
         assertTrue(powpegNodeSystemProperties.shouldUpdateBridgeBtcBlockchain());
@@ -175,7 +175,7 @@ class PowpegNodeSystemPropertiesTest {
 
     @Test
     void shouldUpdateBridgeBtcCoinbaseTransactions_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(UPDATE_BRIDGE_BTC_BLOCKCHAIN.getPath())).thenReturn(false);
+        when(config.hasPath(UPDATE_BRIDGE_BTC_COINBASE_TRANSACTIONS.getPath())).thenReturn(false);
 
         assertTrue(powpegNodeSystemProperties.shouldUpdateBridgeBtcCoinbaseTransactions());
     }
@@ -191,7 +191,7 @@ class PowpegNodeSystemPropertiesTest {
 
     @Test
     void shouldUpdateBridgeBtcTransactions_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(UPDATE_BRIDGE_BTC_BLOCKCHAIN.getPath())).thenReturn(false);
+        when(config.hasPath(UPDATE_BRIDGE_BTC_TRANSACTIONS.getPath())).thenReturn(false);
 
         assertTrue(powpegNodeSystemProperties.shouldUpdateBridgeBtcTransactions());
     }
@@ -240,7 +240,7 @@ class PowpegNodeSystemPropertiesTest {
 
     @Test
     void federatorGasPrice_whenCustomConfigNotAvailable_shouldReturnDefaultConfig() {
-        when(config.hasPath(GAS_PRICE.getPath())).thenReturn(true);
+        when(config.hasPath(GAS_PRICE.getPath())).thenReturn(false);
 
         long defaultValue = GAS_PRICE.getDefaultValue(Long::parseLong);
         assertEquals(defaultValue, powpegNodeSystemProperties.federatorGasPrice());

--- a/src/test/java/co/rsk/federate/mock/SimpleBitcoinWrapper.java
+++ b/src/test/java/co/rsk/federate/mock/SimpleBitcoinWrapper.java
@@ -4,6 +4,7 @@ import co.rsk.federate.bitcoin.BitcoinWrapper;
 import co.rsk.federate.bitcoin.BlockListener;
 import co.rsk.federate.bitcoin.TransactionListener;
 import co.rsk.peg.federation.Federation;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,7 +27,7 @@ public class SimpleBitcoinWrapper implements BitcoinWrapper {
     public void setup(List<PeerAddress> peerAddresses) {}
 
     @Override
-    public void start() {}
+    public void start(Duration timeout) {}
 
     @Override
     public void stop() {}

--- a/src/test/java/co/rsk/federate/mock/SimpleBitcoinWrapper.java
+++ b/src/test/java/co/rsk/federate/mock/SimpleBitcoinWrapper.java
@@ -27,7 +27,7 @@ public class SimpleBitcoinWrapper implements BitcoinWrapper {
     public void setup(List<PeerAddress> peerAddresses) {}
 
     @Override
-    public void start(Duration timeout) {}
+    public void start(Duration progressCheckInterval) {}
 
     @Override
     public void stop() {}


### PR DESCRIPTION
This pull request introduces a configurable startup checking-progress interval for the Bitcoin wrapper, improving the reliability and observability of the Bitcoin node startup process. It also adds related configuration parameters and tests, and enhances logging for peer connection events. The most important changes are grouped below:

**Bitcoin Wrapper Startup Improvements:**

* The `BitcoinWrapper` interface and its implementation now require a `Duration progressCheckInterval` parameter in the `start` method, allowing the startup process to wait for a configurable period and check peer connectivity and chain sync status, throwing an error if no peers are connected after the timeout. (`BitcoinWrapper.java`, `BitcoinWrapperImpl.java`) [[1]](diffhunk://#diff-10083d456d514095433ec2c61fccafde12d8fac01082eaa9f12f5e9865bce522L4-R18) [[2]](diffhunk://#diff-480fcacf3fb8856c2b74fe2877b9b29c130db8e2b30c4349683885d0c3193a04L98-R139)
* Added `checkPeers` and `checkChainHeight` helper methods to log and validate peer connections and chain height during startup. (`BitcoinWrapperImpl.java`)

**Configuration Enhancements:**

* Introduced a new config parameter `BTC_PROGRESS_CHECK_INTERVAL` (`federator.bitcoinProgressCheckIntervalMinutes`) with a default of 10 minutes, and a corresponding getter method in `PowpegNodeSystemProperties`. (`PowpegNodeConfigParameter.java`, `PowpegNodeSystemProperties.java`) [[1]](diffhunk://#diff-f6b44913752bc61260db33ed28184df6f952a9aa75e33294ac73159c27a3bef3R25) [[2]](diffhunk://#diff-fe18777e116b30834129e7430af2d1ea40da1194e3d6163850ffbe150be383d7R91-R97)

**Logging and Observability:**

* Improved logging in `Kit.java` to provide info and warnings when peers connect or disconnect, and clarified setup completion log messages. (`Kit.java`) [[1]](diffhunk://#diff-09a37a7a5294419d9703463ff3bfb0888dedc4bccaa78e138f441bb737453975L48-R55) [[2]](diffhunk://#diff-09a37a7a5294419d9703463ff3bfb0888dedc4bccaa78e138f441bb737453975R65)

**Testing:**

* Added tests in `PowpegNodeSystemPropertiesTest.java` to verify the new config parameter behavior for both custom and default values. (`PowpegNodeSystemPropertiesTest.java`)

**Minor Test and Code Cleanups:**

* Fixed method signatures and test logic for consistency and clarity in `PowpegNodeSystemPropertiesTest.java`. [[1]](diffhunk://#diff-1e91e6929fe01d9289002e9f9f020363893f012ec698b4da4c7e12169083e2c8L59-R62) [[2]](diffhunk://#diff-1e91e6929fe01d9289002e9f9f020363893f012ec698b4da4c7e12169083e2c8L158-R161) [[3]](diffhunk://#diff-1e91e6929fe01d9289002e9f9f020363893f012ec698b4da4c7e12169083e2c8L175-R178) [[4]](diffhunk://#diff-1e91e6929fe01d9289002e9f9f020363893f012ec698b4da4c7e12169083e2c8L191-R194) [[5]](diffhunk://#diff-1e91e6929fe01d9289002e9f9f020363893f012ec698b4da4c7e12169083e2c8L240-R243) [[6]](diffhunk://#diff-1e91e6929fe01d9289002e9f9f020363893f012ec698b4da4c7e12169083e2c8L357-R378)

These changes make the Bitcoin wrapper startup process more robust and configurable, and improve diagnostics during node initialization.