### PR TITLE
Remove the creation of legacy federation in FederationProviderFromFederatorSupport

### DIFF
--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -23,7 +23,6 @@ import static co.rsk.peg.federation.FederationMember.KeyType;
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.peg.bitcoin.ScriptCreationException;
 import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.constants.FederationConstants;
 import java.time.Instant;
@@ -177,6 +176,7 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
                 expectedFederationAddress
             ));
         }
+        logger.trace("[buildFederation] Federation built successfully with address {}", federation.getAddress());
 
         return federation;
     }

--- a/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
+++ b/src/main/java/co/rsk/federate/FederationProviderFromFederatorSupport.java
@@ -164,47 +164,20 @@ public class FederationProviderFromFederatorSupport implements FederationProvide
     }
 
     private Federation buildFederation(FederationArgs federationArgs, Address expectedFederationAddress) {
-        return tryBuildingStandardMultiSigFederation(federationArgs, expectedFederationAddress)
-            .or(() -> tryBuildingP2shP2wshErpFederation(federationArgs,
-                expectedFederationAddress))
-            .orElseThrow(() ->
-                new IllegalStateException(
-                    String.format(
-                        "Cannot determine federation type for federation with address %s. Tried: standard multiSig, and P2SH-P2WSH ERP federations.",
-                        expectedFederationAddress
-                    )
-                )
-            );
-    }
+        Federation federation = FederationFactory.buildP2shP2wshErpFederation(
+            federationArgs,
+            federationConstants.getErpFedPubKeysList(),
+            federationConstants.getErpFedActivationDelay()
+        );
 
-    private Optional<Federation> tryBuildingStandardMultiSigFederation(FederationArgs federationArgs, Address expectedFederationAddress) {
-        Federation standardMultiSigFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-        if (!standardMultiSigFederation.getAddress().equals(expectedFederationAddress)) {
-            logger.debug("[tryBuildingStandardMultiSigFederation] Expected federation is not a standard multiSig one.");
-            return Optional.empty();
+        if (!federation.getAddress().equals(expectedFederationAddress)) {
+            throw new IllegalStateException(String.format(
+                "Federation address %s does not match expected address %s",
+                federation.getAddress(),
+                expectedFederationAddress
+            ));
         }
 
-        logger.debug("[tryBuildingStandardMultiSigFederation] Expected federation is a standard multiSig one.");
-        return Optional.of(standardMultiSigFederation);
-    }
-
-    private Optional<Federation> tryBuildingP2shP2wshErpFederation(FederationArgs federationArgs, Address expectedFederationAddress) {
-        ErpFederation p2shP2wshErpFederation;
-        try {
-            p2shP2wshErpFederation = FederationFactory.buildP2shP2wshErpFederation(
-                federationArgs, federationConstants.getErpFedPubKeysList(),
-                federationConstants.getErpFedActivationDelay());
-        } catch (ErpFederationCreationException | ScriptCreationException e) {
-            logger.debug("[tryBuildingP2shP2wshErpFederation] Failed to build p2sh-p2wsh erp federation.", e);
-            return Optional.empty();
-        }
-
-        if (!p2shP2wshErpFederation.getAddress().equals(expectedFederationAddress)) {
-            logger.debug("[tryBuildingP2shP2wshErpFederation] Expected federation is not a p2sh-p2wsh erp one.");
-            return Optional.empty();
-        }
-
-        logger.debug("[tryBuildingP2shP2wshErpFederation] Expected federation is a p2sh-p2wsh erp one.");
-        return Optional.of(p2shP2wshErpFederation);
+        return federation;
     }
 }

--- a/src/main/java/co/rsk/federate/PegUtils.java
+++ b/src/main/java/co/rsk/federate/PegUtils.java
@@ -1,7 +1,14 @@
 package co.rsk.federate;
 
-import co.rsk.bitcoinj.core.*;
-import co.rsk.bitcoinj.script.*;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.ScriptException;
+import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.script.RedeemScriptParser;
+import co.rsk.bitcoinj.script.RedeemScriptParserFactory;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.bitcoinj.script.ScriptChunk;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.peg.PeginInformation;
 import co.rsk.peg.bitcoin.BitcoinUtils;
@@ -9,10 +16,10 @@ import co.rsk.peg.btcLockSender.BtcLockSender;
 import co.rsk.peg.federation.ErpFederation;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 public class PegUtils {
     public static final Coin MINIMUM_PEGIN_TX_VALUE = Coin.valueOf(500_000);
@@ -38,7 +45,7 @@ public class PegUtils {
             return false;
         }
 
-        Script defaultProposedFederationP2SHScript = getFederationStandardP2SHScript(proposedFederation);
+        Script defaultProposedFederationP2SHScript = ((ErpFederation) proposedFederation).getDefaultP2SHScript();
         int proposedFedInputIndex = 0;
         int flyoverProposedFedInputIndex = 1;
 
@@ -62,7 +69,7 @@ public class PegUtils {
     }
 
     public static boolean isPegOutTx(BtcTransaction btcTx, Federation activeFederation) {
-        Script fedStandardP2SHScript = getFederationStandardP2SHScript(activeFederation);
+        Script fedStandardP2SHScript = ((ErpFederation) activeFederation).getDefaultP2SHScript();
         int inputsSize = btcTx.getInputs().size();
         for (int i = 0; i < inputsSize; i++) {
             if (isInputFromScript(fedStandardP2SHScript, btcTx, i)) {
@@ -93,14 +100,6 @@ public class PegUtils {
         Script p2shOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
         Script p2wshOutputScript = ScriptBuilder.createP2SHP2WSHOutputScript(redeemScript);
         return expectedSpendingScript.equals(p2shOutputScript) || expectedSpendingScript.equals(p2wshOutputScript);
-    }
-
-    private static Script getFederationStandardP2SHScript(Federation federation) {
-        if (!(federation instanceof ErpFederation)) {
-            return federation.getP2SHScript();
-        }
-
-        return ((ErpFederation) federation).getDefaultP2SHScript();
     }
 
     private static boolean allTxOutputsAreToFed(BtcTransaction btcTx, Federation federation) {

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -530,9 +530,6 @@ public class BtcReleaseClient {
     }
 
     private Script extractDefaultRedeemScript(Federation federation) {
-        if (federation instanceof ErpFederation erpFederation) {
-            return erpFederation.getDefaultRedeemScript();
-        }
-        return federation.getRedeemScript();
+        return ((ErpFederation) federation).getDefaultRedeemScript();
     }
 }

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -523,7 +523,7 @@ public class BtcReleaseClient {
         });
     }
 
-    protected Script extractStandardRedeemScript(Script redeemScript) {
+    private Script extractStandardRedeemScript(Script redeemScript) {
         RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
         List<ScriptChunk> defaultRedeemScriptChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
         return new ScriptBuilder().addChunks(defaultRedeemScriptChunks).build();

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -47,7 +47,6 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.internal.util.MockUtil;
 import org.spongycastle.util.encoders.Hex;
 
@@ -3436,21 +3435,6 @@ class BtcToRskClientTest {
 
             // assert
             assertTxNotSentToBridge(migrationBtcTx);
-        }
-
-        private static Stream<Arguments> activeAndNotActiveFedsArgs() {
-            final Federation activeSegwitFed = TestUtils.createP2shP2wshErpFederation(
-                MAINNET_BTC_PARAMS,
-                9
-            );
-            final Federation notActiveFed = TestUtils.createP2shP2wshErpFederation(
-                MAINNET_BTC_PARAMS,
-                20
-            );
-
-            return Stream.of(
-                Arguments.of(activeSegwitFed, notActiveFed)
-            );
         }
 
         @Test

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -1873,15 +1873,15 @@ class BtcToRskClientTest {
             return blockWithTx;
         }
 
-        // the tests will be set in this order:
-        // legacy pay-to-pub-key: p2pkh
-        // bech32 pay-to-script-pub-key: p2shP2wpkh
-        // bech32 pay-to-pub-key: p2wpkh
-        // multisig: p2sh
-        // pay-to-bech32-multisig: p2shP2wsh
-        // bech32 multisig: p2wsh
-
-        // and we will test with standard multisig and p2sh-p2wsh erp federations
+        /*
+        the tests will be set in this order:
+        * legacy pay-to-pub-key: p2pkh
+        * bech32 pay-to-script-pub-key: p2shP2wpkh
+        * bech32 pay-to-pub-key: p2wpkh
+        * multisig: p2sh
+        * pay-to-bech32-multisig: p2shP2wsh
+        * bech32 multisig: p2wsh
+         */
 
         // LEGACY PEGIN
         @Test
@@ -3553,7 +3553,6 @@ class BtcToRskClientTest {
 
         @Test
         void updateBridgeBtcTransactions_clientForBothFeds_separateStorage_shouldSendTx() throws Exception {
-            // arrange
             // arrange
             Federation retiringFed = TestUtils.createP2shP2wshErpFederation(
                 MAINNET_BTC_PARAMS,

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -47,9 +47,7 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.internal.util.MockUtil;
 import org.spongycastle.util.encoders.Hex;
 
@@ -1886,24 +1884,14 @@ class BtcToRskClientTest {
 
         // and we will test with standard multisig and p2sh-p2wsh erp federations
 
-        private static Stream<Federation> activeFedArgs() {
-            final Federation standardMultisigFederation = TestUtils.createStandardMultisigFederation(
-                MAINNET_BTC_PARAMS,
-                9
-            );
-            final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+        // LEGACY PEGIN
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2pkh_shouldBeInformed() throws Exception {
+            // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
                 MAINNET_BTC_PARAMS,
                 20
             );
-
-            return Stream.of(standardMultisigFederation, p2shP2wshErpFederation);
-        }
-
-        // LEGACY PEGIN
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2pkh_shouldBeInformed(Federation federation) throws Exception {
-            // arrange
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -1917,10 +1905,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2pkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2pkh_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -1934,10 +1925,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2wpkh_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2wpkh_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -1951,10 +1945,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wpkh_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wpkh_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -1968,10 +1965,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wpkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wpkh_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -1985,10 +1985,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2shMultiSig_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2shMultiSig_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -2002,10 +2005,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2shMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2shMultiSig_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -2019,10 +2025,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wshMultiSig_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wshMultiSig_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -2036,10 +2045,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2shP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOutputToFedBelowMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -2053,10 +2065,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_legacyPeginFromP2wshMultiSig_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_legacyPeginFromP2wshMultiSig_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -2071,10 +2086,13 @@ class BtcToRskClientTest {
         }
 
         // PEGIN V1
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2pkh_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2089,10 +2107,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2pkh_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2107,10 +2128,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2pkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2125,10 +2149,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2pkh_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2pkh_invalidPayload_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayload(peginBtcTx);
@@ -2143,10 +2170,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2161,10 +2191,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2179,10 +2212,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2197,10 +2233,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2215,10 +2254,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_invalidPayload_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayload(peginBtcTx);
@@ -2233,10 +2275,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_invalidPayload_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wpkh_invalidPayload_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
@@ -2251,10 +2296,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wpkh_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2269,10 +2317,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wpkh_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2287,10 +2338,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wpkh_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2305,10 +2359,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wpkh_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2323,10 +2380,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wpkh_invalidPayload_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_invalidPayload_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayload(peginBtcTx);
@@ -2341,10 +2401,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wpkh_invalidPayload_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wpkh_invalidPayload_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
@@ -2359,10 +2422,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2377,10 +2443,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2395,10 +2464,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2413,10 +2485,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2431,10 +2506,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_invalidPayload_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayload(peginBtcTx);
@@ -2449,10 +2527,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_invalidPayload_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shMultiSig_invalidPayload_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
@@ -2467,10 +2548,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2485,10 +2569,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2503,10 +2590,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2521,10 +2611,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2539,10 +2632,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_invalidPayload_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_invalidPayload_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayload(peginBtcTx);
@@ -2557,10 +2653,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_invalidPayload_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2shP2wshMultiSig_invalidPayload_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
@@ -2575,10 +2674,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2593,10 +2695,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2611,10 +2716,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutput(peginBtcTx);
@@ -2629,10 +2737,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputWithRefundAddress(peginBtcTx);
@@ -2647,10 +2758,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_invalidPayload_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_invalidPayload_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayload(peginBtcTx);
@@ -2665,10 +2779,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_invalidPayload_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginV1FromP2wshMultiSig_invalidPayload_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputInvalidPayloadWithRefundAddress(peginBtcTx);
@@ -2684,10 +2801,13 @@ class BtcToRskClientTest {
         }
 
         // PEGIN WITH INSTRUCTIONS - UNKNOWN PROTOCOL VERSION
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2702,10 +2822,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2720,10 +2843,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2738,10 +2864,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2pkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2756,10 +2885,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2774,10 +2906,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2792,10 +2927,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2810,10 +2948,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wpkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2828,10 +2969,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2846,10 +2990,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2864,10 +3011,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2882,10 +3032,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wpkh_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2900,10 +3053,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2918,10 +3074,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2936,10 +3095,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2954,10 +3116,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -2972,10 +3137,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -2990,10 +3158,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_withRefundAddress_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_withRefundAddress_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -3008,10 +3179,13 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -3026,10 +3200,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2shP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2shP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -3044,10 +3221,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -3062,10 +3242,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -3080,10 +3263,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersion(peginBtcTx);
@@ -3098,10 +3284,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_peginWithInstructionsFromP2wshMultiSig_unknownProtocolVersion_amountBelowMinimum_withRefundAddress_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2wshMultiSig(MAINNET_BTC_PARAMS);
             addOpReturnOutputUnknownProtocolVersionWithRefundAddress(peginBtcTx);
@@ -3116,10 +3305,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(peginBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_pegoutTx_withoutChangeToFed_shouldNotBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_pegoutTx_withoutChangeToFed_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             co.rsk.bitcoinj.core.Address userAddress = BitcoinTestUtils.createP2PKHAddress(
                 MAINNET_BTC_PARAMS,
@@ -3142,10 +3334,13 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(pegoutBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_pegoutTx_withChangeToFed_shouldBeInformed(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_pegoutTx_withChangeToFed_shouldBeInformed() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var userAddress = BitcoinTestUtils.createP2PKHAddress(
                 MAINNET_BTC_PARAMS,
@@ -3172,30 +3367,17 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(pegoutBtcTx);
         }
 
-        private static Stream<Arguments> retiringAndActiveFedsArgs() {
-            final Federation standardMultiSigFed = TestUtils.createStandardMultisigFederation(
+        @Test
+        void updateBridgeBtcTransactions_migrationTx_shouldBeInformed() throws Exception {
+            // arrange
+            Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
                 MAINNET_BTC_PARAMS,
                 9
             );
-            final Federation firstP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
-                MAINNET_BTC_PARAMS,
-                9
-            );
-            final Federation secondP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
+            Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
                 MAINNET_BTC_PARAMS,
                 20
             );
-
-            return Stream.of(
-                Arguments.of(standardMultiSigFed, firstP2shP2wshErpFed),
-                Arguments.of(firstP2shP2wshErpFed, secondP2shP2wshErpFed)
-            );
-        }
-
-        @ParameterizedTest
-        @MethodSource("retiringAndActiveFedsArgs")
-        void updateBridgeBtcTransactions_migrationTx_shouldBeInformed(Federation retiringFederation, Federation activeFederation) throws Exception {
-            // arrange
             setUpRetiringFedClient(retiringFederation);
             setUpActiveFedClient(activeFederation);
             var migrationBtcTx = createMigrationTx(MAINNET_BTC_PARAMS, retiringFederation, activeFederation);
@@ -3208,10 +3390,17 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(migrationBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("retiringAndActiveFedsArgs")
-        void updateBridgeBtcTransactions_migrationTxBelowMinimumPeginValue_shouldBeInformed(Federation retiringFederation, Federation activeFederation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_migrationTxBelowMinimumPeginValue_shouldBeInformed() throws Exception {
             // arrange
+            Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpRetiringFedClient(retiringFederation);
             setUpActiveFedClient(activeFederation);
             var migrationBtcTx = createMigrationTxBelowMinimumPeginValue(MAINNET_BTC_PARAMS, retiringFederation, activeFederation);
@@ -3224,10 +3413,17 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(migrationBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("retiringAndActiveFedsArgs")
-        void updateBridgeBtcTransactions_migrationTx_clientForRetiringFed_shouldNotBeInformed(Federation retiringFederation, Federation activeFederation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_migrationTx_clientForRetiringFed_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpRetiringFedClient(retiringFederation);
             setUpActiveFedClient(activeFederation);
 
@@ -3243,10 +3439,6 @@ class BtcToRskClientTest {
         }
 
         private static Stream<Arguments> activeAndNotActiveFedsArgs() {
-            final Federation activeStandardMultiSigFed = TestUtils.createStandardMultisigFederation(
-                MAINNET_BTC_PARAMS,
-                9
-            );
             final Federation activeSegwitFed = TestUtils.createP2shP2wshErpFederation(
                 MAINNET_BTC_PARAMS,
                 9
@@ -3257,15 +3449,21 @@ class BtcToRskClientTest {
             );
 
             return Stream.of(
-                Arguments.of(activeStandardMultiSigFed, notActiveFed),
                 Arguments.of(activeSegwitFed, notActiveFed)
             );
         }
 
-        @ParameterizedTest
-        @MethodSource("activeAndNotActiveFedsArgs")
-        void updateBridgeBtcTransactions_svpFundTx_shouldBeInformed(Federation activeFederation, Federation notActiveFederation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_svpFundTx_shouldBeInformed() throws Exception {
             // arrange
+            Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation notActiveFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpProposedFed(notActiveFederation);
             setUpActiveFedClient(activeFederation);
 
@@ -3279,10 +3477,17 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(svpFundBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeAndNotActiveFedsArgs")
-        void updateBridgeBtcTransactions_svpSpendTx_shouldBeInformed(Federation activeFederation, Federation notActiveFederation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_svpSpendTx_shouldBeInformed() throws Exception {
             // arrange
+            Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation notActiveFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpProposedFed(notActiveFederation);
             setUpActiveFedClient(activeFederation);
 
@@ -3296,10 +3501,17 @@ class BtcToRskClientTest {
             assertTxSentToBridgeByActiveFedClient(svpSpendBtcTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeAndNotActiveFedsArgs")
-        void updateBridgeBtcTransactions_svpSpendTx_clientForRetiringFed_shouldNotBeInformed(Federation notActiveFederation, Federation activeFederation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_svpSpendTx_clientForRetiringFed_shouldNotBeInformed() throws Exception {
             // arrange
+            Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation notActiveFederation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(activeFederation);
             setUpRetiringFedClient(notActiveFederation);
 
@@ -3321,10 +3533,17 @@ class BtcToRskClientTest {
          * With separate proof files per client, both federations' pending txs must remain stored
          * after both clients process the same block
          */
-        @ParameterizedTest
-        @MethodSource("retiringAndActiveFedsArgs")
-        void updateBridgeBtcTransactions_clientForBothFeds_sharedStorage_shouldNotSendTx(Federation retiringFed, Federation activeFed) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_clientForBothFeds_sharedStorage_shouldNotSendTx() throws Exception {
             // arrange
+            Federation retiringFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation activeFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             // 1. Set up clients with shared storage
             String fileCustomizer = "shared";
             btcToRskActiveFedClientFileStorage = buildClientFileStorageInfo(fileCustomizer);
@@ -3348,10 +3567,18 @@ class BtcToRskClientTest {
             assertTxNotSentToBridge(btcTx2);
         }
 
-        @ParameterizedTest
-        @MethodSource("retiringAndActiveFedsArgs")
-        void updateBridgeBtcTransactions_clientForBothFeds_separateStorage_shouldSendTx(Federation retiringFed, Federation activeFed) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_clientForBothFeds_separateStorage_shouldSendTx() throws Exception {
             // arrange
+            // arrange
+            Federation retiringFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                9
+            );
+            Federation activeFed = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             // 1. Set up clients with separate storage
             String fileCustomizerForActiveFed = "active";
             btcToRskActiveFedClientFileStorage = buildClientFileStorageInfo(fileCustomizerForActiveFed);
@@ -3454,10 +3681,13 @@ class BtcToRskClientTest {
             retiringFedClient.start(retiringFed);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_txAlreadyProcessed_shouldNotBeInformed_rightAfterBtcToRskMinimumAcceptableConfirmationsOnRsk_shouldBeRemovedFromProofsFile(Federation federation) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_txAlreadyProcessed_shouldNotBeInformed_rightAfterBtcToRskMinimumAcceptableConfirmationsOnRsk_shouldBeRemovedFromProofsFile() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
@@ -3565,12 +3795,13 @@ class BtcToRskClientTest {
             assertWTxIdIsNotInProofsFile(testnetParams, btcToRskActiveFedClientFileStorage, peginTx);
         }
 
-        @ParameterizedTest
-        @MethodSource("activeFedArgs")
-        void updateBridgeBtcTransactions_whenOneAppearanceHashNotInBlockStore_shouldBeInformedWithBestChainProof(
-            Federation federation
-        ) throws Exception {
+        @Test
+        void updateBridgeBtcTransactions_whenOneAppearanceHashNotInBlockStore_shouldBeInformedWithBestChainProof() throws Exception {
             // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
             setUpActiveFedClient(federation);
             var peginBtcTx = createTxFromP2pkh(MAINNET_BTC_PARAMS);
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -220,14 +220,6 @@ class FederationProviderFromFederatorSupportTest {
         // Assert
         assertFalse(result.isPresent());
     }
-  
-    @Test
-    void getProposedFederationAddress_whenRSKIP419IsNotActivated_shouldReturnEmptyOptional() {
-        // Act
-        Optional<Address> result = federationProvider.getProposedFederationAddress();
-        // Assert
-        assertFalse(result.isPresent());
-    }
 
     private static ErpFederation createP2shP2wshErpFederation() {
         Integer[] privateKeys = IntStream.iterate(1000, n -> n <= 20000, n -> n + 1000)

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -229,16 +229,6 @@ class FederationProviderFromFederatorSupportTest {
         assertFalse(result.isPresent());
     }
 
-    private static Federation createStandardMultiSigFederation() {
-        Integer[] privateKeys = IntStream.iterate(1000, n -> n <= 5000, n -> n + 1000)
-            .boxed()
-            .toArray(Integer[]::new);
-        List<FederationMember> federationMembers = getFederationMembersFromPks(privateKeys);
-        FederationArgs federationArgs = new FederationArgs(federationMembers, creationTime, 0L,
-            networkParameters);
-        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
-    }
-
     private static ErpFederation createP2shP2wshErpFederation() {
         Integer[] privateKeys = IntStream.iterate(1000, n -> n <= 20000, n -> n + 1000)
             .boxed()

--- a/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
+++ b/src/test/java/co/rsk/federate/FederationProviderFromFederatorSupportTest.java
@@ -1,29 +1,37 @@
 package co.rsk.federate;
 
 import static co.rsk.peg.federation.FederationChangeResponseCode.FEDERATION_NON_EXISTENT;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.federate.bitcoin.BitcoinTestUtils;
-import co.rsk.peg.federation.*;
+import co.rsk.peg.federation.ErpFederation;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationFormatVersion;
+import co.rsk.peg.federation.FederationMember;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.federation.constants.FederationMainNetConstants;
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
 import org.ethereum.crypto.ECKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class FederationProviderFromFederatorSupportTest {
-    private static final int STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION = FederationFormatVersion.STANDARD_MULTISIG_FEDERATION.getFormatVersion();
     private static final int P2SH_P2WSH_ERP_FEDERATION_FORMAT_VERSION = FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion();
     private static final FederationConstants federationConstants = FederationMainNetConstants.getInstance();
     private static final NetworkParameters networkParameters = federationConstants.getBtcParams();
@@ -41,10 +49,10 @@ class FederationProviderFromFederatorSupportTest {
         );
     }
 
-    @ParameterizedTest
-    @MethodSource("federation_args")
-    void getActiveFederation_withTheAddressCorrespondingToItsVersion_shouldReturnTheCorrectActiveFederation(Federation expectedFederation, int expectedFormatVersion) {
+    @Test
+    void getActiveFederation_withTheAddressCorresponding_shouldReturnTheCorrectActiveFederation() {
         // arrange
+        Federation expectedFederation = createP2shP2wshErpFederation();
         setupActiveFederation(expectedFederation);
         when(federatorSupportMock.getFederationAddress()).thenReturn(expectedFederation.getAddress());
         int expectedFederationSize = expectedFederation.getSize();
@@ -52,25 +60,12 @@ class FederationProviderFromFederatorSupportTest {
         // act
         Federation obtainedFederation = federationProvider.getActiveFederation();
         // assert
-        assertEquals(expectedFormatVersion, obtainedFederation.getFormatVersion());
+        assertEquals(P2SH_P2WSH_ERP_FEDERATION_FORMAT_VERSION, obtainedFederation.getFormatVersion());
         assertEquals(expectedFederation, obtainedFederation);
 
         Address expectedFederationAddress = expectedFederation.getAddress();
         Address actualFederationAddress = obtainedFederation.getAddress();
         assertEquals(expectedFederationAddress, actualFederationAddress);
-    }
-
-    private static Stream<Arguments> federation_args() {
-        return Stream.of(
-            Arguments.of(
-                createStandardMultiSigFederation(),
-                STANDARD_MULTISIG_FEDERATION_FORMAT_VERSION
-            ),
-            Arguments.of(
-                createP2shP2wshErpFederation(),
-                P2SH_P2WSH_ERP_FEDERATION_FORMAT_VERSION
-            )
-        );
     }
 
     private void setupActiveFederation(Federation activeFederation) {
@@ -80,10 +75,10 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getBtcParams()).thenReturn(activeFederation.getBtcParams());
     }
 
-    @ParameterizedTest
-    @MethodSource("federation_args")
-    void getActiveFederation_whenFederationAddressNotMatch_shouldThrowISE(Federation federation) {
+    @Test
+    void getActiveFederation_whenFederationAddressNotMatch_shouldThrowISE() {
         // arrange
+        Federation federation = createP2shP2wshErpFederation();
         setupActiveFederation(federation);
         setupActiveFederationKeys(federation.getSize());
         // Set up an unknown address from the bridge
@@ -135,10 +130,10 @@ class FederationProviderFromFederatorSupportTest {
         when(federatorSupportMock.getBtcParams()).thenReturn(networkParameters);
     }
 
-    @ParameterizedTest
-    @MethodSource("federation_args")
-    void getRetiringFederation_withTheAddressCorrespondingToItsVersion_shouldReturnTheCorrectRetiringFederation(Federation expectedFederation, int expectedFormatVersion) {
+    @Test
+    void getRetiringFederation_withTheAddressCorresponding_shouldReturnTheCorrectRetiringFederation() {
         // Arrange
+        Federation expectedFederation = createP2shP2wshErpFederation();
         setupRetiringFederation(expectedFederation);
         setupRetiringFederationKeys(expectedFederation.getSize());
         // Act
@@ -147,7 +142,7 @@ class FederationProviderFromFederatorSupportTest {
         assertTrue(obtainedFederationOptional.isPresent());
 
         Federation obtainedFederation = obtainedFederationOptional.get();
-        assertEquals(expectedFormatVersion, obtainedFederation.getFormatVersion());
+        assertEquals(P2SH_P2WSH_ERP_FEDERATION_FORMAT_VERSION, obtainedFederation.getFormatVersion());
         assertEquals(expectedFederation, obtainedFederation);
 
         Address expectedFederationAddress = expectedFederation.getAddress();

--- a/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
+++ b/src/test/java/co/rsk/federate/bitcoin/BitcoinWrapperImplTest.java
@@ -1,44 +1,50 @@
 package co.rsk.federate.bitcoin;
 
-import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.createMigrationTx;
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.createMigrationTxBelowMinimumPeginValue;
 import static co.rsk.federate.utils.ClientProofsAssertions.assertProofsFileIsEmpty;
 import static co.rsk.federate.utils.ClientProofsAssertions.assertWTxIdIsInProofsFile;
 import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
 import static org.bitcoinj.script.ScriptOpCodes.OP_RETURN;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.federate.BtcToRskClientBuilder;
-import co.rsk.federate.config.PowpegNodeSystemProperties;
-import co.rsk.federate.io.*;
-import co.rsk.federate.signing.utils.TestUtils;
-import co.rsk.peg.constants.BridgeConstants;
-import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.adapter.ThinConverter;
-import co.rsk.peg.federation.Federation;
+import co.rsk.federate.config.PowpegNodeSystemProperties;
+import co.rsk.federate.io.BtcToRskClientDirectoryStorageInfo;
+import co.rsk.federate.io.BtcToRskClientFileStorage;
+import co.rsk.federate.io.BtcToRskClientFileStorageFactory;
+import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import co.rsk.peg.federation.Federation;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Stream;
-
-import org.bitcoinj.core.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.PeerAddress;
+import org.bitcoinj.core.Transaction;
 import org.bitcoinj.wallet.Wallet;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.HashUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.spongycastle.util.encoders.Hex;
 
 class BitcoinWrapperImplTest {
@@ -121,23 +127,13 @@ class BitcoinWrapperImplTest {
         bitcoinWrapper.addFederationListener(federationToListen, listener);
     }
 
-    private static Stream<Federation> fedArgs() {
-        final Federation standardMultisigFederation = TestUtils.createStandardMultisigFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation p2shP2wshErpFederation = TestUtils.createP2shP2wshErpFederation(
+    @Test
+    void coinsReceivedOrSent_validLegacyPegIn_shouldListenTx() throws Exception {
+        // arrange
+        Federation federation = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             20
         );
-
-        return Stream.of(standardMultisigFederation, p2shP2wshErpFederation);
-    }
-
-    @ParameterizedTest
-    @MethodSource("fedArgs")
-    void coinsReceivedOrSent_validLegacyPegIn_shouldListenTx(Federation federation) throws Exception {
-        // arrange
         setUpActiveFedListener(federation);
         Transaction pegin = createLegacyPegIn(federation);
 
@@ -148,10 +144,13 @@ class BitcoinWrapperImplTest {
         assertWTxIdIsInActiveFedClientProofsFile(pegin);
     }
 
-    @ParameterizedTest
-    @MethodSource("fedArgs")
-    void coinsReceivedOrSent_validPeginV1_shouldListenTx(Federation federation) throws Exception {
+    @Test
+    void coinsReceivedOrSent_validPeginV1_shouldListenTx() throws Exception {
         // arrange
+        Federation federation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
         setUpActiveFedListener(federation);
         Transaction pegin = createValidPegInV1(federation.getAddress());
 
@@ -196,10 +195,13 @@ class BitcoinWrapperImplTest {
         return pegin;
     }
 
-    @ParameterizedTest
-    @MethodSource("fedArgs")
-    void coinsReceivedOrSent_validPegOutTx_shouldListenTx(Federation federation) throws Exception {
+    @Test
+    void coinsReceivedOrSent_validPegOutTx_shouldListenTx() throws Exception {
         // arrange
+        Federation federation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
         setUpActiveFedListener(federation);
         final Transaction pegout = createPegOutTx(federation);
 
@@ -244,30 +246,17 @@ class BitcoinWrapperImplTest {
         return ThinConverter.toOriginalInstance(originalNetworkParameters.getId(), pegout);
     }
 
-    private static Stream<Arguments> retiringAndActiveFedsArgs() {
-        final Federation standardMultiSigFed = TestUtils.createStandardMultisigFederation(
+    @Test
+    void coinsReceivedOrSent_migrationTx_listenerForBothFeds_shouldBeSavedJustInActiveFedProofsFile() throws Exception {
+        // arrange
+        Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             9
         );
-        final Federation firstP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
-            thinNetworkParameters,
-            9
-        );
-        final Federation secondP2shP2wshErpFed = TestUtils.createP2shP2wshErpFederation(
+        Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
             thinNetworkParameters,
             20
         );
-
-        return Stream.of(
-            Arguments.of(standardMultiSigFed, firstP2shP2wshErpFed),
-            Arguments.of(firstP2shP2wshErpFed, secondP2shP2wshErpFed)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("retiringAndActiveFedsArgs")
-    void coinsReceivedOrSent_migrationTx_listenerForBothFeds_shouldBeSavedJustInActiveFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
-        // arrange
         setUpActiveFedListener(activeFederation);
         setUpRetiringFedListener(retiringFederation);
         var migrationBtcTx = createMigrationTx(thinNetworkParameters, retiringFederation, activeFederation);
@@ -281,10 +270,17 @@ class BitcoinWrapperImplTest {
         assertProofsFileIsEmpty(originalNetworkParameters, btcToRskRetiringFedClientFileStorage);
     }
 
-    @ParameterizedTest
-    @MethodSource("retiringAndActiveFedsArgs")
-    void coinsReceivedOrSent_migrationTxBelowMinimumPeginValue_listenerForBothFeds_shouldBeSavedJustInActiveFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+    @Test
+    void coinsReceivedOrSent_migrationTxBelowMinimumPeginValue_listenerForBothFeds_shouldBeSavedJustInActiveFedProofsFile() throws Exception {
         // arrange
+        Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            9
+        );
+        Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
         setUpActiveFedListener(activeFederation);
         setUpRetiringFedListener(retiringFederation);
         var migrationBtcTx = createMigrationTxBelowMinimumPeginValue(thinNetworkParameters, retiringFederation, activeFederation);
@@ -298,10 +294,17 @@ class BitcoinWrapperImplTest {
         assertProofsFileIsEmpty(originalNetworkParameters, btcToRskRetiringFedClientFileStorage);
     }
 
-    @ParameterizedTest
-    @MethodSource("retiringAndActiveFedsArgs")
-    void coinsReceivedOrSent_peginToActiveFed_listenerForBothFeds_shouldBeSavedJustInActiveFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+    @Test
+    void coinsReceivedOrSent_peginToActiveFed_listenerForBothFeds_shouldBeSavedJustInActiveFedProofsFile() throws Exception {
         // arrange
+        Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            9
+        );
+        Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
         setUpActiveFedListener(activeFederation);
         setUpRetiringFedListener(retiringFederation);
 
@@ -316,10 +319,17 @@ class BitcoinWrapperImplTest {
         assertProofsFileIsEmpty(originalNetworkParameters, btcToRskRetiringFedClientFileStorage);
     }
 
-    @ParameterizedTest
-    @MethodSource("retiringAndActiveFedsArgs")
-    void coinsReceivedOrSent_peginToRetiringFed_listenerForBothFeds_shouldBeSavedJustInRetiringFedProofsFile(Federation retiringFederation, Federation activeFederation) throws Exception {
+    @Test
+    void coinsReceivedOrSent_peginToRetiringFed_listenerForBothFeds_shouldBeSavedJustInRetiringFedProofsFile() throws Exception {
         // arrange
+        Federation retiringFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            9
+        );
+        Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+            thinNetworkParameters,
+            20
+        );
         setUpActiveFedListener(activeFederation);
         setUpRetiringFedListener(retiringFederation);
 

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -96,9 +96,15 @@ class BtcReleaseClientTest {
     void start_whenFederationMemberNotPartOfDesiredFederation_shouldThrowException() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
-        Federation otherFederation = TestUtils.createStandardMultisigFederation(params, 2);
-        FederationMember federationMember = otherFederation.getMembers().get(1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 10);
+        Federation otherFederation = TestUtils.createP2shP2wshErpFederation(params, 11);
+
+        // Find the member that is part of otherFederation and not part of federation
+        FederationMember federationMember = otherFederation.getMembers().stream()
+            .filter(member -> !federation.isMember(member))
+            .findFirst()
+            .orElseThrow();
+
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
@@ -1695,7 +1701,7 @@ class BtcReleaseClientTest {
     void onBestBlock_whenSvpSpendTxIsNotReadyToBeSigned_shouldNotAddSignature() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, 9);
+        Federation proposedFederation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = proposedFederation.getMembers().get(0);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
@@ -1775,7 +1781,7 @@ class BtcReleaseClientTest {
     void onBestBlock_return_when_node_is_syncing() throws BtcReleaseClientException {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1816,7 +1822,7 @@ class BtcReleaseClientTest {
     void onBestBlock_return_when_pegout_is_disabled() throws BtcReleaseClientException {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(false);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1857,7 +1863,7 @@ class BtcReleaseClientTest {
     void onBlock_return_when_node_is_syncing() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1897,7 +1903,7 @@ class BtcReleaseClientTest {
     void onBlock_return_when_pegout_is_disabled() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(false);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
 
         Ethereum ethereum = mock(Ethereum.class);
@@ -1972,23 +1978,6 @@ class BtcReleaseClientTest {
     }
 
     @Test
-    void validateTxCanBeSigned_erp_fed_ok() throws Exception {
-        powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 3);
-        FederationArgs federationArgs = federation.getArgs();
-        ErpFederation nonStandardErpFederation =
-            FederationFactory.buildNonStandardErpFederation(federationArgs, erpFedKeys, 5063, mock(ActivationConfig.ForBlock.class));
-
-        // Create a tx from the Fed to a random btc address
-        BtcTransaction releaseTx = createReleaseTxAndAddInput(federation);
-
-        BtcECKey fed1Key = nonStandardErpFederation.getBtcPublicKeys().get(0);
-        ECPublicKey signerPublicKey = new ECPublicKey(fed1Key.getPubKey());
-
-        test_validateTxCanBeSigned(nonStandardErpFederation, releaseTx, signerPublicKey);
-    }
-
-    @Test
     void validateTxCanBeSigned_federatorAlreadySigned() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
@@ -2058,7 +2047,7 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_federationCantSign() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = new BtcTransaction(params);
@@ -2084,30 +2073,6 @@ class BtcReleaseClientTest {
 
         // Act
         assertThrows(FederationCantSignException.class, () -> client.validateTxCanBeSigned(releaseTx));
-    }
-
-    @Test
-    void extractStandardRedeemScript_fast_bridge_redeem_script() {
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
-
-        Keccak256 flyoverDerivationHash = createHash(1);
-        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
-            flyoverDerivationHash,
-            federation.getRedeemScript()
-        );
-
-        test_extractStandardRedeemScript(federation.getRedeemScript(), flyoverRedeemScript);
-    }
-
-    @Test
-    void extractStandardRedeemScript_erp_redeem_script() {
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
-        FederationArgs federationArgs = federation.getArgs();
-
-        ErpFederation nonStandardErpFederation =
-            FederationFactory.buildNonStandardErpFederation(federationArgs, erpFedKeys, 5063, mock(ActivationConfig.ForBlock.class));
-
-        test_extractStandardRedeemScript(federation.getRedeemScript(), nonStandardErpFederation.getRedeemScript());
     }
 
     private void test_validateTxCanBeSigned(
@@ -2138,24 +2103,6 @@ class BtcReleaseClientTest {
         client.validateTxCanBeSigned(releaseTx);
     }
 
-    private void test_extractStandardRedeemScript(
-        Script expectedRedeemScript,
-        Script redeemScriptToExtract)
-    {
-        powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        client = new BtcReleaseClient(
-            mock(Ethereum.class),
-            mock(FederatorSupport.class),
-            powpegNodeSystemProperties,
-            mock(NodeBlockProcessor.class)
-        );
-
-        assertEquals(
-            expectedRedeemScript,
-            client.extractStandardRedeemScript(redeemScriptToExtract)
-        );
-    }
-
     private BtcTransaction createReleaseTxAndAddInput(Federation federation, Script redeemScript) {
         BtcTransaction releaseTx = new BtcTransaction(params);
         TransactionInput releaseInput = TestUtils.createTransactionInput(
@@ -2167,9 +2114,5 @@ class BtcReleaseClientTest {
         releaseTx.addInput(releaseInput);
 
         return releaseTx;
-    }
-
-    private BtcTransaction createReleaseTxAndAddInput(Federation federation) {
-        return createReleaseTxAndAddInput(federation, null);
     }
 }

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -261,7 +261,7 @@ class BtcReleaseClientTest {
     void processReleases_ok() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
 
         // Create a tx from the Fed to a random btc address
@@ -284,9 +284,11 @@ class BtcReleaseClientTest {
         SigHashCalculator sigHashCalculator = new LegacySigHashCalculatorImpl();
         SignerMessageBuilder messageBuilder = new SignerMessageBuilderV1(releaseTx, sigHashCalculator);
         SignerMessageBuilderFactory signerMessageBuilderFactory = mock(SignerMessageBuilderFactory.class);
-        when(signerMessageBuilderFactory.buildFromConfig(ArgumentMatchers.anyInt(), ArgumentMatchers
-            .any(ReleaseCreationInformation.class), ArgumentMatchers.anyInt()))
-            .thenReturn(messageBuilder);
+        when(signerMessageBuilderFactory.buildFromConfig(
+            ArgumentMatchers.anyInt(),
+            ArgumentMatchers.any(ReleaseCreationInformation.class),
+            ArgumentMatchers.anyInt()
+        )).thenReturn(messageBuilder);
 
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
@@ -328,8 +330,10 @@ class BtcReleaseClientTest {
         client.processReleases(releases.entrySet());
 
         // Assert
-        Mockito.verify(signer, Mockito.times(amountOfInputs))
-            .sign(eq(BTC.getKeyId()), any(SignerMessage.class));
+        Mockito.verify(signer, Mockito.times(amountOfInputs)).sign(
+            eq(BTC.getKeyId()),
+            any(SignerMessage.class)
+        );
     }
 
     @Nested
@@ -1004,7 +1008,7 @@ class BtcReleaseClientTest {
     void having_two_pegouts_signs_only_one() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
         BtcTransaction tx1 = TestUtils.createBtcTransaction(params, federation);
         BtcTransaction tx2 = TestUtils.createBtcTransaction(params, federation);
@@ -1099,7 +1103,7 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenPegoutTxIsCached_shouldNotSignSamePegoutTxAgain() throws Exception {
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 9);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
@@ -1187,7 +1191,7 @@ class BtcReleaseClientTest {
     @Test
     void onBestBlock_whenPegoutTxIsCachedWithInvalidTimestamp_shouldSignSamePegoutTxAgain() throws Exception {
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 9);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = federation.getMembers().get(0);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
@@ -1281,7 +1285,7 @@ class BtcReleaseClientTest {
     void onBestBlock_whenOnlySvpSpendTxWaitingForSignaturesIsAvailable_shouldAddSignature() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, 9);
+        Federation proposedFederation = TestUtils.createP2shP2wshErpFederation(params, 20);
         FederationMember federationMember = proposedFederation.getMembers().get(0);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
@@ -1369,7 +1373,7 @@ class BtcReleaseClientTest {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
         List<BtcECKey> federationKeys = TestUtils.getFederationPrivateKeys(9);
-        Federation proposedFederation = TestUtils.createStandardMultisigFederation(bridgeConstants.getBtcParams(), federationKeys);
+        Federation proposedFederation = TestUtils.createP2shP2wshErpFederation(bridgeConstants.getBtcParams(), federationKeys);
         Script scriptSig = proposedFederation.getP2SHScript().createEmptyInputScript(null, proposedFederation.getRedeemScript());
 
         BtcTransaction svpSpendTx = new BtcTransaction(params);
@@ -1478,7 +1482,7 @@ class BtcReleaseClientTest {
             BtcECKey key = getBtcEcKeyFromSeed(seed);
             federationMemberKeys.add(key);
         }
-        Federation federation = TestUtils.createStandardMultisigFederation(params, federationMemberKeys);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, federationMemberKeys);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
@@ -1493,7 +1497,7 @@ class BtcReleaseClientTest {
             BtcECKey key = getBtcEcKeyFromSeed(seed);
             proposedFedMemberKeys.add(key);
         }
-        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, proposedFedMemberKeys);
+        Federation proposedFederation = TestUtils.createP2shP2wshErpFederation(params, proposedFedMemberKeys);
         int lastMemberIndex = proposedFedMembersCount - 1;
         FederationMember federatorJustPartOfProposedFederation = proposedFederation.getMembers().get(lastMemberIndex);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
@@ -1551,10 +1555,10 @@ class BtcReleaseClientTest {
         when(svpSpendTxInfo.getBlockHash()).thenReturn(svpSpendBlockHash.getBytes());
         when(receiptStore.getInMainChain(svpSpendCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(svpSpendTxInfo));
 
-        ReleaseCreationInformationGetter releaseCreationInformationGetter =
-            new ReleaseCreationInformationGetter(
-                receiptStore, blockStore
-            );
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
+            receiptStore,
+            blockStore
+        );
 
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
             ethereum,
@@ -1590,7 +1594,7 @@ class BtcReleaseClientTest {
         List<BtcECKey> keys = Stream.generate(BtcECKey::new).limit(9).toList();
         BtcECKey fedKey = keys.get(0);
         FederationMember federationMember = FederationMember.getFederationMembersFromKeys(keys).get(0);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, keys);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, keys);
         BtcTransaction pegout = TestUtils.createBtcTransaction(params, federation);
         Keccak256 pegoutCreationRskTxHash = createHash(0);
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
@@ -1599,7 +1603,7 @@ class BtcReleaseClientTest {
 
         List<BtcECKey> proposedKeys = Stream.generate(BtcECKey::new).limit(8).collect(Collectors.toList());
         proposedKeys.add(fedKey);
-        Federation proposedFederation = TestUtils.createStandardMultisigFederation(params, proposedKeys);
+        Federation proposedFederation = TestUtils.createP2shP2wshErpFederation(params, proposedKeys);
         BtcTransaction svpSpendTx = TestUtils.createBtcTransaction(params, proposedFederation);
         Keccak256 svpSpendCreationRskTxHash = createHash(1);
         Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
@@ -1932,7 +1936,7 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_ok() throws Exception {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx = new BtcTransaction(params);
@@ -1949,12 +1953,10 @@ class BtcReleaseClientTest {
     void validateTxCanBeSigned_fast_bridge_ok() throws Exception {
         // Create a StandardMultisigFederation
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createStandardMultisigFederation(params, 1);
+        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
 
         // Create fast bridge redeem script
-
         Keccak256 flyoverDerivationHash = createHash(1);
-
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             federation.getRedeemScript()

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderV1Test.java
@@ -26,7 +26,10 @@ class SignerMessageBuilderV1Test {
     void createHSMVersion1Message() {
         NetworkParameters params = RegTestParams.get();
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        final Federation activeFederation = TestUtils.createStandardMultisigFederation(bridgeMainNetConstants.getBtcParams(), 9);
+        final Federation activeFederation = TestUtils.createP2shP2wshErpFederation(
+            bridgeMainNetConstants.getBtcParams(),
+            20
+        );
 
         // Create a tx from the Fed to a random btc address
         BtcTransaction releaseTx1 = new BtcTransaction(params);

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -42,6 +42,7 @@ public final class TestUtils {
         "02370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80"
     ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
     private static final long ERP_FED_ACTIVATION_DELAY = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
+    private static final Instant FED_CREATION_TIME = Instant.ofEpochSecond(1781877536);
 
     private TestUtils() {
     }
@@ -114,7 +115,7 @@ public final class TestUtils {
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPrivatekeys);
         FederationArgs federationArgs = new FederationArgs(
             federationMembers,
-            Instant.now(),
+            FED_CREATION_TIME,
             CREATION_BLOCK_NUMBER,
             params
         );
@@ -134,18 +135,35 @@ public final class TestUtils {
 
     public static Federation createP2shP2wshErpFederation(NetworkParameters params, List<BtcECKey> keys) {
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, params);
-        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, ERP_FED_PUB_KEYS_LIST,
-            ERP_FED_ACTIVATION_DELAY);
+        FederationArgs federationArgs = new FederationArgs(
+            members,
+            FED_CREATION_TIME,
+            CREATION_BLOCK_NUMBER,
+            params
+        );
+
+        return FederationFactory.buildP2shP2wshErpFederation(
+            federationArgs,
+            ERP_FED_PUB_KEYS_LIST,
+            ERP_FED_ACTIVATION_DELAY
+        );
     }
 
     public static Federation createP2shP2wshErpFederation(BridgeConstants constants, List<BtcECKey> keys) {
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(keys);
-        FederationArgs federationArgs = new FederationArgs(members, Instant.now(), CREATION_BLOCK_NUMBER, constants.getBtcParams());
+        FederationArgs federationArgs = new FederationArgs(
+            members,
+            FED_CREATION_TIME,
+            CREATION_BLOCK_NUMBER,
+            constants.getBtcParams()
+        );
 
         FederationConstants federationConstants = constants.getFederationConstants();
-        return FederationFactory.buildP2shP2wshErpFederation(federationArgs, federationConstants.getErpFedPubKeysList(),
-            federationConstants.getErpFedActivationDelay());
+        return FederationFactory.buildP2shP2wshErpFederation(
+            federationArgs,
+            federationConstants.getErpFedPubKeysList(),
+            federationConstants.getErpFedActivationDelay()
+        );
     }
 
     public static List<BtcECKey> getFederationPrivateKeys(long amountOfMembers) {


### PR DESCRIPTION
This pull request simplifies federation handling by removing support for standard multisig federations, ensuring only P2SH-P2WSH ERP federations are considered. The code and test suite are updated accordingly to reflect this change.

**Federation logic simplification:**

* [`FederationProviderFromFederatorSupport.java`](diffhunk://#diff-61f6f27493e2a3120aa314b7fa243a9ede58b289f091e0d14a4bf5d4a98e56faL167-R181): Refactored `buildFederation` to only attempt building a P2SH-P2WSH ERP federation, removing all logic and error handling related to standard multisig federations. Throws an exception if the generated address does not match the expected address.

**Test suite updates:**

* [`FederationProviderFromFederatorSupportTest.java`](diffhunk://#diff-0a92c9da6dbe7744283a2537ee999935c65037fb9f2fe4c11d3b23dd93726b59L4-L26): Removed parameterized tests and related code for standard multisig federations. Tests now only cover P2SH-P2WSH ERP federations, with assertions updated to use the correct format version. [[1]](diffhunk://#diff-0a92c9da6dbe7744283a2537ee999935c65037fb9f2fe4c11d3b23dd93726b59L4-L26) [[2]](diffhunk://#diff-0a92c9da6dbe7744283a2537ee999935c65037fb9f2fe4c11d3b23dd93726b59L44-R81) [[3]](diffhunk://#diff-0a92c9da6dbe7744283a2537ee999935c65037fb9f2fe4c11d3b23dd93726b59L138-R136) [[4]](diffhunk://#diff-0a92c9da6dbe7744283a2537ee999935c65037fb9f2fe4c11d3b23dd93726b59L150-R145)

`rskj:genesis-federation-segwit`
`rit:genesis-federation-segwit`