### PR TITLE
Update Dockerfile for reproducible builds and enhance README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS build
 
-ARG RSK_RELEASE
-ENV RSK_VERSION $RSK_RELEASE
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
@@ -13,21 +11,18 @@ USER rsk
 WORKDIR /home/rsk
 COPY --chown=rsk:rsk . ./
 
-RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
-    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
-    sha256sum --check SHA256SUMS && \
-    ./configure.sh && \
-    ./gradlew --no-daemon clean build -x test && \
-    cp "build/libs/federate-node-$RSK_VERSION-all.jar" rsk.jar
+RUN ./gradlew --no-daemon clean build -x test && \
+    mkdir -p artifacts && \
+    cp build/libs/federate-node-*.jar artifacts/
 
-    FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4
-LABEL org.opencontainers.image.authors="ops@rootstocklabs.com"
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4
 
 RUN useradd -ms /sbin/nologin -d /var/lib/rsk rsk
 USER rsk
 
 WORKDIR /var/lib/rsk
-COPY --from=build --chown=rsk:rsk /home/rsk/rsk.jar ./
+COPY --from=build --chown=rsk:rsk /home/rsk/artifacts/ ./
+RUN ln -s $(ls federate-node-*-all.jar) rsk.jar
 
 ENV DEFAULT_JVM_OPTS="-Xss4M"
 ENV RSKJ_SYS_PROPS="-Drsk.conf.file=/etc/rsk/node.conf"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ USER rsk
 WORKDIR /home/rsk
 COPY --chown=rsk:rsk . ./
 
-RUN ./gradlew --no-daemon clean build -x test && \
+RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test && \
     mkdir -p artifacts && \
     cp build/libs/federate-node-*.jar artifacts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991
     cp build/libs/federate-node-*.jar artifacts/
 
 FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4
+LABEL org.opencontainers.image.authors="ops@rootstocklabs.com"
 
 RUN useradd -ms /sbin/nologin -d /var/lib/rsk rsk
 USER rsk

--- a/README.md
+++ b/README.md
@@ -358,6 +358,29 @@ java -cp /<PATH-TO-POW-PEG-SOURCE-CODE>/build/libs/<JAR-NAME>.jar -Drsk.conf.fil
 If you want to specify a directory to save the logs, add -Dlogback.configurationFile=/<PATH-TO-LOG-DIR>/logback.xml to the command.
 
 ---
+
+## Generate reproducible build from branch
+
+To generate a reproducible build from the current branch, use the Dockerfile in the root:
+
+```bash
+$ docker build -t powpeg-node-local .
+$ cid=$(docker run -d powpeg-node-local /bin/true)
+$ docker cp "$cid":/var/lib/rsk/. ./artifacts/
+$ docker rm "$cid"
+$ cd artifacts/
+$ sha256sum * | grep -v javadoc.jar
+```
+
+This will print the sha256sum from the artifacts, for example:
+
+```
+6e6bbd7e5f37f2d114f2e9246350d7e623d921f7041dd7e7a99ab7cc51864194  federate-node-SNAPSHOT-9.1.0.0-all.jar
+ad954cc543147b40e5fef8ea319ebea2a6fa183961cbef811b480e26e1d3e1e6  federate-node-SNAPSHOT-9.1.0.0.jar
+18394152a87c4182c5893d7886e1dc80d6a319b2df5a5f9131d25a9b38dba76b  federate-node-SNAPSHOT-9.1.0.0-sources.jar
+```
+
+---
 ## Report Security Vulnerabilities
 
 We have a [vulnerability reporting guideline](SECURITY.md) for details on how to contact us to report a vulnerability.


### PR DESCRIPTION
This pull request updates the Docker build process and documentation to improve reproducibility and artifact management for the project. The main changes include restructuring how build artifacts are handled in the `Dockerfile` and adding clear instructions in the `README.md` for generating reproducible builds using Docker.

**Docker build and artifact management:**

* The `Dockerfile` now copies all JAR artifacts from the build stage into an `artifacts` directory, rather than copying a single JAR file. It also creates a symlink `rsk.jar` pointing to the `*-all.jar` file for easier reference.
* The unused `RSK_RELEASE` and `RSK_VERSION` build arguments and environment variables have been removed from the `Dockerfile` for simplification.

**Documentation improvements:**

* The `README.md` now includes a new section with step-by-step instructions for generating a reproducible build from the current branch using Docker, including how to extract and verify the build artifacts.