### PR TITLE
Improve release event log checks

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -243,9 +243,8 @@ public class BtcReleaseClient {
                 BitcoinUtils.removeSignaturesFromMultiSigTransaction(svpSpendTx);
                 logger.debug("[isSvpSpendTxReadyToSign] SVP spend tx after removing signatures [{}]", svpSpendTx.getHash());
 
-                int version = signer.getVersionForKeyId(BTC.getKeyId());
                 ReleaseCreationInformation releaseCreationInformation = releaseCreationInformationGetter.getTxInfoToSign(
-                    version, svpSpendTxEntry.getKey(), svpSpendTx);
+                    svpSpendTxEntry.getKey(), svpSpendTx);
 
                 boolean isReadyToSign = Optional.ofNullable(releaseCreationInformation)
                     .map(ReleaseCreationInformation::getPegoutCreationBlock)
@@ -286,7 +285,7 @@ public class BtcReleaseClient {
                     continue;
                 }
 
-                tryGetReleaseInformation(version, pegoutCreationRskTxHash, pegoutBtcTx)
+                tryGetReleaseInformation(pegoutCreationRskTxHash, pegoutBtcTx)
                     .ifPresent(pegoutsReadyToSign::add);
             }
             logger.debug("[processReleases] Going to sign {} pegouts", pegoutsReadyToSign.size());
@@ -315,72 +314,54 @@ public class BtcReleaseClient {
     }
 
     protected Optional<ReleaseCreationInformation> tryGetReleaseInformation(
-        int signerVersion,
         Keccak256 pegoutCreationRskTxHash,
         BtcTransaction pegoutToSign
     ) {
+        co.rsk.bitcoinj.core.Sha256Hash pegoutBtcTxHash = pegoutToSign.getHash();
+        logger.trace("[tryGetReleaseInformation] Getting release information from pegout btcTxHash {}", pegoutBtcTxHash);
+
         try {
             // Discard pegout tx if processed in a previous round of execution
-            logger.trace(
-                "[tryGetReleaseInformation] Checking if pegout {} has already been processed",
-                pegoutCreationRskTxHash
-            );
             validateTxIsNotCached(pegoutCreationRskTxHash);
-
             // Discard pegout if it cannot be signed by the observed federations
-            logger.trace(
-                "[tryGetReleaseInformation] Checking if pegout {} can be signed by observed federations",
-                pegoutCreationRskTxHash
-            );
             validateTxCanBeSigned(pegoutToSign);
 
             // IMPORTANT: As per the current behaviour of the bridge, no pegout should have inputs to be signed
             // by different federations. Taking this into account, when removing the signatures from the tx new
             // scriptSigs are created that all spend from the same federation
-
             // We need to get the release information from the original pegout (i.e. without signatures)
-            logger.trace("[tryGetReleaseInformation] Getting release information from pegout btcTxHash {}", pegoutToSign.getHash());
             BtcTransaction originalPegout = BitcoinUtils.getMultiSigTransactionWithoutSignatures(pegoutToSign);
-            co.rsk.bitcoinj.core.Sha256Hash originalPegoutHash = originalPegout.getHash();
-            logger.trace("[tryGetReleaseInformation] Pegout btc tx hash without signatures {}", originalPegoutHash);
-
-            logger.debug("[tryGetReleaseInformation] Going to lookup rsk transaction {} to get pegout to sign", pegoutCreationRskTxHash);
             ReleaseCreationInformation releaseToSignCreationInformation = releaseCreationInformationGetter.getTxInfoToSign(
-                signerVersion,
                 pegoutCreationRskTxHash,
                 originalPegout
             );
-            if (isNull(releaseToSignCreationInformation)) {
-                return Optional.empty();
-            }
 
             // Discard pegout if federator already signed it
-            logger.trace(
-                "[tryGetReleaseInformation] Validating if pegout {} is not already signed by current federator",
-                pegoutToSign.getHash()
-            );
             // we need to pass the pegout btc tx we want to sign
             // since the original one does not have any sigs,
             // so it cannot have been signed by the federator
             validateTxIsNotAlreadySigned(releaseToSignCreationInformation, pegoutToSign);
-
-            // [-- Ignore punished transactions] --> this won't be done for now but should be taken into consideration
-            // -- Get Real Block where release_requested was emitted
-            logger.trace("[tryGetReleaseInformation] Getting pegout information");
+            logger.trace(
+                "[tryGetReleaseInformation] Release information obtained successfully for rsk tx {} and pegout btc tx {}",
+                pegoutCreationRskTxHash,
+                pegoutBtcTxHash
+            );
             return Optional.of(releaseToSignCreationInformation);
-        } catch (HSMReleaseCreationInformationException | FederationCantSignException e) {
+        } catch (FederatorAlreadySignedException | FederationCantSignException | HSMReleaseCreationInformationException e) {
             String message = String.format(
                 "[tryGetReleaseInformation] There was an error trying to process pegout with btcTxHash %s",
-                pegoutToSign.getHash()
+                pegoutBtcTxHash
             );
             logger.error(message, e);
-        } catch (FederatorAlreadySignedException e) {
-            logger.info("[tryGetReleaseInformation] {}", e.getMessage());
         }
         return Optional.empty();
     }
 
     void validateTxIsNotCached(Keccak256 pegoutCreationRskTxHash) throws FederatorAlreadySignedException {
+        logger.trace(
+            "[validateTxIsNotCached] Checking if pegout {} has already been processed",
+            pegoutCreationRskTxHash
+        );
         if (pegoutSignedCache.hasAlreadyBeenSigned(pegoutCreationRskTxHash)) {
             String message = String.format(
                 "Rsk pegout creation tx hash %s was found in the pegouts signed cache",
@@ -390,6 +371,10 @@ public class BtcReleaseClient {
     }
 
     protected void validateTxCanBeSigned(BtcTransaction pegoutBtcTx) throws FederationCantSignException {
+        logger.trace(
+            "[validateTxCanBeSigned] Checking if pegout {} can be signed by observed federations",
+            pegoutBtcTx.getHash()
+        );
         for (int inputIndex = 0; inputIndex < pegoutBtcTx.getInputs().size(); inputIndex++) {
             final int index = inputIndex; // Required for lambda expression
             Script redeemScript = BitcoinUtils.extractRedeemScriptFromInput(pegoutBtcTx, inputIndex).orElseThrow(
@@ -421,6 +406,10 @@ public class BtcReleaseClient {
         ReleaseCreationInformation releaseCreationInformation,
         BtcTransaction pegoutBtcTx
     ) throws FederatorAlreadySignedException {
+        logger.trace(
+            "[validateTxIsNotAlreadySigned] Validating if pegout {} is not already signed by current federator",
+            pegoutBtcTx.getHash()
+        );
         try {
             BtcECKey federatorPublicKey = signer.getPublicKey(BTC.getKeyId()).toBtcKey();
             logger.trace("[validateTxCanBeSigned] Federator public key {}", federatorPublicKey);

--- a/src/main/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilder.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilder.java
@@ -1,14 +1,11 @@
 package co.rsk.federate.signing.hsm.message;
 
 import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.core.bc.BlockHashesHelperException;
 import co.rsk.federate.signing.SigHashCalculator;
 import co.rsk.trie.Trie;
 import java.util.List;
-import org.ethereum.core.Block;
-import org.ethereum.core.TransactionReceipt;
 import org.ethereum.db.ReceiptStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +13,7 @@ import org.slf4j.LoggerFactory;
 public class PowHSMSignerMessageBuilder extends SignerMessageBuilder {
     private static final Logger logger = LoggerFactory.getLogger(PowHSMSignerMessageBuilder.class);
     private final ReceiptStore receiptStore;
-    private final TransactionReceipt txReceipt;
-    private final Block rskBlock;
-    private final List<Coin> outpointValues;
+    private final ReleaseCreationInformation releaseCreationInformation;
 
     private List<Trie> receiptMerkleProof;
     private boolean envelopeCreated;
@@ -29,12 +24,9 @@ public class PowHSMSignerMessageBuilder extends SignerMessageBuilder {
         SigHashCalculator sigHashCalculator
     ) {
         super(releaseCreationInformation.getPegoutBtcTx(), sigHashCalculator);
-
-        this.txReceipt = releaseCreationInformation.getTransactionReceipt();
-        this.rskBlock = releaseCreationInformation.getPegoutCreationBlock();
         this.receiptStore = receiptStore;
+        this.releaseCreationInformation = releaseCreationInformation;
         this.envelopeCreated = false;
-        this.outpointValues = releaseCreationInformation.getUtxoOutpointValues();
     }
 
     private void buildMessageEnvelope() throws BlockHashesHelperException {
@@ -43,9 +35,9 @@ public class PowHSMSignerMessageBuilder extends SignerMessageBuilder {
         }
 
         receiptMerkleProof = BlockHashesHelper.calculateReceiptsTrieRootFor(
-            rskBlock,
+            releaseCreationInformation.getPegoutCreationBlock(),
             receiptStore,
-            txReceipt.getTransaction().getHash()
+            releaseCreationInformation.getPegoutCreationRskTxHash()
         );
         envelopeCreated = true;
     }
@@ -63,10 +55,10 @@ public class PowHSMSignerMessageBuilder extends SignerMessageBuilder {
         return new PowHSMSignerMessage(
             unsignedBtcTx,
             inputIndex,
-            txReceipt,
+            releaseCreationInformation.getTransactionReceipt(),
             receiptMerkleProof,
             sigHash,
-            outpointValues
+            releaseCreationInformation.getUtxoOutpointValues()
         );
     }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformation.java
@@ -3,22 +3,17 @@ package co.rsk.federate.signing.hsm.message;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.BridgeEvents;
-import co.rsk.peg.bitcoin.UtxoUtils;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.ethereum.core.Block;
-import org.ethereum.core.CallTransaction.Function;
 import org.ethereum.core.TransactionReceipt;
-import org.ethereum.vm.LogInfo;
 
 public class ReleaseCreationInformation {
-
     private final Block pegoutCreationBlock;
     private final TransactionReceipt transactionReceipt;
     private final Keccak256 pegoutCreationRskTxHash;
     private final BtcTransaction pegoutBtcTx;
+
     private final List<Coin> utxoOutpointValues;
 
     /**
@@ -31,40 +26,14 @@ public class ReleaseCreationInformation {
         Block pegoutCreationBlock,
         TransactionReceipt transactionReceipt,
         Keccak256 pegoutCreationRskTxHash,
-        BtcTransaction pegoutBtcTx
+        BtcTransaction pegoutBtcTx,
+        List<Coin> utxoOutpointsValues
     ) {
         this.pegoutCreationBlock = pegoutCreationBlock;
         this.transactionReceipt = transactionReceipt;
         this.pegoutCreationRskTxHash = pegoutCreationRskTxHash;
         this.pegoutBtcTx = pegoutBtcTx;
-
-        this.utxoOutpointValues = decodeUtxoOutpointValues();
-    }
-
-    private List<Coin> decodeUtxoOutpointValues() {
-        return transactionReceipt.getLogInfoList().stream()
-            .filter(this::isPegoutTransactionCreatedLog)
-            .findFirst()
-            .map(LogInfo::getData)
-            .map(this::decodePegoutTransactionEventData)
-            .map(UtxoUtils::decodeOutpointValues)
-            .orElse(Collections.emptyList());
-    }
-
-    private boolean isPegoutTransactionCreatedLog(LogInfo log) {
-        Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-        final byte[] pegoutTransactionCreatedSignatureTopic = pegoutTransactionCreatedEvent.encodeSignatureLong();
-
-        boolean logHasTopics = !log.getTopics().isEmpty();
-        return logHasTopics &&
-            // event signature topic is always the first one
-            Arrays.equals(log.getTopics().get(0).getData(), pegoutTransactionCreatedSignatureTopic);
-    }
-
-    private byte[] decodePegoutTransactionEventData(byte[] pegoutCreatedTransactionEventData) {
-        Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-        return (byte[]) pegoutTransactionCreatedEvent.decodeEventData(
-            pegoutCreatedTransactionEventData)[0];
+        this.utxoOutpointValues = Collections.unmodifiableList(utxoOutpointsValues);
     }
 
     public Block getPegoutCreationBlock() {
@@ -89,7 +58,5 @@ public class ReleaseCreationInformation {
         return pegoutBtcTx;
     }
 
-    public List<Coin> getUtxoOutpointValues() {
-        return Collections.unmodifiableList(utxoOutpointValues);
-    }
+    public List<Coin> getUtxoOutpointValues() { return utxoOutpointValues; }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 public class ReleaseCreationInformationGetter {
     private static final Logger logger = LoggerFactory.getLogger(ReleaseCreationInformationGetter.class);
 
-    private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
-
     private final BlockStore blockStore;
     private final ReceiptStore receiptStore;
 
@@ -35,15 +33,15 @@ public class ReleaseCreationInformationGetter {
     }
 
     public ReleaseCreationInformation getTxInfoToSign(
-        int version,
+        int signerVersion,
         Keccak256 pegoutCreationRskTxHash,
         BtcTransaction pegoutBtcTx
     ) throws HSMReleaseCreationInformationException {
         HSMVersion hsmVersion;
         try {
-            hsmVersion = HSMVersion.fromNumber(version);
+            hsmVersion = HSMVersion.fromNumber(signerVersion);
         } catch (HSMUnsupportedVersionException e) {
-            throw new HSMReleaseCreationInformationException(String.format("Unsupported version %d", version), e);
+            throw new HSMReleaseCreationInformationException(String.format("Unsupported version %d", signerVersion), e);
         }
 
         ReleaseCreationInformation baseReleaseCreationInformation = getBaseReleaseCreationInformation(pegoutCreationRskTxHash, pegoutBtcTx);
@@ -135,7 +133,7 @@ public class ReleaseCreationInformationGetter {
 
         if (transactions.size() != 1) {
             String message = String.format(
-                "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Filter size: %d",
+                "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Txs found: %d",
                 pegoutCreationRskTxHash,
                 pegoutCreationBlock.getHash().toHexString(),
                 transactions.size()
@@ -151,25 +149,37 @@ public class ReleaseCreationInformationGetter {
         BtcTransaction pegoutBtcTx,
         Keccak256 pegoutCreationRskTxHash
     ) throws HSMReleaseCreationInformationException {
+        boolean hasReleaseRequestedLogs = false;
+        boolean hasPegoutTransactionCreatedLogs = false;
 
         for (LogInfo logInfo : logs) {
-            if (isLogValid(logInfo, pegoutBtcTx, pegoutCreationRskTxHash)) {
+            if (isReleaseRequestedLog(logInfo, pegoutBtcTx, pegoutCreationRskTxHash)) {
                 logger.debug(
-                    "[validateReleaseRequestedLogsAreFound] Expected log for pegout creation rsk tx {} was found",
+                    "[validateReleaseRequestedLogsAreFound] Expected release requested log for pegout creation rsk tx {} was found",
                     pegoutCreationRskTxHash
                 );
-                return;
+                hasReleaseRequestedLogs = true;
+            }
+
+            if (isPegoutTransactionCreatedLog(logInfo, pegoutBtcTx)) {
+                logger.debug(
+                    "[validateReleaseRequestedLogsAreFound] Expected pegout transaction created log for pegout creation rsk tx {} was found",
+                    pegoutCreationRskTxHash
+                );
+                hasPegoutTransactionCreatedLogs = true;
             }
         }
 
-        // Since RSKIP375, release_requested and pegout_transaction_created events
-        // are always emitted in the same block where the pegout was created.
-        throw new HSMReleaseCreationInformationException(
-            String.format("Expected logs not found. Rsk transaction: [%s]", pegoutCreationRskTxHash)
-        );
+        if (!hasReleaseRequestedLogs || !hasPegoutTransactionCreatedLogs) {
+            // Since RSKIP375, release_requested and pegout_transaction_created events
+            // are always emitted in the same block where the pegout was created.
+            throw new HSMReleaseCreationInformationException(
+                String.format("Expected logs not found. Rsk transaction: [%s]", pegoutCreationRskTxHash)
+            );
+        }
     }
 
-    private boolean isLogValid(
+    private boolean isReleaseRequestedLog(
         LogInfo logInfo,
         BtcTransaction pegoutBtcTx,
         Keccak256 pegoutCreationRskTxHash
@@ -177,7 +187,17 @@ public class ReleaseCreationInformationGetter {
         List<DataWord> topics = logInfo.getTopics();
 
         return isLogFromBridge(logInfo) &&
-            hasExpectedTopics(topics, pegoutBtcTx, pegoutCreationRskTxHash);
+            hasReleaseRequestedExpectedTopics(topics, pegoutBtcTx, pegoutCreationRskTxHash);
+    }
+
+    private boolean isPegoutTransactionCreatedLog(
+        LogInfo logInfo,
+        BtcTransaction pegoutBtcTx
+    ) {
+        List<DataWord> topics = logInfo.getTopics();
+
+        return isLogFromBridge(logInfo) &&
+            hasPegoutTransactionCreatedExpectedTopics(topics, pegoutBtcTx);
     }
 
     private boolean isLogFromBridge(LogInfo logInfo) {
@@ -185,22 +205,21 @@ public class ReleaseCreationInformationGetter {
         return logsEmittedFrom.equals(PrecompiledContracts.BRIDGE_ADDR);
     }
 
-    private boolean hasExpectedTopics(
+    private boolean hasReleaseRequestedExpectedTopics(
         List<DataWord> topics,
         BtcTransaction pegoutBtcTx,
         Keccak256 pegoutCreationRskTxHash
     ) {
         // three topics expected (in order):
-        // release requested signature, pegout creation rsk tx hash, and pegout btc tx hash
+        // release requested event signature, pegout creation rsk tx hash, and pegout btc tx hash
 
         int expectedTopicsSize = 3;
-        boolean hasExpectedTopicsSize = topics.size() == expectedTopicsSize;
-        if (!hasExpectedTopicsSize) {
+        if (topics.size() != expectedTopicsSize) {
             return false;
         }
 
         byte[] releaseRequestedSignatureTopic = topics.get(0).getData();
-        boolean hasReleaseRequestedTopic = Arrays.equals(releaseRequestedSignatureTopic, releaseRequestedEvent.encodeSignatureLong());
+        boolean hasReleaseRequestedTopic = Arrays.equals(releaseRequestedSignatureTopic, BridgeEvents.RELEASE_REQUESTED.getEvent().encodeSignatureLong());
 
         byte[] pegoutCreationRskTxHashTopic = topics.get(1).getData();
         boolean hasPegoutCreationRskTxHashTopic = Arrays.equals(pegoutCreationRskTxHashTopic, pegoutCreationRskTxHash.getBytes());
@@ -211,5 +230,26 @@ public class ReleaseCreationInformationGetter {
         return hasReleaseRequestedTopic &&
             hasPegoutCreationRskTxHashTopic &&
             hasPegoutBtcTxHashTopic;
+    }
+
+    private boolean hasPegoutTransactionCreatedExpectedTopics(
+        List<DataWord> topics,
+        BtcTransaction pegoutBtcTx
+    ) {
+        // two topics expected (in order):
+        // pegout transaction created event signature and pegout btc tx hash
+
+        int expectedTopicsSize = 2;
+        if (topics.size() != expectedTopicsSize) {
+            return false;
+        }
+
+        byte[] pegoutTransactionCreatedSignatureTopic = topics.get(0).getData();
+        boolean hasPegoutTransactionCreatedTopic = Arrays.equals(pegoutTransactionCreatedSignatureTopic, BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent().encodeSignatureLong());
+
+        byte[] pegoutBtcTxHashTopic = topics.get(1).getData();
+        boolean hasPegoutBtcTxHashTopic = Arrays.equals(pegoutBtcTxHashTopic, pegoutBtcTx.getHash().getBytes());
+
+        return hasPegoutTransactionCreatedTopic && hasPegoutBtcTxHashTopic;
     }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -1,11 +1,11 @@
 package co.rsk.federate.signing.hsm.message;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-import co.rsk.federate.signing.hsm.HSMUnsupportedVersionException;
-import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.peg.BridgeEvents;
+import co.rsk.peg.bitcoin.UtxoUtils;
 import org.ethereum.core.*;
 import org.ethereum.db.*;
 import org.ethereum.vm.DataWord;
@@ -19,6 +19,13 @@ import java.util.List;
 import java.util.Optional;
 
 public class ReleaseCreationInformationGetter {
+
+    private record ReleaseCreationLogs(
+        LogInfo releaseRequestedEvent,
+        LogInfo pegoutTransactionCreatedEvent
+    ) {
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(ReleaseCreationInformationGetter.class);
 
     private final BlockStore blockStore;
@@ -33,150 +40,79 @@ public class ReleaseCreationInformationGetter {
     }
 
     public ReleaseCreationInformation getTxInfoToSign(
-        int signerVersion,
         Keccak256 pegoutCreationRskTxHash,
         BtcTransaction pegoutBtcTx
     ) throws HSMReleaseCreationInformationException {
-        HSMVersion hsmVersion;
-        try {
-            hsmVersion = HSMVersion.fromNumber(signerVersion);
-        } catch (HSMUnsupportedVersionException e) {
-            throw new HSMReleaseCreationInformationException(String.format("Unsupported version %d", signerVersion), e);
-        }
+        logger.debug("[getTxInfoToSign] Going to lookup rsk transaction {} to get pegout to sign", pegoutCreationRskTxHash);
 
-        ReleaseCreationInformation baseReleaseCreationInformation = getBaseReleaseCreationInformation(pegoutCreationRskTxHash, pegoutBtcTx);
-        if (!hsmVersion.isPowHSM()) {
-            return baseReleaseCreationInformation;
-        }
+        TransactionInfo pegoutCreationRskTxInfo = receiptStore
+            .getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore)
+            .orElseThrow(() -> {
+                String message = String.format(
+                    "Rsk transaction %s where the pegout was created could not be found in best chain",
+                    pegoutCreationRskTxHash
+                );
+                logger.error("[getReleaseCreationInformation] {}", message);
+                return new HSMReleaseCreationInformationException(message);
+            });
 
-        return getReleaseCreationInformationToSignWithPowHsm(baseReleaseCreationInformation);
-    }
-
-    protected ReleaseCreationInformation getBaseReleaseCreationInformation(
-        Keccak256 pegoutCreationRskTxHash,
-        BtcTransaction pegoutBtcTx
-    ) throws HSMReleaseCreationInformationException {
-        Optional<TransactionInfo> pegoutCreationRskTxInfoOpt = receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore);
-
-        if (pegoutCreationRskTxInfoOpt.isEmpty()) {
-            String message = String.format(
-                "Rsk transaction %s where the pegout was created could not be found in best chain",
-                pegoutCreationRskTxHash
-            );
-            logger.error("[getBaseReleaseCreationInformation] {}", message);
-            throw new HSMReleaseCreationInformationException(message);
-        }
-
-        TransactionInfo pegoutCreationRskTxInfo = pegoutCreationRskTxInfoOpt.get();
         TransactionReceipt pegoutCreationRskTxReceipt = pegoutCreationRskTxInfo.getReceipt();
         Block pegoutCreationRskBlock = blockStore.getBlockByHash(pegoutCreationRskTxInfo.getBlockHash());
+
+        List<LogInfo> logs = pegoutCreationRskTxReceipt.getLogInfoList();
+        ReleaseCreationLogs releaseCreationLogs = getReleaseCreationLogs(pegoutCreationRskTxHash, pegoutBtcTx, logs);
+        List<Coin> utxoOutpointsValues = getUtxoOutpointsValues(releaseCreationLogs.pegoutTransactionCreatedEvent());
 
         return new ReleaseCreationInformation(
             pegoutCreationRskBlock,
             pegoutCreationRskTxReceipt,
             pegoutCreationRskTxHash,
-            pegoutBtcTx
+            pegoutBtcTx,
+            utxoOutpointsValues
         );
     }
 
-    protected ReleaseCreationInformation getReleaseCreationInformationToSignWithPowHsm(
-        ReleaseCreationInformation baseReleaseCreationInformation
-    ) throws HSMReleaseCreationInformationException {
-        try {
-            Block pegoutCreationBlock = baseReleaseCreationInformation.getPegoutCreationBlock();
-            Keccak256 pegoutCreationRskTxHash = baseReleaseCreationInformation.getPegoutCreationRskTxHash();
-            BtcTransaction pegoutBtcTx = baseReleaseCreationInformation.getPegoutBtcTx();
-            TransactionReceipt pegoutCreationRskTxReceipt = baseReleaseCreationInformation.getTransactionReceipt();
-
-            // to be able to sign with hsm,
-            // we first need to check the release requested event related logs are found
-            validateReleaseRequestedLogsAreFound(
-                pegoutCreationRskTxReceipt.getLogInfoList(),
-                pegoutBtcTx,
-                pegoutCreationRskTxHash
-            );
-
-            // and then set the pegout creation rsk tx in the tx receipt
-            Transaction transaction = findPegoutCreationRskTxInBlock(baseReleaseCreationInformation);
-            pegoutCreationRskTxReceipt.setTransaction(transaction);
-
-            return new ReleaseCreationInformation(
-                pegoutCreationBlock,
-                pegoutCreationRskTxReceipt,
-                pegoutCreationRskTxHash,
-                pegoutBtcTx
-            );
-
-        } catch (Exception e) {
-            throw new HSMReleaseCreationInformationException("Unhandled exception occurred", e);
-        }
-    }
-
-    private Transaction findPegoutCreationRskTxInBlock(
-        ReleaseCreationInformation baseReleaseCreationInformation
-    ) throws HSMReleaseCreationInformationException {
-        Block pegoutCreationBlock = baseReleaseCreationInformation.getPegoutCreationBlock();
-        Keccak256 pegoutCreationRskTxHash = baseReleaseCreationInformation.getPegoutCreationRskTxHash();
-
-        logger.trace(
-            "[findPegoutCreationRskTxInBlock] Searching for pegout creation rsk tx {} in block {} ({})",
-            pegoutCreationRskTxHash,
-            pegoutCreationBlock.getHash(),
-            pegoutCreationBlock.getNumber()
-        );
-
-        // Get transaction from the block searching by tx hash
-        List<Transaction> transactions = pegoutCreationBlock.getTransactionsList().stream()
-            .filter(t -> t.getHash().equals(pegoutCreationRskTxHash))
-            .toList();
-        logger.trace("[findPegoutCreationRskTxInBlock] Transactions found {}", transactions.size());
-
-        if (transactions.size() != 1) {
-            String message = String.format(
-                "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Txs found: %d",
-                pegoutCreationRskTxHash,
-                pegoutCreationBlock.getHash().toHexString(),
-                transactions.size()
-            );
-            logger.error("[findPegoutCreationRskTxInBlock] {}", message);
-            throw new HSMReleaseCreationInformationException(message);
-        }
-        return transactions.get(0);
-    }
-
-    private void validateReleaseRequestedLogsAreFound(
-        List<LogInfo> logs,
+    private ReleaseCreationLogs getReleaseCreationLogs(
+        Keccak256 pegoutCreationRskTxHash,
         BtcTransaction pegoutBtcTx,
-        Keccak256 pegoutCreationRskTxHash
+        List<LogInfo> logs
     ) throws HSMReleaseCreationInformationException {
-        boolean hasReleaseRequestedLogs = false;
-        boolean hasPegoutTransactionCreatedLogs = false;
 
+        Optional<LogInfo> releaseRequestedEvent = Optional.empty();
+        Optional<LogInfo> pegoutTransactionCreatedEvent = Optional.empty();
         for (LogInfo logInfo : logs) {
             if (isReleaseRequestedLog(logInfo, pegoutBtcTx, pegoutCreationRskTxHash)) {
                 logger.debug(
-                    "[validateReleaseRequestedLogsAreFound] Expected release requested log for pegout creation rsk tx {} was found",
+                    "[getReleaseCreationInformation] Expected release requested log for pegout creation rsk tx {} was found",
                     pegoutCreationRskTxHash
                 );
-                hasReleaseRequestedLogs = true;
+                releaseRequestedEvent = Optional.of(logInfo);
             }
 
             if (isPegoutTransactionCreatedLog(logInfo, pegoutBtcTx)) {
                 logger.debug(
-                    "[validateReleaseRequestedLogsAreFound] Expected pegout transaction created log for pegout creation rsk tx {} was found",
+                    "[getReleaseCreationInformation] Expected pegout transaction created log for pegout creation rsk tx {} was found",
                     pegoutCreationRskTxHash
                 );
-                hasPegoutTransactionCreatedLogs = true;
+                pegoutTransactionCreatedEvent = Optional.of(logInfo);
             }
         }
 
-        if (!hasReleaseRequestedLogs || !hasPegoutTransactionCreatedLogs) {
+        if (releaseRequestedEvent.isEmpty() || pegoutTransactionCreatedEvent.isEmpty()) {
             // Since RSKIP375, release_requested and pegout_transaction_created events
             // are always emitted in the same block where the pegout was created.
             throw new HSMReleaseCreationInformationException(
                 String.format("Expected logs not found. Rsk transaction: [%s]", pegoutCreationRskTxHash)
             );
         }
+        return new ReleaseCreationLogs(releaseRequestedEvent.get(), pegoutTransactionCreatedEvent.get());
+    }
+
+    private List<Coin> getUtxoOutpointsValues(LogInfo logInfo) {
+        CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
+        byte[] pegoutTransactionCreatedEventData = logInfo.getData();
+        byte[] utxoOutpointsValuesEncoded = (byte[]) pegoutTransactionCreatedEvent.decodeEventData(pegoutTransactionCreatedEventData)[0];
+        return UtxoUtils.decodeOutpointValues(utxoOutpointsValuesEncoded);
     }
 
     private boolean isReleaseRequestedLog(

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -7,7 +7,9 @@ import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.peg.BridgeEvents;
 import org.ethereum.core.*;
 import org.ethereum.db.*;
+import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,9 +20,11 @@ import java.util.Optional;
 public class ReleaseCreationInformationGetter {
     private static final Logger logger = LoggerFactory.getLogger(ReleaseCreationInformationGetter.class);
 
+    private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
+    private final byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
+
     private final BlockStore blockStore;
     private final ReceiptStore receiptStore;
-    private final byte[] releaseRequestedSignatureTopic;
 
     public ReleaseCreationInformationGetter(
         ReceiptStore receiptStore,
@@ -28,9 +32,6 @@ public class ReleaseCreationInformationGetter {
     ) {
         this.blockStore = blockStore;
         this.receiptStore = receiptStore;
-
-        CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
-        releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
     }
 
     public ReleaseCreationInformation getTxInfoToSign(
@@ -92,6 +93,7 @@ public class ReleaseCreationInformationGetter {
                 .filter(t -> t.getHash().equals(pegoutCreationRskTxHash))
                 .toList();
             logger.trace("[getTxInfoToSign] Transactions found {}", transactions.size());
+
             if (transactions.size() != 1) {
                 String message = String.format(
                     "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Filter size: %d",
@@ -148,23 +150,25 @@ public class ReleaseCreationInformationGetter {
         Keccak256 pegoutCreationRskTxHash
     ) {
         boolean hasLogs = !transactionReceipt.getLogInfoList().isEmpty();
+
+        Keccak256 txHash = transactionReceipt.getTransaction().getHash();
+        Keccak256 blockHash = block.getHash();
         logger.trace(
-            "[getInformationFromEvent] Rsk Transaction ({}) in block ({} - {}). has logs? {}",
-            transactionReceipt.getTransaction().getHash(),
+            "[getInformationFromEvent] Rsk Transaction ({}) in block ({} - {}). Has logs? {}",
+            txHash,
             block.getNumber(),
-            block.getHash(),
+            blockHash,
             hasLogs
         );
+
         if (hasLogs) {
             List<LogInfo> logs = transactionReceipt.getLogInfoList();
             for (LogInfo logInfo : logs) {
-                // You should check that the event is Release and contains the hash of the transaction.
-                boolean hasReleaseRequestEvent = Arrays.equals(logInfo.getTopics().get(0).getData(), releaseRequestedSignatureTopic);
-                if (hasReleaseRequestEvent && (Arrays.equals(logInfo.getTopics().get(2).getData(), pegoutBtcTx.getHash().getBytes()))) {
+                if (isLogValid(logInfo, pegoutBtcTx, pegoutCreationRskTxHash)) {
                     logger.debug(
                         "[getInformationFromEvent] Found transaction {} and block {}",
-                        transactionReceipt.getTransaction().getHash(),
-                        block.getHash()
+                        txHash,
+                        blockHash
                     );
                     return Optional.of(
                         new ReleaseCreationInformation(
@@ -178,5 +182,44 @@ public class ReleaseCreationInformationGetter {
             }
         }
         return Optional.empty();
+    }
+
+    private boolean isLogValid(
+        LogInfo logInfo,
+        BtcTransaction pegoutBtcTx,
+        Keccak256 pegoutCreationRskTxHash
+    ) {
+        List<DataWord> topics = logInfo.getTopics();
+
+        return isLogFromBridge(logInfo) &&
+            expectedTopicsSize(topics) &&
+            expectedTopics(topics, pegoutBtcTx, pegoutCreationRskTxHash);
+    }
+
+    private boolean isLogFromBridge(LogInfo logInfo) {
+        byte[] logsEmittedFrom = logInfo.getAddress();
+        return Arrays.equals(logsEmittedFrom, PrecompiledContracts.BRIDGE_ADDR.getBytes());
+    }
+
+    private boolean expectedTopicsSize(List<DataWord> topics) {
+        int expectedTopicsSize = 3;
+        return topics.size() == expectedTopicsSize;
+    }
+
+    private boolean expectedTopics(
+        List<DataWord> topics,
+        BtcTransaction pegoutBtcTx,
+        Keccak256 pegoutCreationRskTxHash
+    ) {
+        byte[] firstTopic = topics.get(0).getData();
+        boolean hasReleaseRequestedTopic = Arrays.equals(firstTopic, releaseRequestedSignatureTopic);
+
+        byte[] secondTopic = topics.get(1).getData();
+        boolean hasPegoutCreationRskTxHashTopic = Arrays.equals(secondTopic, pegoutCreationRskTxHash.getBytes());
+
+        byte[] thirdTopic = topics.get(2).getData();
+        boolean hasPegoutBtcTxHashTopic = Arrays.equals(thirdTopic, pegoutBtcTx.getHash().getBytes());
+
+        return hasReleaseRequestedTopic && hasPegoutCreationRskTxHashTopic && hasPegoutBtcTxHashTopic;
     }
 }

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -63,7 +63,7 @@ public class ReleaseCreationInformationGetter {
                 "Rsk transaction %s where the pegout was created could not be found in best chain",
                 pegoutCreationRskTxHash
             );
-            logger.error("[getTxInfoToSign] {}", message);
+            logger.error("[getBaseReleaseCreationInformation] {}", message);
             throw new HSMReleaseCreationInformationException(message);
         }
         TransactionReceipt transactionReceipt = transactionInfo.getReceipt();
@@ -88,11 +88,11 @@ public class ReleaseCreationInformationGetter {
             TransactionReceipt transactionReceipt = baseReleaseCreationInformation.getTransactionReceipt();
 
             // Get transaction from the block, searching by tx hash, and set it in the tx receipt
-            logger.trace("[getTxInfoToSign] Searching for rsk transaction {} in block {} ({})", pegoutCreationRskTxHash, block.getHash(), block.getNumber());
+            logger.trace("[getTxInfoToSignPowHsm] Searching for rsk transaction {} in block {} ({})", pegoutCreationRskTxHash, block.getHash(), block.getNumber());
             List<Transaction> transactions = block.getTransactionsList().stream()
                 .filter(t -> t.getHash().equals(pegoutCreationRskTxHash))
                 .toList();
-            logger.trace("[getTxInfoToSign] Transactions found {}", transactions.size());
+            logger.trace("[getTxInfoToSignPowHsm] Transactions found {}", transactions.size());
 
             if (transactions.size() != 1) {
                 String message = String.format(
@@ -101,7 +101,7 @@ public class ReleaseCreationInformationGetter {
                     block.getHash().toHexString(),
                     transactions.size()
                 );
-                logger.error("[getTxInfoToSign] {}", message);
+                logger.error("[getTxInfoToSignPowHsm] {}", message);
                 throw new HSMReleaseCreationInformationException(message);
             }
             Transaction transaction = transactions.get(0);

--- a/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
+++ b/src/main/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetter.java
@@ -1,6 +1,7 @@
 package co.rsk.federate.signing.hsm.message;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.federate.signing.hsm.HSMUnsupportedVersionException;
 import co.rsk.federate.signing.hsm.HSMVersion;
@@ -21,7 +22,6 @@ public class ReleaseCreationInformationGetter {
     private static final Logger logger = LoggerFactory.getLogger(ReleaseCreationInformationGetter.class);
 
     private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
-    private final byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
 
     private final BlockStore blockStore;
     private final ReceiptStore receiptStore;
@@ -41,24 +41,26 @@ public class ReleaseCreationInformationGetter {
     ) throws HSMReleaseCreationInformationException {
         HSMVersion hsmVersion;
         try {
-             hsmVersion = HSMVersion.fromNumber(version);
+            hsmVersion = HSMVersion.fromNumber(version);
         } catch (HSMUnsupportedVersionException e) {
             throw new HSMReleaseCreationInformationException(String.format("Unsupported version %d", version), e);
         }
 
+        ReleaseCreationInformation baseReleaseCreationInformation = getBaseReleaseCreationInformation(pegoutCreationRskTxHash, pegoutBtcTx);
         if (!hsmVersion.isPowHSM()) {
-            return getBaseReleaseCreationInformation(pegoutCreationRskTxHash, pegoutBtcTx);
+            return baseReleaseCreationInformation;
         }
 
-        return getTxInfoToSignPowHsm(pegoutCreationRskTxHash, pegoutBtcTx);
+        return getReleaseCreationInformationToSignWithPowHsm(baseReleaseCreationInformation);
     }
 
     protected ReleaseCreationInformation getBaseReleaseCreationInformation(
         Keccak256 pegoutCreationRskTxHash,
         BtcTransaction pegoutBtcTx
     ) throws HSMReleaseCreationInformationException {
-        TransactionInfo transactionInfo = receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore).orElse(null);
-        if (transactionInfo == null) {
+        Optional<TransactionInfo> pegoutCreationRskTxInfoOpt = receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore);
+
+        if (pegoutCreationRskTxInfoOpt.isEmpty()) {
             String message = String.format(
                 "Rsk transaction %s where the pegout was created could not be found in best chain",
                 pegoutCreationRskTxHash
@@ -66,122 +68,105 @@ public class ReleaseCreationInformationGetter {
             logger.error("[getBaseReleaseCreationInformation] {}", message);
             throw new HSMReleaseCreationInformationException(message);
         }
-        TransactionReceipt transactionReceipt = transactionInfo.getReceipt();
-        Block block = blockStore.getBlockByHash(transactionInfo.getBlockHash());
+
+        TransactionInfo pegoutCreationRskTxInfo = pegoutCreationRskTxInfoOpt.get();
+        TransactionReceipt pegoutCreationRskTxReceipt = pegoutCreationRskTxInfo.getReceipt();
+        Block pegoutCreationRskBlock = blockStore.getBlockByHash(pegoutCreationRskTxInfo.getBlockHash());
 
         return new ReleaseCreationInformation(
-            block,
-            transactionReceipt,
+            pegoutCreationRskBlock,
+            pegoutCreationRskTxReceipt,
             pegoutCreationRskTxHash,
             pegoutBtcTx
         );
     }
 
-    protected ReleaseCreationInformation getTxInfoToSignPowHsm(
-        Keccak256 pegoutCreationRskTxHash,
-        BtcTransaction pegoutBtcTx
+    protected ReleaseCreationInformation getReleaseCreationInformationToSignWithPowHsm(
+        ReleaseCreationInformation baseReleaseCreationInformation
     ) throws HSMReleaseCreationInformationException {
         try {
-            ReleaseCreationInformation baseReleaseCreationInformation =
-                getBaseReleaseCreationInformation(pegoutCreationRskTxHash, pegoutBtcTx);
-            Block block = baseReleaseCreationInformation.getPegoutCreationBlock();
-            TransactionReceipt transactionReceipt = baseReleaseCreationInformation.getTransactionReceipt();
+            Block pegoutCreationBlock = baseReleaseCreationInformation.getPegoutCreationBlock();
+            Keccak256 pegoutCreationRskTxHash = baseReleaseCreationInformation.getPegoutCreationRskTxHash();
+            BtcTransaction pegoutBtcTx = baseReleaseCreationInformation.getPegoutBtcTx();
+            TransactionReceipt pegoutCreationRskTxReceipt = baseReleaseCreationInformation.getTransactionReceipt();
 
-            // Get transaction from the block, searching by tx hash, and set it in the tx receipt
-            logger.trace("[getTxInfoToSignPowHsm] Searching for rsk transaction {} in block {} ({})", pegoutCreationRskTxHash, block.getHash(), block.getNumber());
-            List<Transaction> transactions = block.getTransactionsList().stream()
-                .filter(t -> t.getHash().equals(pegoutCreationRskTxHash))
-                .toList();
-            logger.trace("[getTxInfoToSignPowHsm] Transactions found {}", transactions.size());
+            // to be able to sign with hsm,
+            // we first need to check the release requested event related logs are found
+            validateReleaseRequestedLogsAreFound(
+                pegoutCreationRskTxReceipt.getLogInfoList(),
+                pegoutBtcTx,
+                pegoutCreationRskTxHash
+            );
 
-            if (transactions.size() != 1) {
-                String message = String.format(
-                    "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Filter size: %d",
-                    pegoutCreationRskTxHash,
-                    block.getHash().toHexString(),
-                    transactions.size()
-                );
-                logger.error("[getTxInfoToSignPowHsm] {}", message);
-                throw new HSMReleaseCreationInformationException(message);
-            }
-            Transaction transaction = transactions.get(0);
-            transactionReceipt.setTransaction(transaction);
+            // and then set the pegout creation rsk tx in the tx receipt
+            Transaction transaction = findPegoutCreationRskTxInBlock(baseReleaseCreationInformation);
+            pegoutCreationRskTxReceipt.setTransaction(transaction);
 
-            return findReleaseRequestedEventInBlock(block, pegoutBtcTx, pegoutCreationRskTxHash);
+            return new ReleaseCreationInformation(
+                pegoutCreationBlock,
+                pegoutCreationRskTxReceipt,
+                pegoutCreationRskTxHash,
+                pegoutBtcTx
+            );
+
         } catch (Exception e) {
             throw new HSMReleaseCreationInformationException("Unhandled exception occurred", e);
         }
     }
 
-    private ReleaseCreationInformation findReleaseRequestedEventInBlock(
-        Block pegoutCreationBlock,
+    private Transaction findPegoutCreationRskTxInBlock(
+        ReleaseCreationInformation baseReleaseCreationInformation
+    ) throws HSMReleaseCreationInformationException {
+        Block pegoutCreationBlock = baseReleaseCreationInformation.getPegoutCreationBlock();
+        Keccak256 pegoutCreationRskTxHash = baseReleaseCreationInformation.getPegoutCreationRskTxHash();
+
+        logger.trace(
+            "[findPegoutCreationRskTxInBlock] Searching for pegout creation rsk tx {} in block {} ({})",
+            pegoutCreationRskTxHash,
+            pegoutCreationBlock.getHash(),
+            pegoutCreationBlock.getNumber()
+        );
+
+        // Get transaction from the block searching by tx hash
+        List<Transaction> transactions = pegoutCreationBlock.getTransactionsList().stream()
+            .filter(t -> t.getHash().equals(pegoutCreationRskTxHash))
+            .toList();
+        logger.trace("[findPegoutCreationRskTxInBlock] Transactions found {}", transactions.size());
+
+        if (transactions.size() != 1) {
+            String message = String.format(
+                "Rsk transaction %s could not be found in block %s or more than 1 result obtained. Filter size: %d",
+                pegoutCreationRskTxHash,
+                pegoutCreationBlock.getHash().toHexString(),
+                transactions.size()
+            );
+            logger.error("[findPegoutCreationRskTxInBlock] {}", message);
+            throw new HSMReleaseCreationInformationException(message);
+        }
+        return transactions.get(0);
+    }
+
+    private void validateReleaseRequestedLogsAreFound(
+        List<LogInfo> logs,
         BtcTransaction pegoutBtcTx,
         Keccak256 pegoutCreationRskTxHash
     ) throws HSMReleaseCreationInformationException {
-        for (Transaction pegoutCreationRskTx : pegoutCreationBlock.getTransactionsList()) {
-            TransactionReceipt pegoutRskTxReceipt = receiptStore.getInMainChain(pegoutCreationRskTx.getHash().getBytes(), blockStore)
-                .map(TransactionInfo::getReceipt)
-                .orElseThrow(() -> new HSMReleaseCreationInformationException(
-                    String.format("Rsk Transaction hash [%s] should exist", pegoutCreationRskTx.getHash())));
 
-            pegoutRskTxReceipt.setTransaction(pegoutCreationRskTx);
-
-            Optional<ReleaseCreationInformation> releaseCreationInformation = getInformationFromEvent(
-                pegoutCreationBlock,
-                pegoutRskTxReceipt,
-                pegoutBtcTx,
-                pegoutCreationRskTxHash
-            );
-            if (releaseCreationInformation.isPresent()) {
-                return releaseCreationInformation.get();
+        for (LogInfo logInfo : logs) {
+            if (isLogValid(logInfo, pegoutBtcTx, pegoutCreationRskTxHash)) {
+                logger.debug(
+                    "[validateReleaseRequestedLogsAreFound] Expected log for pegout creation rsk tx {} was found",
+                    pegoutCreationRskTxHash
+                );
+                return;
             }
         }
 
-        // Since RSKIP375, release_requested and pegout_transaction_created events are always emitted in the same block where the pegout was created.
+        // Since RSKIP375, release_requested and pegout_transaction_created events
+        // are always emitted in the same block where the pegout was created.
         throw new HSMReleaseCreationInformationException(
-            String.format("Event not found. Rsk transaction: [%s]", pegoutCreationRskTxHash)
+            String.format("Expected logs not found. Rsk transaction: [%s]", pegoutCreationRskTxHash)
         );
-    }
-
-    private Optional<ReleaseCreationInformation> getInformationFromEvent(
-        Block block,
-        TransactionReceipt transactionReceipt,
-        BtcTransaction pegoutBtcTx,
-        Keccak256 pegoutCreationRskTxHash
-    ) {
-        boolean hasLogs = !transactionReceipt.getLogInfoList().isEmpty();
-
-        Keccak256 txHash = transactionReceipt.getTransaction().getHash();
-        Keccak256 blockHash = block.getHash();
-        logger.trace(
-            "[getInformationFromEvent] Rsk Transaction ({}) in block ({} - {}). Has logs? {}",
-            txHash,
-            block.getNumber(),
-            blockHash,
-            hasLogs
-        );
-
-        if (hasLogs) {
-            List<LogInfo> logs = transactionReceipt.getLogInfoList();
-            for (LogInfo logInfo : logs) {
-                if (isLogValid(logInfo, pegoutBtcTx, pegoutCreationRskTxHash)) {
-                    logger.debug(
-                        "[getInformationFromEvent] Found transaction {} and block {}",
-                        txHash,
-                        blockHash
-                    );
-                    return Optional.of(
-                        new ReleaseCreationInformation(
-                            block,
-                            transactionReceipt,
-                            pegoutCreationRskTxHash,
-                            pegoutBtcTx
-                        )
-                    );
-                }
-            }
-        }
-        return Optional.empty();
     }
 
     private boolean isLogValid(
@@ -192,34 +177,39 @@ public class ReleaseCreationInformationGetter {
         List<DataWord> topics = logInfo.getTopics();
 
         return isLogFromBridge(logInfo) &&
-            expectedTopicsSize(topics) &&
-            expectedTopics(topics, pegoutBtcTx, pegoutCreationRskTxHash);
+            hasExpectedTopics(topics, pegoutBtcTx, pegoutCreationRskTxHash);
     }
 
     private boolean isLogFromBridge(LogInfo logInfo) {
-        byte[] logsEmittedFrom = logInfo.getAddress();
-        return Arrays.equals(logsEmittedFrom, PrecompiledContracts.BRIDGE_ADDR.getBytes());
+        RskAddress logsEmittedFrom = new RskAddress(logInfo.getAddress());
+        return logsEmittedFrom.equals(PrecompiledContracts.BRIDGE_ADDR);
     }
 
-    private boolean expectedTopicsSize(List<DataWord> topics) {
-        int expectedTopicsSize = 3;
-        return topics.size() == expectedTopicsSize;
-    }
-
-    private boolean expectedTopics(
+    private boolean hasExpectedTopics(
         List<DataWord> topics,
         BtcTransaction pegoutBtcTx,
         Keccak256 pegoutCreationRskTxHash
     ) {
-        byte[] firstTopic = topics.get(0).getData();
-        boolean hasReleaseRequestedTopic = Arrays.equals(firstTopic, releaseRequestedSignatureTopic);
+        // three topics expected (in order):
+        // release requested signature, pegout creation rsk tx hash, and pegout btc tx hash
 
-        byte[] secondTopic = topics.get(1).getData();
-        boolean hasPegoutCreationRskTxHashTopic = Arrays.equals(secondTopic, pegoutCreationRskTxHash.getBytes());
+        int expectedTopicsSize = 3;
+        boolean hasExpectedTopicsSize = topics.size() == expectedTopicsSize;
+        if (!hasExpectedTopicsSize) {
+            return false;
+        }
 
-        byte[] thirdTopic = topics.get(2).getData();
-        boolean hasPegoutBtcTxHashTopic = Arrays.equals(thirdTopic, pegoutBtcTx.getHash().getBytes());
+        byte[] releaseRequestedSignatureTopic = topics.get(0).getData();
+        boolean hasReleaseRequestedTopic = Arrays.equals(releaseRequestedSignatureTopic, releaseRequestedEvent.encodeSignatureLong());
 
-        return hasReleaseRequestedTopic && hasPegoutCreationRskTxHashTopic && hasPegoutBtcTxHashTopic;
+        byte[] pegoutCreationRskTxHashTopic = topics.get(1).getData();
+        boolean hasPegoutCreationRskTxHashTopic = Arrays.equals(pegoutCreationRskTxHashTopic, pegoutCreationRskTxHash.getBytes());
+
+        byte[] pegoutBtcTxHashTopic = topics.get(2).getData();
+        boolean hasPegoutBtcTxHashTopic = Arrays.equals(pegoutBtcTxHashTopic, pegoutBtcTx.getHash().getBytes());
+
+        return hasReleaseRequestedTopic &&
+            hasPegoutCreationRskTxHashTopic &&
+            hasPegoutBtcTxHashTopic;
     }
 }

--- a/src/test/java/co/rsk/federate/EventsTestUtils.java
+++ b/src/test/java/co/rsk/federate/EventsTestUtils.java
@@ -8,10 +8,9 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.pegin.RejectedPeginReason;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+
+import java.util.*;
+
 import org.ethereum.core.CallTransaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.DataWord;
@@ -21,6 +20,29 @@ import org.ethereum.vm.PrecompiledContracts;
 public final class EventsTestUtils {
 
     private EventsTestUtils() {
+    }
+
+    private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
+
+    public static List<DataWord> buildCustomTopics(CallTransaction.Function event, List<byte[]> topicsToAdd) {
+        List<DataWord> topics = new ArrayList<>();
+
+        byte[] eventSignature = event.encodeSignatureLong();
+        topics.add(DataWord.valueOf(eventSignature));
+        for (byte[] topicToAdd : topicsToAdd) {
+            topics.add(DataWord.valueOf(topicToAdd));
+        }
+
+        return topics;
+    }
+
+    public static List<DataWord> buildEncodedTopics(CallTransaction.Function bridgeEvent, Object... args) {
+        byte[][] encodedTopicsInBytes = bridgeEvent.encodeEventTopics(args);
+        return LogInfo.byteArrayToList(encodedTopicsInBytes);
+    }
+
+    public static byte[] buildEncodedData(CallTransaction.Function bridgeEvent, Object... args) {
+        return bridgeEvent.encodeEventData(args);
     }
 
     public static LogInfo createPegoutTransactionCreatedLog(
@@ -62,24 +84,19 @@ public final class EventsTestUtils {
     }
 
     public static LogInfo createReleaseRequestedLog(
-        Keccak256 pegoutRskTxHash,
+        Keccak256 pegoutCreationRskTxHash,
         Sha256Hash pegoutBtcTxHash,
         Coin amount
     ) {
         CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
+        List<DataWord> topics = buildEncodedTopics(releaseRequestedEvent, pegoutCreationRskTxHash.getBytes(), pegoutBtcTxHash.getBytes());
+        byte[] data = buildEncodedData(releaseRequestedEvent, amount.getValue());
 
-        byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
-        List<DataWord> topics = new ArrayList<>();
-        topics.add(DataWord.valueOf(releaseRequestedSignatureTopic));
-        topics.add(DataWord.valueOf(pegoutRskTxHash.getBytes()));
-        topics.add(DataWord.valueOf(pegoutBtcTxHash.getBytes()));
+        return buildLogInfoFrom(BRIDGE_ADDRESS, topics, data);
+    }
 
-        byte[] encodedData = releaseRequestedEvent.encodeEventData(amount.getValue());
-
-        return new LogInfo(
-            PrecompiledContracts.BRIDGE_ADDR.getBytes(),
-            topics, encodedData
-        );
+    public static LogInfo buildLogInfoFrom(byte[] sender, List<DataWord> topics, byte[] data) {
+        return new LogInfo(sender, topics, data);
     }
 
     public static LogInfo createUpdateCollectionsLog(RskAddress senderAddress) {

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -265,84 +265,6 @@ class BtcReleaseClientTest {
         Mockito.verify(ethereum, Mockito.times(1)).removeListener(ArgumentMatchers.any(EthereumListener.class));
     }
 
-    @Test
-    void processReleases_ok() throws Exception {
-        // Arrange
-        powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
-        FederationMember federationMember = federation.getMembers().get(0);
-
-        // Create a tx from the Fed to a random btc address
-        BtcTransaction releaseTx = new BtcTransaction(params);
-
-        int amountOfInputs = 5;
-        for (int i = 0; i < amountOfInputs; i++) {
-            TransactionInput releaseInput = TestUtils.createTransactionInput(params, releaseTx, federation);
-            releaseTx.addInput(releaseInput);
-        }
-
-        BtcECKey fedKey = new BtcECKey();
-        ECPublicKey signerPublicKey = new ECPublicKey(fedKey.getPubKey());
-        ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-
-        when(signer.getPublicKey(BTC.getKeyId())).thenReturn(signerPublicKey);
-        when(signer.getVersionForKeyId(BTC.getKeyId())).thenReturn(1);
-        when(signer.sign(eq(BTC.getKeyId()), ArgumentMatchers.any())).thenReturn(ethSig);
-
-        SigHashCalculator sigHashCalculator = new LegacySigHashCalculatorImpl();
-        SignerMessageBuilder messageBuilder = new SignerMessageBuilderV1(releaseTx, sigHashCalculator);
-        SignerMessageBuilderFactory signerMessageBuilderFactory = mock(SignerMessageBuilderFactory.class);
-        when(signerMessageBuilderFactory.buildFromConfig(
-            ArgumentMatchers.anyInt(),
-            ArgumentMatchers.any(ReleaseCreationInformation.class),
-            ArgumentMatchers.anyInt()
-        )).thenReturn(messageBuilder);
-
-        doReturn(federationMember).when(federatorSupport).getFederationMember();
-
-        client = new BtcReleaseClient(
-            mock(Ethereum.class),
-            federatorSupport,
-            powpegNodeSystemProperties,
-            mock(NodeBlockProcessor.class)
-        );
-
-        Keccak256 rskTxHash = Keccak256.ZERO_HASH;
-
-        Block block = mock(Block.class);
-        ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
-            block,
-            mock(TransactionReceipt.class),
-            rskTxHash,
-            releaseTx
-        );
-        ReleaseCreationInformationGetter releaseCreationInformationGetter = mock(ReleaseCreationInformationGetter.class);
-        when(releaseCreationInformationGetter.getTxInfoToSign(
-            anyInt(),
-            any(),
-            any()
-        )).thenReturn(releaseCreationInformation);
-
-        client.setup(
-            signer,
-            signerMessageBuilderFactory,
-            releaseCreationInformationGetter,
-            mock(ReleaseRequirementsEnforcer.class)
-        );
-        client.start(federation);
-
-        SortedMap<Keccak256, BtcTransaction> releases = new TreeMap<>();
-        releases.put(rskTxHash, releaseTx);
-
-        // Act
-        client.processReleases(releases.entrySet());
-
-        // Assert
-        Mockito.verify(signer, Mockito.times(amountOfInputs)).sign(
-            eq(BTC.getKeyId()),
-            any(SignerMessage.class)
-        );
-    }
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -1249,6 +1171,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash1.getBytes())).thenReturn(block1);
         when(txInfo1.getReceipt()).thenReturn(txReceipt1);
         when(txInfo1.getBlockHash()).thenReturn(blockHash1.getBytes());
+        Coin pegout1Amount = tx1.getOutputSum();
+        when(txReceipt1.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(hash1, tx1.getHash(), pegout1Amount),
+            createPegoutTransactionCreatedLog(
+                tx1.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(tx1.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(hash1.getBytes(), blockStore)).thenReturn(Optional.of(txInfo1));
 
         Keccak256 blockHash2 = createHash(3);
@@ -1259,6 +1189,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash2.getBytes())).thenReturn(block2);
         when(txInfo2.getReceipt()).thenReturn(txReceipt2);
         when(txInfo2.getBlockHash()).thenReturn(blockHash2.getBytes());
+        Coin pegout2Amount = tx2.getOutputSum();
+        when(txReceipt2.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(hash2, tx2.getHash(), pegout2Amount),
+            createPegoutTransactionCreatedLog(
+                tx2.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(tx2.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(hash2.getBytes(), blockStore)).thenReturn(Optional.of(txInfo2));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter =
@@ -1332,6 +1270,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(txInfo.getReceipt()).thenReturn(txReceipt);
         when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        Coin pegoutAmount = pegout.getOutputSum();
+        when(txReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(pegoutCreationRskTxHash, pegout.getHash(), pegoutAmount),
+            createPegoutTransactionCreatedLog(
+                pegout.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(pegout.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter =
@@ -1419,6 +1365,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(txInfo.getReceipt()).thenReturn(txReceipt);
         when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        Coin pegoutAmount = pegout.getOutputSum();
+        when(txReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(pegoutCreationRskTxHash, pegout.getHash(), pegoutAmount),
+            createPegoutTransactionCreatedLog(
+                pegout.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(pegout.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter =
@@ -1517,6 +1471,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(txInfo.getReceipt()).thenReturn(txReceipt);
         when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        Coin svpSpendAmount = svpSpendTx.getOutputSum();
+        when(txReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(svpSpendCreationRskTxHash, svpSpendTx.getHash(), svpSpendAmount),
+            createPegoutTransactionCreatedLog(
+                svpSpendTx.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(svpSpendTx.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(svpSpendCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter =
@@ -1622,6 +1584,15 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(txInfo.getReceipt()).thenReturn(txReceipt);
         when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        BitcoinUtils.removeSignaturesFromMultiSigTransaction(svpSpendTx);
+        Coin svpSpendAmount = svpSpendTx.getOutputSum();
+        when(txReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(svpSpendCreationRskTxHash, svpSpendTx.getHash(), svpSpendAmount),
+            createPegoutTransactionCreatedLog(
+                svpSpendTx.getHash(),
+                UtxoUtils.encodeOutpointValues(List.of(Coin.valueOf(100_000)))
+            )
+        ));
         when(receiptStore.getInMainChain(svpSpendCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
@@ -1731,6 +1702,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(txInfo.getReceipt()).thenReturn(txReceipt);
         when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        Coin pegoutAmount = pegout.getOutputSum();
+        when(txReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(pegoutCreationRskTxHash, pegout.getHash(), pegoutAmount),
+            createPegoutTransactionCreatedLog(
+                pegout.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(pegout.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
 
         // svp spend tx
@@ -1744,6 +1723,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(svpSpendBlockHash.getBytes())).thenReturn(svpSpendBlock);
         when(svpSpendTxInfo.getReceipt()).thenReturn(svpSpendTxReceipt);
         when(svpSpendTxInfo.getBlockHash()).thenReturn(svpSpendBlockHash.getBytes());
+        Coin svpSpendAmount = svpSpendTx.getOutputSum();
+        when(svpSpendTxReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(svpSpendCreationRskTxHash, svpSpendTx.getHash(), svpSpendAmount),
+            createPegoutTransactionCreatedLog(
+                svpSpendTx.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(svpSpendTx.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(svpSpendCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(svpSpendTxInfo));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
@@ -1835,6 +1822,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
         when(txInfo.getReceipt()).thenReturn(txReceipt);
         when(txInfo.getBlockHash()).thenReturn(blockHash.getBytes());
+        Coin pegoutAmount = pegout.getOutputSum();
+        when(txReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(pegoutCreationRskTxHash, pegout.getHash(), pegoutAmount),
+            createPegoutTransactionCreatedLog(
+                pegout.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(pegout.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(pegoutCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(txInfo));
 
         // svp spend tx
@@ -1848,6 +1843,14 @@ class BtcReleaseClientTest {
         when(blockStore.getBlockByHash(svpSpendBlockHash.getBytes())).thenReturn(svpSpendBlock);
         when(svpSpendTxInfo.getReceipt()).thenReturn(svpSpendTxReceipt);
         when(svpSpendTxInfo.getBlockHash()).thenReturn(svpSpendBlockHash.getBytes());
+        Coin svpSpendAmount = svpSpendTx.getOutputSum();
+        when(svpSpendTxReceipt.getLogInfoList()).thenReturn(List.of(
+            createReleaseRequestedLog(svpSpendCreationRskTxHash, svpSpendTx.getHash(), svpSpendAmount),
+            createPegoutTransactionCreatedLog(
+                svpSpendTx.getHash(),
+                UtxoUtils.encodeOutpointValues(Collections.singletonList(svpSpendTx.getInputSum()))
+            )
+        ));
         when(receiptStore.getInMainChain(svpSpendCreationRskTxHash.getBytes(), blockStore)).thenReturn(Optional.of(svpSpendTxInfo));
 
         ReleaseCreationInformationGetter releaseCreationInformationGetter =
@@ -2124,23 +2127,6 @@ class BtcReleaseClientTest {
     }
 
     @Test
-    void validateTxCanBeSigned_ok() throws Exception {
-        // Arrange
-        powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-        Federation federation = TestUtils.createP2shP2wshErpFederation(params, 20);
-
-        // Create a tx from the Fed to a random btc address
-        BtcTransaction releaseTx = new BtcTransaction(params);
-        TransactionInput releaseInput = TestUtils.createTransactionInput(params, releaseTx, federation);
-        releaseTx.addInput(releaseInput);
-
-        BtcECKey fed1Key = federation.getBtcPublicKeys().get(0);
-        ECPublicKey signerPublicKey = new ECPublicKey(fed1Key.getPubKey());
-
-        test_validateTxCanBeSigned(federation, releaseTx, signerPublicKey);
-    }
-
-    @Test
     void validateTxCanBeSigned_fast_bridge_ok() throws Exception {
         // Create a StandardMultisigFederation
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
@@ -2221,7 +2207,8 @@ class BtcReleaseClientTest {
             mock(Block.class),
             mock(TransactionReceipt.class),
             rskTxHash,
-            releaseTx
+            releaseTx,
+            Collections.emptyList()
         );
 
         // Act

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -12,6 +12,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.script.*;
+import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.federate.FederatorSupport;
 import co.rsk.federate.bitcoin.BitcoinTestUtils;
@@ -404,8 +405,9 @@ class BtcReleaseClientTest {
         private final byte[] releaseCreationRskTxHashBytes = releaseCreationRskTxHash.getBytes();
 
         private final Keccak256 anotherRskTxHash = createHash(123);
-        private final Transaction anotherRskTx = mock(Transaction.class);
-        private final TransactionReceipt anotherRskTxReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
+
+        private final RskAddress pegnatoryAddress = new RskAddress(TestUtils.getEcKeyFromSeed("pegnatory").getAddress());
+        private final LogInfo updateCollectionsLog = createUpdateCollectionsLog(pegnatoryAddress);
 
         private final Coin prevReleaseTxValue = Coin.COIN;
         private final byte[] releaseRequestedEventData = buildEncodedData(RELEASE_REQUESTED_EVENT, prevReleaseTxValue.getValue());
@@ -421,8 +423,6 @@ class BtcReleaseClientTest {
         void setUp() {
             powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
             releases = new TreeMap<>();
-
-            when(anotherRskTx.getHash()).thenReturn(anotherRskTxHash);;
 
             rskTxsList = new ArrayList<>();
             when(bestBlock.getTransactionsList()).thenReturn(rskTxsList);
@@ -460,9 +460,9 @@ class BtcReleaseClientTest {
         private void setUpBlockchainForProcessingRelease(Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
             addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
 
-            TransactionReceipt txReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
-            addReleaseRequestedLogs(txReceipt, releaseCreationRskTxHash, releaseTx);
-            setUpBlockChain(txReceipt, releaseCreationRskTxHash);
+            TransactionReceipt rskTxReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
+            addLogsForReleaseRequestedEventToTxReceipt(rskTxReceipt, releaseCreationRskTxHash, releaseTx);
+            setUpBlockChain(rskTxReceipt, releaseCreationRskTxHash);
         }
 
         private void addReleaseTxToSet(Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
@@ -474,15 +474,17 @@ class BtcReleaseClientTest {
             rskTxsList.add(rskTx);
         }
 
-        private void addReleaseRequestedLogs(TransactionReceipt pegoutCreationRskTxReceipt, Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
+        private void addLogsForReleaseRequestedEventToTxReceipt(TransactionReceipt rskTxReceipt, Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
+            addLogToRskTxReceipt(rskTxReceipt, updateCollectionsLog);
+
             Sha256Hash originalReleaseTxHash = releaseTx.getHash();
             Coin prevTxValue = releaseTx.getInput(0).getValue();
             LogInfo releaseRequestedLog = createReleaseRequestedLog(releaseCreationRskTxHash, originalReleaseTxHash, prevTxValue);
-            addLogToRskTxReceipt(pegoutCreationRskTxReceipt, releaseRequestedLog);
+            addLogToRskTxReceipt(rskTxReceipt, releaseRequestedLog);
 
             byte[] serializedOutpointValues = UtxoUtils.encodeOutpointValues(List.of(prevTxValue));
             LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(originalReleaseTxHash, serializedOutpointValues);
-            addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
+            addLogToRskTxReceipt(rskTxReceipt, pegoutTransactionCreatedLog);
         }
 
         private void setUpBlockChain(TransactionReceipt txReceipt, Keccak256 releaseCreationRskTxHash) {
@@ -816,7 +818,7 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            verify(federatorSupport, never()).addSignature(anyList(), any(byte[].class));
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
@@ -829,6 +831,8 @@ class BtcReleaseClientTest {
             releases.put(releaseCreationRskTxHash, releaseTx);
 
             // block will not contain pegoutCreationRskTx, but another one
+            Transaction anotherRskTx = mock(Transaction.class);
+            when(anotherRskTx.getHash()).thenReturn(anotherRskTxHash);
             rskTxsList.clear();
             rskTxsList.add(anotherRskTx);
             // tx receipt for the other tx
@@ -844,172 +848,167 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenFirstMatchIsFromWrongSender_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogsAreFromWrongSender_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - correct topics but from another sender (not the bridge)
-            List<DataWord> topics = buildEncodedTopics(RELEASE_REQUESTED_EVENT, releaseCreationRskTxHashBytes, releaseBtcTxHashBytes);
+            // build wrong log - correct topics but from another sender (not the bridge)
+            List<DataWord> topics = buildEncodedTopics(
+                RELEASE_REQUESTED_EVENT,
+                releaseCreationRskTxHashBytes,
+                releaseBtcTxHashBytes
+            );
             byte[] sender = org.bouncycastle.util.encoders.Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
-            LogInfo wrongReleaseRequestedLogInfo = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, wrongReleaseRequestedLogInfo);
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
-        void processReleases_whenFirstMatchHasWrongReleaseRequestedTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogHasWrongReleaseRequestedTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - wrong event topic
+            // build wrong log - wrong event topic
             CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
             List<DataWord> topics = buildCustomTopics(
                 wrongEvent,
                 List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes)
             );
-            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, log);
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
-        void processReleases_whenFirstMatchHasWrongPegoutCreationRskTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogHasWrongPegoutCreationRskTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - wrong pegoutCreationRskTxHash topic
+            // build wrong log - wrong pegoutCreationRskTxHash topic
             List<DataWord> topics = buildCustomTopics(
                 RELEASE_REQUESTED_EVENT,
                 List.of(WRONG_TOPIC, releaseBtcTxHashBytes)
             );
-            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, log);
-
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
-        void processReleases_whenFirstMatchHasWrongPegoutBtcTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogHasWrongPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - wrong pegoutBtcTxHash topic
+            // build wrong log - wrong pegoutBtcTxHash topic
             List<DataWord> topics = buildCustomTopics(
                 RELEASE_REQUESTED_EVENT,
                 List.of(releaseCreationRskTxHashBytes, WRONG_TOPIC)
             );
-            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, log);
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
-        void processReleases_whenFirstMatchMissesPegoutCreationRskTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogMissesPegoutCreationRskTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - missing pegoutCreationRskTxHash topic
+            // build wrong log - missing pegoutCreationRskTxHash topic
             List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseBtcTxHashBytes));
-            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, log);
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
-        void processReleases_whenFirstMatchMissesPegoutBtcTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogMissesPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - missing pegoutBtcTxHash topic
+            // build wrong log - missing pegoutBtcTxHash topic
             List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseCreationRskTxHashBytes));
-            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, log);
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
-        void processReleases_whenFirstMatchHasExtraTopics_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+        void processReleases_whenLogHasExtraTopics_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
-            setUpReleaseTxFromFed(segwitFederation);
-
-            // build tx with wrong log - one extra topic
+            // build wrong log - one extra topic
             List<DataWord> topics = buildCustomTopics(
                 RELEASE_REQUESTED_EVENT,
                 List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, WRONG_TOPIC)
             );
-            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            addLogToRskTxReceipt(anotherRskTxReceipt, log);
-            // wrong tx should appear first in the list
-            rskTxsList.add(0, anotherRskTx);
-            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+            LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            setUpReleaseTxWithWrongLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
-            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
+        }
+
+        @Test
+        void processReleases_whenAnotherTxHasExpectedLogs_shouldNotSign() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
+            // build release tx and add it to the set
+            buildReleaseTx(segwitFederation);
+            addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
+            // but put the logs in another rsk tx
+            TransactionReceipt anotherRskTxReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
+            addLogsForReleaseRequestedEventToTxReceipt(anotherRskTxReceipt, releaseCreationRskTxHash, releaseTx);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            verify(federatorSupport, never()).addSignature(anyList(), any(byte[].class));
+        }
+
+        private void setUpReleaseTxWithWrongLog(LogInfo wrongLog) {
+            buildReleaseTx(segwitFederation);
+            addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
+
+            TransactionReceipt rskTxReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
+            addLogToRskTxReceipt(rskTxReceipt, wrongLog);
+
+            Sha256Hash originalReleaseTxHash = releaseTx.getHash();
+            Coin prevTxValue = releaseTx.getInput(0).getValue();
+            byte[] serializedOutpointValues = UtxoUtils.encodeOutpointValues(List.of(prevTxValue));
+            LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(originalReleaseTxHash, serializedOutpointValues);
+            addLogToRskTxReceipt(rskTxReceipt, pegoutTransactionCreatedLog);
+
+            setUpBlockChain(rskTxReceipt, releaseCreationRskTxHash);
         }
 
         private void addUnprocessableReleaseTxToSet(Federation federation) {

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -1,5 +1,6 @@
 package co.rsk.federate.btcreleaseclient;
 
+import static co.rsk.federate.EventsTestUtils.*;
 import static co.rsk.federate.signing.PowPegNodeKeyId.BTC;
 import static co.rsk.federate.signing.utils.TestUtils.*;
 import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
@@ -349,12 +350,19 @@ class BtcReleaseClientTest {
         // when recreating already signed pegouts
         // we need to manually add the sigs,
         // since the real signing is done by the bridge
-        
-        private final byte[] bridgeContractAddressSerialized = PrecompiledContracts.BRIDGE_ADDR.getBytes();
-        private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
-        private final CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-        
+
+        private final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
+        private final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
+        private final byte[] wrongTopic = TestUtils.createHash(456).getBytes();
+
         // feds setup
+        private final ECKey.ECDSASignature ethSig1 = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
+        private final BtcECKey.ECDSASignature btcSig1 = new BtcECKey.ECDSASignature(ethSig1.r, ethSig1.s);
+        private final ECKey.ECDSASignature ethSig2 = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
+        private final BtcECKey.ECDSASignature btcSig2 = new BtcECKey.ECDSASignature(ethSig2.r, ethSig2.s);
+        private final int latestHSMVersion = TestUtils.getLatestHsmVersion().getNumber();
+        private final int keyFileVersion = 1;
+
         private final BtcECKey keyFile1BtcPubKey = getBtcEcKeyFromSeed("keyFile1BtcPubKey");
         private final ECKey keyFile1RskPubKey = ECKey.fromPublicOnly(keyFile1BtcPubKey.getPubKey());
         private final BtcECKey keyFile2BtcPubKey = getBtcEcKeyFromSeed("keyFile2BtcPubKey");
@@ -372,7 +380,7 @@ class BtcReleaseClientTest {
         private final long erpActivationDelay = federationMainnetConstants.getErpFedActivationDelay();
         private final Instant creationTime = Instant.ofEpochSecond(100_000_000L);
         private final long creationBlockNumber = 1L;
-        
+
         private final FederationArgs federationArgs = new FederationArgs(members, creationTime, creationBlockNumber, params);
         private final Federation legacyFederation =
             FederationFactory.buildP2shErpFederation(federationArgs, erpFedKeys, erpActivationDelay);
@@ -380,22 +388,29 @@ class BtcReleaseClientTest {
             FederationFactory.buildP2shP2wshErpFederation(federationArgs, erpFedKeys, erpActivationDelay);
 
         private final Keccak256 unprocessableTestnetPegoutRskTxCreationHash = new Keccak256("86c6739feeb9279d8c7cd85bc6732cb818c3a9d54b55a070adfe1d31ba10f4e5");
-        private final Keccak256 rskTxHash = new Keccak256("0102030405060708090000000000000000000000000000000000000000000000");
-        private final byte[] rskTxHashSerialized = rskTxHash.getBytes();
-        private final byte[] notNullBytes = new byte[]{0x01};
+        private final Keccak256 releaseCreationRskTxHash = new Keccak256("0102030405060708090000000000000000000000000000000000000000000000");
+        private final byte[] releaseCreationRskTxHashBytes = releaseCreationRskTxHash.getBytes();
+
+        private final Keccak256 anotherRskTxHash = createHash(123);
+        private final Transaction anotherRskTx = mock(Transaction.class);
+        private final TransactionReceipt anotherRskTxReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
+
+        private final Coin prevReleaseTxValue = Coin.COIN;
+        private final byte[] releaseRequestedEventData = buildEncodedData(RELEASE_REQUESTED_EVENT, prevReleaseTxValue.getValue());
 
         private BtcTransaction releaseTx;
+        private byte[] releaseBtcTxHashBytes;
         private SortedMap<Keccak256, BtcTransaction> releases;
         private SignerMessageBuilderFactory signerMessageBuilderFactory;
         private ReleaseCreationInformationGetter releaseCreationInformationGetter;
-        private List<LogInfo> logInfoList;
         private List<Transaction> rskTxsList;
 
         @BeforeEach
         void setUp() {
             powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
-            logInfoList = new ArrayList<>();
             releases = new TreeMap<>();
+
+            when(anotherRskTx.getHash()).thenReturn(anotherRskTxHash);;
 
             rskTxsList = new ArrayList<>();
             when(bestBlock.getTransactionsList()).thenReturn(rskTxsList);
@@ -409,11 +424,15 @@ class BtcReleaseClientTest {
             powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
         }
 
-        private void addReleaseTxFromFedToSet(Federation federation) {
+        private void setUpReleaseTxFromFed(Federation federation) {
+            buildReleaseTx(federation);
+            setUpBlockchainForProcessingRelease(releaseCreationRskTxHash, releaseTx);
+        }
+
+        private void buildReleaseTx(Federation federation) {
             // set up for release tx
             BtcTransaction prevTx = new BtcTransaction(params);
-            Coin prevTxValue = Coin.COIN;
-            prevTx.addOutput(prevTxValue, federation.getAddress());
+            prevTx.addOutput(prevReleaseTxValue, federation.getAddress());
             releaseTx = new BtcTransaction(params);
             releaseTx.addInput(prevTx.getOutput(0));
             addSpendingFederationBaseScript(
@@ -423,49 +442,43 @@ class BtcReleaseClientTest {
                 federation.getFormatVersion()
             );
 
-            setUpBlockchainForProcessingRelease(rskTxHash, releaseTx);
+            releaseBtcTxHashBytes = releaseTx.getHash().getBytes();
         }
 
         private void setUpBlockchainForProcessingRelease(Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
+            addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
+
+            TransactionReceipt txReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
+            addReleaseRequestedLogs(txReceipt, releaseCreationRskTxHash, releaseTx);
+            setUpBlockChain(txReceipt, releaseCreationRskTxHash);
+        }
+
+        private void addReleaseTxToSet(Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
             // put release in set
             releases.put(releaseCreationRskTxHash, releaseTx);
             // add rsk tx to txs list
             Transaction rskTx = mock(Transaction.class);
             when(rskTx.getHash()).thenReturn(releaseCreationRskTxHash);
             rskTxsList.add(rskTx);
+        }
 
+        private void addReleaseRequestedLogs(TransactionReceipt pegoutCreationRskTxReceipt, Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
             Sha256Hash originalReleaseTxHash = releaseTx.getHash();
             Coin prevTxValue = releaseTx.getInput(0).getValue();
+            LogInfo releaseRequestedLog = createReleaseRequestedLog(releaseCreationRskTxHash, originalReleaseTxHash, prevTxValue);
+            addLogToRskTxReceipt(pegoutCreationRskTxReceipt, releaseRequestedLog);
 
-            // set up release requested event
-            byte[] releaseCreationRskTxHashSerialized = releaseCreationRskTxHash.getBytes();
-            byte[][] releaseRequestedEncodedTopics = releaseRequestedEvent.encodeEventTopics(releaseCreationRskTxHashSerialized, originalReleaseTxHash.getBytes());
-            List<DataWord> releaseRequestedTopics = LogInfo.byteArrayToList(releaseRequestedEncodedTopics);
-            byte[] releaseRequestedEncodedData = releaseRequestedEvent.encodeEventData(prevTxValue.getValue());
-            LogInfo releaseRequestedLogInfo = new LogInfo(bridgeContractAddressSerialized, releaseRequestedTopics, releaseRequestedEncodedData);
-            logInfoList.add(releaseRequestedLogInfo);
-
-            // set up pegout transaction created event
-            byte[][] pegoutTransactionCreatedEncodedTopicsSerialized = pegoutTransactionCreatedEvent.encodeEventTopics(originalReleaseTxHash.getBytes());
-            List<DataWord> pegoutTransactionCreatedEncodedTopics = LogInfo.byteArrayToList(pegoutTransactionCreatedEncodedTopicsSerialized);
             byte[] serializedOutpointValues = UtxoUtils.encodeOutpointValues(List.of(prevTxValue));
-            byte[] pegoutTransactionCreatedEncodedData = pegoutTransactionCreatedEvent.encodeEventData(serializedOutpointValues);
-            LogInfo pegoutTransactionCreatedLogInfo = new LogInfo(bridgeContractAddressSerialized, pegoutTransactionCreatedEncodedTopics, pegoutTransactionCreatedEncodedData);
-            logInfoList.add(pegoutTransactionCreatedLogInfo);
+            LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(originalReleaseTxHash, serializedOutpointValues);
+            addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
+        }
 
-            TransactionReceipt txReceipt = new TransactionReceipt(
-                releaseCreationRskTxHashSerialized,
-                notNullBytes,
-                notNullBytes,
-                mock(Bloom.class),
-                logInfoList,
-                notNullBytes
-            );
-
-            byte[] rskBlockHashSerialized = rskBlockHash.getBytes();
+        private void setUpBlockChain(TransactionReceipt txReceipt, Keccak256 releaseCreationRskTxHash) {
             int txIndex = releases.size(); // to not override txs
-            TransactionInfo txInfo = new TransactionInfo(txReceipt, rskBlockHashSerialized, txIndex);
+            TransactionInfo txInfo = buildTxInfo(txReceipt, rskBlockHash, txIndex);
 
+            byte[] releaseCreationRskTxHashSerialized = releaseCreationRskTxHash.getBytes();
+            byte[] rskBlockHashSerialized = rskBlockHash.getBytes();
             when(receiptStore.getInMainChain(releaseCreationRskTxHashSerialized, blockStore)).thenReturn(Optional.of(txInfo));
             when(receiptStore.get(releaseCreationRskTxHashSerialized, rskBlockHashSerialized)).thenReturn(Optional.of(txInfo));
             when(blockStore.getBlockByHash(rskBlockHashSerialized)).thenReturn(bestBlock);
@@ -475,12 +488,9 @@ class BtcReleaseClientTest {
         void processReleases_signWithKeyFile_legacyFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            addReleaseTxFromFedToSet(legacyFederation);
+            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
-
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -488,29 +498,16 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            // assert signable release was signed
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-
-            // assert unprocessable release was not signed
-            verify(federatorSupport, never()).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithKeyFile_legacyFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
+            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
-
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -518,27 +515,17 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            addReleaseTxFromFedToSet(legacyFederation);
+            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -546,29 +533,16 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            // assert signable release was signed
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-
-            // assert unprocessable release was not signed
-            verify(federatorSupport, never()).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
+            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -576,153 +550,99 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_legacyFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
-
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
+            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(legacyFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
+            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(legacyFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_legacyFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
-            
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
+            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport, times(0)).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
-            
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
+            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport, times(0)).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_whenOtherFedAlreadySigned_legacyFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
-            
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(legacyFederation, keyFile1Member, signerVersion, ethSig);
-
+            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
-            
+
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_whenOtherFedAlreadySigned_legacyFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(legacyFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(legacyFederation, hsm1Member, signerVersion, ethSig);
-
+            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            addReleaseTxFromFedToSet(segwitFederation);
+            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
-
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -730,29 +650,16 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            // assert signable release was signed
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-
-            // assert unprocessable release was not signed
-            verify(federatorSupport, never()).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
+            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
-
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -760,27 +667,17 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            addReleaseTxFromFedToSet(segwitFederation);
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(segwitFederation, hsm1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -788,29 +685,16 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            // assert signable release was signed
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-
-            // assert unprocessable release was not signed
-            verify(federatorSupport, never()).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(segwitFederation, hsm1Member, signerVersion, ethSig);
 
             // act
             for (int i = 0; i < releases.size(); i++) {
@@ -818,142 +702,90 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(unprocessableTestnetPegoutRskTxCreationHash.getBytes(), rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
-
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
+            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(segwitFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
-            
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(segwitFederation, hsm1Member, signerVersion, ethSig);
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
-            
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
-
+            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport, times(0)).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(segwitFederation, hsm1Member, signerVersion, ethSig);
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport, times(0)).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig1);
         }
 
         @Test
         void processReleases_signWithKeyFile_whenOtherFedAlreadySigned_segwitFed_ok() throws Exception {
             // arrange
-            addReleaseTxFromFedToSet(segwitFederation);
-            
-            int signerVersion = 1;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-            setUpFederator(segwitFederation, keyFile1Member, signerVersion, ethSig);
-
+            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
         }
 
         @Test
         void processReleases_signWithHSM_whenOtherFedAlreadySigned_segwitFed_ok() throws Exception {
             // Arrange
-            addReleaseTxFromFedToSet(segwitFederation);
-
-            int signerVersion = 5;
-            ECKey.ECDSASignature ethSig = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-            setUpFederator(segwitFederation, hsm1Member, signerVersion, ethSig);
-
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            BtcECKey.ECDSASignature btcSig = new BtcECKey.ECDSASignature(ethSig.r, ethSig.s);
-            verify(federatorSupport).addSignature(
-                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
-                argThat(rskHash -> Arrays.equals(rskTxHashSerialized, rskHash))
-            );
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
         }
 
         private void addUnprocessableReleaseTxToSet(Federation federation) {
@@ -972,7 +804,7 @@ class BtcReleaseClientTest {
 
             setUpBlockchainForProcessingRelease(unprocessableTestnetPegoutRskTxCreationHash, unprocessableReleaseTx);
         }
-        
+
         private void setUpFederator(
             Federation federation,
             FederationMember member,
@@ -1007,6 +839,20 @@ class BtcReleaseClientTest {
             );
 
             client.start(federation);
+        }
+
+        private void assertTxWasSigned(Keccak256 rskTxHash, BtcECKey.ECDSASignature btcSig) {
+            verify(federatorSupport).addSignature(
+                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
+                argThat(rskHash -> Arrays.equals(rskTxHash.getBytes(), rskHash))
+            );
+        }
+
+        private void assertTxWasNotSigned(Keccak256 rskTxHash, BtcECKey.ECDSASignature btcSig) {
+            verify(federatorSupport, never()).addSignature(
+                argThat(signatures -> Arrays.equals(btcSig.encodeToDER(), signatures.get(0))),
+                argThat(rskHash -> Arrays.equals(rskTxHash.getBytes(), rskHash))
+            );
         }
     }
 
@@ -1270,7 +1116,7 @@ class BtcReleaseClientTest {
         field = pegoutSignedCache.getClass().getDeclaredField("clock");
         field.setAccessible(true);
         field.set(pegoutSignedCache, Clock.offset(baseClock, Duration.ofHours(1)));
-    
+
         // At this point the pegout tx is invalid in the pegouts signed cache,
         // so it should not throw an exception
         assertDoesNotThrow(
@@ -1397,7 +1243,7 @@ class BtcReleaseClientTest {
                 List.of(federationKeys.get(0))
             );
         }
-      
+
         Keccak256 svpSpendCreationRskTxHash = createHash(0);
         Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendCreationRskTxHash, svpSpendTx);
         StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(svpSpendTxWFS);
@@ -1464,7 +1310,7 @@ class BtcReleaseClientTest {
         ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
 
         // Assert
-        
+
         // We should have searched by the expected svp spend tx hash
         BitcoinUtils.removeSignaturesFromMultiSigTransaction(svpSpendTx);
         assertEquals(svpSpendTxHashBeforeSigning, svpSpendTx.getHash());
@@ -1765,7 +1611,7 @@ class BtcReleaseClientTest {
         );
 
         btcReleaseClient.start(proposedFederation);
-      
+
         // Act
         ethereumListener.get().onBestBlock(bestBlock, Collections.emptyList());
 
@@ -2012,7 +1858,7 @@ class BtcReleaseClientTest {
 
         ECPublicKey signerPublicKey = new ECPublicKey(federator1PrivKey.getPubKey());
         Mockito.doReturn(signerPublicKey).when(signer).getPublicKey(ArgumentMatchers.any(KeyId.class));
-      
+
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
         client = new BtcReleaseClient(

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -788,6 +788,218 @@ class BtcReleaseClientTest {
             assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
         }
 
+        @Test
+        void processReleases_whenTxHasEmptyReceipt_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+
+            buildReleaseTx(segwitFederation);
+            addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
+            // replace tx receipt to not have logs
+            TransactionReceipt txReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
+            txReceipt.setLogInfoList(Collections.emptyList());
+            setUpBlockChain(txReceipt, releaseCreationRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            verify(federatorSupport, never()).addSignature(anyList(), any(byte[].class));
+        }
+
+        @Test
+        void processReleases_whenBlockDoesNotContainPegoutCreationRskTx_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+
+            // put release in set
+            buildReleaseTx(segwitFederation);
+            releases.put(releaseCreationRskTxHash, releaseTx);
+
+            // block will not contain pegoutCreationRskTx, but another one
+            rskTxsList.clear();
+            rskTxsList.add(anotherRskTx);
+            // tx receipt for the other tx
+            TransactionReceipt txReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
+            txReceipt.setLogInfoList(Collections.emptyList());
+            setUpBlockChain(txReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            verify(federatorSupport, never()).addSignature(anyList(), any(byte[].class));
+        }
+
+        @Test
+        void processReleases_whenFirstMatchIsFromWrongSender_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - correct topics but from another sender (not the bridge)
+            List<DataWord> topics = buildEncodedTopics(RELEASE_REQUESTED_EVENT, releaseCreationRskTxHashBytes, releaseBtcTxHashBytes);
+            byte[] sender = org.bouncycastle.util.encoders.Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+            LogInfo wrongReleaseRequestedLogInfo = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, wrongReleaseRequestedLogInfo);
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
+        @Test
+        void processReleases_whenFirstMatchHasWrongReleaseRequestedTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - wrong event topic
+            CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
+            List<DataWord> topics = buildCustomTopics(
+                wrongEvent,
+                List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes)
+            );
+            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, log);
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
+        @Test
+        void processReleases_whenFirstMatchHasWrongPegoutCreationRskTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - wrong pegoutCreationRskTxHash topic
+            List<DataWord> topics = buildCustomTopics(
+                RELEASE_REQUESTED_EVENT,
+                List.of(wrongTopic, releaseBtcTxHashBytes)
+            );
+            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
+        @Test
+        void processReleases_whenFirstMatchHasWrongPegoutBtcTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - wrong pegoutBtcTxHash topic
+            List<DataWord> topics = buildCustomTopics(
+                RELEASE_REQUESTED_EVENT,
+                List.of(releaseCreationRskTxHashBytes, wrongTopic)
+            );
+            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, log);
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
+        @Test
+        void processReleases_whenFirstMatchMissesPegoutCreationRskTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - missing pegoutCreationRskTxHash topic
+            List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseBtcTxHashBytes));
+            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, log);
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
+        @Test
+        void processReleases_whenFirstMatchMissesPegoutBtcTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - missing pegoutBtcTxHash topic
+            List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseCreationRskTxHashBytes));
+            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, log);
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
+        @Test
+        void processReleases_whenFirstMatchHasExtraTopics_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpReleaseTxFromFed(segwitFederation);
+
+            // build tx with wrong log - one extra topic
+            List<DataWord> topics = buildCustomTopics(
+                RELEASE_REQUESTED_EVENT,
+                List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, wrongTopic)
+            );
+            LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+            addLogToRskTxReceipt(anotherRskTxReceipt, log);
+            // wrong tx should appear first in the list
+            rskTxsList.add(0, anotherRskTx);
+            setUpBlockChain(anotherRskTxReceipt, anotherRskTxHash);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+        }
+
         private void addUnprocessableReleaseTxToSet(Federation federation) {
             BtcTransaction prevTx = new BtcTransaction(params);
             Coin prevTxValue = Coin.COIN.div(2);

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -351,17 +351,29 @@ class BtcReleaseClientTest {
         // we need to manually add the sigs,
         // since the real signing is done by the bridge
 
-        private final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
-        private final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
-        private final byte[] wrongTopic = TestUtils.createHash(456).getBytes();
+        private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
+        private static final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
+        private static final byte[] WRONG_TOPIC = TestUtils.createHash(456).getBytes();
 
         // feds setup
-        private final ECKey.ECDSASignature ethSig1 = new ECKey.ECDSASignature(BigInteger.ONE, BigInteger.TEN);
-        private final BtcECKey.ECDSASignature btcSig1 = new BtcECKey.ECDSASignature(ethSig1.r, ethSig1.s);
-        private final ECKey.ECDSASignature ethSig2 = new ECKey.ECDSASignature(BigInteger.TWO, BigInteger.TEN);
-        private final BtcECKey.ECDSASignature btcSig2 = new BtcECKey.ECDSASignature(ethSig2.r, ethSig2.s);
-        private final int latestHSMVersion = TestUtils.getLatestHsmVersion().getNumber();
-        private final int keyFileVersion = 1;
+        private static final ECKey.ECDSASignature ETH_SIG_1 = new ECKey.ECDSASignature(
+            BigInteger.ONE,
+            BigInteger.TEN
+        );
+        private static final BtcECKey.ECDSASignature BTC_SIG_1 = new BtcECKey.ECDSASignature(
+            ETH_SIG_1.r,
+            ETH_SIG_1.s
+        );
+        private static final ECKey.ECDSASignature ETH_SIG_2 = new ECKey.ECDSASignature(
+            BigInteger.TWO,
+            BigInteger.TEN
+        );
+        private static final BtcECKey.ECDSASignature BTC_SIG_2 = new BtcECKey.ECDSASignature(
+            ETH_SIG_2.r,
+            ETH_SIG_2.s
+        );
+        private static final int LATEST_HSM_VERSION = TestUtils.getLatestHsmVersion().getNumber();
+        private static final int KEY_FILE_VERSION = 1;
 
         private final BtcECKey keyFile1BtcPubKey = getBtcEcKeyFromSeed("keyFile1BtcPubKey");
         private final ECKey keyFile1RskPubKey = ECKey.fromPublicOnly(keyFile1BtcPubKey.getPubKey());
@@ -488,7 +500,7 @@ class BtcReleaseClientTest {
         void processReleases_signWithKeyFile_legacyFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(legacyFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
 
@@ -498,14 +510,14 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
-            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithKeyFile_legacyFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(legacyFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
 
@@ -515,15 +527,15 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
-            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(legacyFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
 
@@ -533,14 +545,14 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(legacyFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(legacyFederation);
             addUnprocessableReleaseTxToSet(legacyFederation);
 
@@ -550,40 +562,40 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_legacyFed_ok() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(legacyFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(legacyFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_ok() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(legacyFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(legacyFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_legacyFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(legacyFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
@@ -591,13 +603,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_legacyFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(legacyFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
@@ -605,13 +617,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_whenOtherFedAlreadySigned_legacyFed_ok() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(legacyFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
@@ -619,13 +631,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_whenOtherFedAlreadySigned_legacyFed_ok() throws Exception {
             // Arrange
-            setUpFederator(legacyFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(legacyFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(legacyFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
@@ -633,14 +645,14 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(segwitFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
 
@@ -650,14 +662,14 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
-            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(segwitFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
 
@@ -667,15 +679,15 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
-            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_whenSetHasUnprocessablePegout_testnet_shouldSkipJustIt() throws Exception {
             // Arrange
             testnetPowpegNodeSetUp();
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
 
@@ -685,14 +697,14 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_whenSetHasUnprocessablePegout_mainnet_shouldSign() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
             addUnprocessableReleaseTxToSet(segwitFederation);
 
@@ -702,40 +714,40 @@ class BtcReleaseClientTest {
             }
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasSigned(unprocessableTestnetPegoutRskTxCreationHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_ok() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(segwitFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(segwitFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_ok() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // act
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_segwitFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(segwitFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
@@ -743,13 +755,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_segwitFed_whenSameFederatorAlreadySigned_shouldNotSignAgain() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
@@ -757,13 +769,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasNotSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_signWithKeyFile_whenOtherFedAlreadySigned_segwitFed_ok() throws Exception {
             // arrange
-            setUpFederator(segwitFederation, keyFile1Member, keyFileVersion, ethSig2);
+            setUpFederator(segwitFederation, keyFile1Member, KEY_FILE_VERSION, ETH_SIG_2);
             setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, hsm1BtcPubKey);
 
@@ -771,13 +783,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig2);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_2);
         }
 
         @Test
         void processReleases_signWithHSM_whenOtherFedAlreadySigned_segwitFed_ok() throws Exception {
             // Arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
             TestUtils.addSignatures(releaseTx, keyFile1BtcPubKey);
 
@@ -785,13 +797,13 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenTxHasEmptyReceipt_shouldNotSign() throws Exception {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
 
             buildReleaseTx(segwitFederation);
             addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
@@ -810,7 +822,7 @@ class BtcReleaseClientTest {
         @Test
         void processReleases_whenBlockDoesNotContainPegoutCreationRskTx_shouldNotSign() throws Exception {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
 
             // put release in set
             buildReleaseTx(segwitFederation);
@@ -834,7 +846,7 @@ class BtcReleaseClientTest {
         @Test
         void processReleases_whenFirstMatchIsFromWrongSender_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - correct topics but from another sender (not the bridge)
@@ -850,14 +862,14 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenFirstMatchHasWrongReleaseRequestedTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - wrong event topic
@@ -876,20 +888,20 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenFirstMatchHasWrongPegoutCreationRskTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - wrong pegoutCreationRskTxHash topic
             List<DataWord> topics = buildCustomTopics(
                 RELEASE_REQUESTED_EVENT,
-                List.of(wrongTopic, releaseBtcTxHashBytes)
+                List.of(WRONG_TOPIC, releaseBtcTxHashBytes)
             );
             LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
             addLogToRskTxReceipt(anotherRskTxReceipt, log);
@@ -902,20 +914,20 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenFirstMatchHasWrongPegoutBtcTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - wrong pegoutBtcTxHash topic
             List<DataWord> topics = buildCustomTopics(
                 RELEASE_REQUESTED_EVENT,
-                List.of(releaseCreationRskTxHashBytes, wrongTopic)
+                List.of(releaseCreationRskTxHashBytes, WRONG_TOPIC)
             );
             LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
             addLogToRskTxReceipt(anotherRskTxReceipt, log);
@@ -927,14 +939,14 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenFirstMatchMissesPegoutCreationRskTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - missing pegoutCreationRskTxHash topic
@@ -949,14 +961,14 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenFirstMatchMissesPegoutBtcTxHashTopic_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - missing pegoutBtcTxHash topic
@@ -971,20 +983,20 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         @Test
         void processReleases_whenFirstMatchHasExtraTopics_shouldSignCorrectTx() throws BtcReleaseClientException, SignerException {
             // arrange
-            setUpFederator(segwitFederation, hsm1Member, latestHSMVersion, ethSig1);
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             setUpReleaseTxFromFed(segwitFederation);
 
             // build tx with wrong log - one extra topic
             List<DataWord> topics = buildCustomTopics(
                 RELEASE_REQUESTED_EVENT,
-                List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, wrongTopic)
+                List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, WRONG_TOPIC)
             );
             LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
             addLogToRskTxReceipt(anotherRskTxReceipt, log);
@@ -996,8 +1008,8 @@ class BtcReleaseClientTest {
             client.processReleases(releases.entrySet());
 
             // assert
-            assertTxWasSigned(releaseCreationRskTxHash, btcSig1);
-            assertTxWasNotSigned(anotherRskTxHash, btcSig1);
+            assertTxWasSigned(releaseCreationRskTxHash, BTC_SIG_1);
+            assertTxWasNotSigned(anotherRskTxHash, BTC_SIG_1);
         }
 
         private void addUnprocessableReleaseTxToSet(Federation federation) {

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -354,6 +354,7 @@ class BtcReleaseClientTest {
 
         private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
         private static final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
+        private static final CallTransaction.Function PEGOUT_TRANSACTION_CREATED_EVENT = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
         private static final byte[] WRONG_TOPIC = TestUtils.createHash(456).getBytes();
 
         // feds setup
@@ -409,8 +410,12 @@ class BtcReleaseClientTest {
         private final RskAddress pegnatoryAddress = new RskAddress(TestUtils.getEcKeyFromSeed("pegnatory").getAddress());
         private final LogInfo updateCollectionsLog = createUpdateCollectionsLog(pegnatoryAddress);
 
+        private final Coin pegoutAmount = Coin.COIN;
+        private final byte[] releaseRequestedEventData = buildEncodedData(RELEASE_REQUESTED_EVENT, pegoutAmount.getValue());
+
         private final Coin prevReleaseTxValue = Coin.COIN;
-        private final byte[] releaseRequestedEventData = buildEncodedData(RELEASE_REQUESTED_EVENT, prevReleaseTxValue.getValue());
+        private final byte[] serializedOutpointValues = UtxoUtils.encodeOutpointValues(List.of(prevReleaseTxValue));
+        private final byte[] pegoutTransactionCreatedEventData = buildEncodedData(PEGOUT_TRANSACTION_CREATED_EVENT, serializedOutpointValues);
 
         private BtcTransaction releaseTx;
         private byte[] releaseBtcTxHashBytes;
@@ -461,7 +466,7 @@ class BtcReleaseClientTest {
             addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
 
             TransactionReceipt rskTxReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
-            addLogsForReleaseRequestedEventToTxReceipt(rskTxReceipt, releaseCreationRskTxHash, releaseTx);
+            addNeededLogsForSigning(rskTxReceipt, releaseCreationRskTxHash, releaseTx);
             setUpBlockChain(rskTxReceipt, releaseCreationRskTxHash);
         }
 
@@ -474,14 +479,22 @@ class BtcReleaseClientTest {
             rskTxsList.add(rskTx);
         }
 
-        private void addLogsForReleaseRequestedEventToTxReceipt(TransactionReceipt rskTxReceipt, Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
+        private void addNeededLogsForSigning(TransactionReceipt rskTxReceipt, Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
             addLogToRskTxReceipt(rskTxReceipt, updateCollectionsLog);
+            addValidReleaseRequestedLogs(rskTxReceipt, releaseCreationRskTxHash, releaseTx);
+            addValidPegoutTransactionCreatedEventLogs(rskTxReceipt, releaseTx);
+        }
 
+        private void addValidReleaseRequestedLogs(TransactionReceipt rskTxReceipt, Keccak256 releaseCreationRskTxHash, BtcTransaction releaseTx) {
             Sha256Hash originalReleaseTxHash = releaseTx.getHash();
             Coin prevTxValue = releaseTx.getInput(0).getValue();
             LogInfo releaseRequestedLog = createReleaseRequestedLog(releaseCreationRskTxHash, originalReleaseTxHash, prevTxValue);
             addLogToRskTxReceipt(rskTxReceipt, releaseRequestedLog);
+        }
 
+        private void addValidPegoutTransactionCreatedEventLogs(TransactionReceipt rskTxReceipt, BtcTransaction releaseTx) {
+            Sha256Hash originalReleaseTxHash = releaseTx.getHash();
+            Coin prevTxValue = releaseTx.getInput(0).getValue();
             byte[] serializedOutpointValues = UtxoUtils.encodeOutpointValues(List.of(prevTxValue));
             LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(originalReleaseTxHash, serializedOutpointValues);
             addLogToRskTxReceipt(rskTxReceipt, pegoutTransactionCreatedLog);
@@ -848,7 +861,7 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogsAreFromWrongSender_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogIsFromWrongSender_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - correct topics but from another sender (not the bridge)
@@ -859,7 +872,7 @@ class BtcReleaseClientTest {
             );
             byte[] sender = org.bouncycastle.util.encoders.Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
             LogInfo wrongLog = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -869,7 +882,7 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogHasWrongReleaseRequestedTopic_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogHasWrongReleaseRequestedTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - wrong event topic
@@ -879,7 +892,7 @@ class BtcReleaseClientTest {
                 List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes)
             );
             LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -889,7 +902,7 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogHasWrongPegoutCreationRskTxHashTopic_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogHasWrongPegoutCreationRskTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - wrong pegoutCreationRskTxHash topic
@@ -898,7 +911,7 @@ class BtcReleaseClientTest {
                 List.of(WRONG_TOPIC, releaseBtcTxHashBytes)
             );
             LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -908,7 +921,7 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogHasWrongPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogHasWrongPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - wrong pegoutBtcTxHash topic
@@ -917,7 +930,7 @@ class BtcReleaseClientTest {
                 List.of(releaseCreationRskTxHashBytes, WRONG_TOPIC)
             );
             LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -927,13 +940,13 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogMissesPegoutCreationRskTxHashTopic_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogMissesPegoutCreationRskTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - missing pegoutCreationRskTxHash topic
             List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseBtcTxHashBytes));
             LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -943,13 +956,13 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogMissesPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogMissesPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - missing pegoutBtcTxHash topic
             List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseCreationRskTxHashBytes));
             LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -959,7 +972,7 @@ class BtcReleaseClientTest {
         }
 
         @Test
-        void processReleases_whenLogHasExtraTopics_shouldNotSign() throws Exception {
+        void processReleases_whenReleaseRequestedLogHasExtraTopics_shouldNotSign() throws Exception {
             // arrange
             setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
             // build wrong log - one extra topic
@@ -968,7 +981,7 @@ class BtcReleaseClientTest {
                 List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, WRONG_TOPIC)
             );
             LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-            setUpReleaseTxWithWrongLog(wrongLog);
+            setUpReleaseTxWithWrongReleaseRequestedLog(wrongLog);
 
             // act
             client.processReleases(releases.entrySet());
@@ -986,7 +999,7 @@ class BtcReleaseClientTest {
             addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
             // but put the logs in another rsk tx
             TransactionReceipt anotherRskTxReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
-            addLogsForReleaseRequestedEventToTxReceipt(anotherRskTxReceipt, releaseCreationRskTxHash, releaseTx);
+            addNeededLogsForSigning(anotherRskTxReceipt, releaseCreationRskTxHash, releaseTx);
 
             // act
             client.processReleases(releases.entrySet());
@@ -995,18 +1008,121 @@ class BtcReleaseClientTest {
             verify(federatorSupport, never()).addSignature(anyList(), any(byte[].class));
         }
 
-        private void setUpReleaseTxWithWrongLog(LogInfo wrongLog) {
+        private void setUpReleaseTxWithWrongReleaseRequestedLog(LogInfo wrongLog) {
             buildReleaseTx(segwitFederation);
             addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
 
             TransactionReceipt rskTxReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
-            addLogToRskTxReceipt(rskTxReceipt, wrongLog);
 
-            Sha256Hash originalReleaseTxHash = releaseTx.getHash();
-            Coin prevTxValue = releaseTx.getInput(0).getValue();
-            byte[] serializedOutpointValues = UtxoUtils.encodeOutpointValues(List.of(prevTxValue));
-            LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(originalReleaseTxHash, serializedOutpointValues);
-            addLogToRskTxReceipt(rskTxReceipt, pegoutTransactionCreatedLog);
+            addLogToRskTxReceipt(rskTxReceipt, wrongLog);
+            addValidPegoutTransactionCreatedEventLogs(rskTxReceipt, releaseTx);
+
+            setUpBlockChain(rskTxReceipt, releaseCreationRskTxHash);
+        }
+
+        @Test
+        void processReleases_whenPegoutTransactionCreatedLogFromWrongSender_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
+            // build wrong log - correct topics but from another sender (not the bridge)
+            buildReleaseTx(segwitFederation);
+            List<DataWord> topics = buildCustomTopics(
+                PEGOUT_TRANSACTION_CREATED_EVENT,
+                List.of(releaseBtcTxHashBytes)
+            );
+            byte[] sender = org.bouncycastle.util.encoders.Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+            LogInfo wrongPegoutLog = buildLogInfoFrom(sender, topics, pegoutTransactionCreatedEventData);
+            setUpReleaseTxWithWrongPegoutTransactionCreatedLog(wrongPegoutLog);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
+        }
+
+        @Test
+        void processReleases_whenPegoutTransactionCreatedLogHasWrongEventTopic_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
+            // build wrong log - wrong event topic
+            buildReleaseTx(segwitFederation);
+            CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
+            List<DataWord> topics = buildCustomTopics(wrongEvent, List.of(releaseBtcTxHashBytes));
+            LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+            setUpReleaseTxWithWrongPegoutTransactionCreatedLog(wrongPegoutLog);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
+        }
+
+        @Test
+        void processReleases_whenPegoutTransactionCreatedLogHasWrongPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
+            // build wrong log - wrong pegoutBtcTxHash topic
+            buildReleaseTx(segwitFederation);
+            List<DataWord> topics = buildCustomTopics(
+                PEGOUT_TRANSACTION_CREATED_EVENT,
+                List.of(WRONG_TOPIC)
+            );
+            LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+            setUpReleaseTxWithWrongPegoutTransactionCreatedLog(wrongPegoutLog);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
+        }
+
+        @Test
+        void processReleases_whenPegoutTransactionCreatedLogMissesPegoutBtcTxHashTopic_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
+            // build wrong log - missing pegoutBtcTxHash topic
+            buildReleaseTx(segwitFederation);
+            List<DataWord> topics = buildCustomTopics(PEGOUT_TRANSACTION_CREATED_EVENT, List.of());
+            LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+            setUpReleaseTxWithWrongPegoutTransactionCreatedLog(wrongPegoutLog);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
+        }
+
+        @Test
+        void processReleases_whenPegoutTransactionCreatedLogHasExtraTopics_shouldNotSign() throws Exception {
+            // arrange
+            setUpFederator(segwitFederation, hsm1Member, LATEST_HSM_VERSION, ETH_SIG_1);
+            // build wrong log - one extra topic
+            buildReleaseTx(segwitFederation);
+            List<DataWord> topics = buildCustomTopics(
+                PEGOUT_TRANSACTION_CREATED_EVENT,
+                List.of(releaseBtcTxHashBytes, WRONG_TOPIC)
+            );
+            LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+            setUpReleaseTxWithWrongPegoutTransactionCreatedLog(wrongPegoutLog);
+
+            // act
+            client.processReleases(releases.entrySet());
+
+            // assert
+            assertTxWasNotSigned(releaseCreationRskTxHash, BTC_SIG_1);
+        }
+
+        private void setUpReleaseTxWithWrongPegoutTransactionCreatedLog(LogInfo wrongLog) {
+            addReleaseTxToSet(releaseCreationRskTxHash, releaseTx);
+
+            TransactionReceipt rskTxReceipt = buildTxReceiptForRskTx(releaseCreationRskTxHash);
+
+            addValidReleaseRequestedLogs(rskTxReceipt, releaseCreationRskTxHash, releaseTx);
+            addLogToRskTxReceipt(rskTxReceipt, wrongLog);
 
             setUpBlockChain(rskTxReceipt, releaseCreationRskTxHash);
         }

--- a/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
@@ -8,7 +8,7 @@ import static co.rsk.federate.signing.HSMCommand.SIGN;
 import static co.rsk.federate.signing.HSMField.*;
 import static co.rsk.federate.signing.hsm.config.PowHSMConfigParameter.INTERVAL_BETWEEN_ATTEMPTS;
 import static co.rsk.federate.signing.hsm.config.PowHSMConfigParameter.MAX_ATTEMPTS;
-import static co.rsk.federate.signing.utils.TestUtils.createBlock;
+import static co.rsk.federate.signing.utils.TestUtils.createBlockWithTxs;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -84,7 +84,7 @@ class PowHSMSigningClientBtcTest {
         when(pegoutCreationRskTx.getHash()).thenReturn(pegoutCreationRskTxHash);
         when(pegoutCreationRskTx.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
 
-        pegoutCreationBlock = createBlock(Collections.singletonList(pegoutCreationRskTx));
+        pegoutCreationBlock = createBlockWithTxs(Collections.singletonList(pegoutCreationRskTx));
 
         pegoutCreationRskTxReceipt = new TransactionReceipt();
         pegoutCreationRskTxReceipt.setLogInfoList(Collections.emptyList());

--- a/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/client/PowHSMSigningClientBtcTest.java
@@ -250,9 +250,18 @@ class PowHSMSigningClientBtcTest {
         pegoutCreationRskTxReceipt.setLogInfoList(logs);
         pegoutCreationRskTxReceipt.setTransaction(pegoutCreationRskTx);
 
+        List<Coin> outpointValues = new ArrayList<>();
+        for (int i=0; i < pegoutBtcTx.getInputs().size(); i++) {
+            TransactionInput input = pegoutBtcTx.getInput(i);
+            outpointValues.add(input.getValue());
+        }
         ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
-            pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx);
+            pegoutCreationBlock,
+            pegoutCreationRskTxReceipt,
+            pegoutCreationRskTx.getHash(),
+            pegoutBtcTx,
+            outpointValues
+        );
 
         client = new PowHSMSigningClientBtc(hsmClientProtocol, hsmVersion);
 
@@ -286,9 +295,18 @@ class PowHSMSigningClientBtcTest {
         pegoutCreationRskTxReceipt.setLogInfoList(logs);
         pegoutCreationRskTxReceipt.setTransaction(pegoutCreationRskTx);
 
+        List<Coin> outpointValues = new ArrayList<>();
+        for (int i=0; i < pegoutBtcTx.getInputs().size(); i++) {
+            TransactionInput input = pegoutBtcTx.getInput(i);
+            outpointValues.add(input.getValue());
+        }
         ReleaseCreationInformation releaseCreationInformation = new ReleaseCreationInformation(
-            pegoutCreationBlock, pegoutCreationRskTxReceipt, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx);
+            pegoutCreationBlock,
+            pegoutCreationRskTxReceipt,
+            pegoutCreationRskTx.getHash(),
+            pegoutBtcTx,
+            outpointValues
+        );
 
         client = new PowHSMSigningClientBtc(hsmClientProtocol, hsmVersion);
 

--- a/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/PowHSMSignerMessageBuilderTest.java
@@ -1,8 +1,7 @@
 package co.rsk.federate.signing.hsm.message;
 
 import static co.rsk.federate.EventsTestUtils.*;
-import static co.rsk.federate.bitcoin.BitcoinTestUtils.coinListOf;
-import static co.rsk.federate.bitcoin.BitcoinTestUtils.createPegout;
+import static co.rsk.federate.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.federate.signing.HSMField.TX;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -116,7 +115,8 @@ class PowHSMSignerMessageBuilderTest {
             pegoutCreationBlock,
             pegoutCreationRskTxReceipt,
             pegoutCreationRskTx.getHash(),
-            pegoutBtcTx
+            pegoutBtcTx,
+            outpointValues
         );
         SigHashCalculator sigHashCalculator = new SegwitSigHashCalculatorImpl(outpointValues);
         PowHSMSignerMessageBuilder messageBuilder = new PowHSMSignerMessageBuilder(
@@ -177,7 +177,8 @@ class PowHSMSignerMessageBuilderTest {
             block,
             pegoutCreationRskTxReceipt,
             pegoutCreationRskTx.getHash(),
-            mock(BtcTransaction.class)
+            mock(BtcTransaction.class),
+            Collections.emptyList()
         );
         SigHashCalculator sigHashCalculator = new LegacySigHashCalculatorImpl();
         PowHSMSignerMessageBuilder signerMessageBuilder = new PowHSMSignerMessageBuilder(
@@ -310,11 +311,17 @@ class PowHSMSignerMessageBuilderTest {
         List<Coin> expectedOutpointValues,
         BtcTransaction pegoutBtcTx
     ) throws SignerMessageBuilderException {
+        List<Coin> outpointValues = new ArrayList<>();
+        for (int i=0; i < pegoutBtcTx.getInputs().size(); i++) {
+            TransactionInput input = pegoutBtcTx.getInput(i);
+            outpointValues.add(input.getValue());
+        }
         ReleaseCreationInformation releaseInformation = new ReleaseCreationInformation(
             pegoutCreationBlock,
             pegoutCreationRskTxReceipt,
             pegoutCreationRskTx.getHash(),
-            pegoutBtcTx
+            pegoutBtcTx,
+            outpointValues
         );
 
         List<Coin> actualOutpointValues = releaseInformation.getUtxoOutpointValues();

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -1,16 +1,8 @@
 package co.rsk.federate.signing.hsm.message;
 
-import static co.rsk.federate.EventsTestUtils.createRejectedPeginLog;
-import static co.rsk.federate.EventsTestUtils.createBatchPegoutCreatedLog;
-import static co.rsk.federate.EventsTestUtils.createPegoutTransactionCreatedLog;
-import static co.rsk.federate.EventsTestUtils.createReleaseRequestedLog;
-import static co.rsk.federate.EventsTestUtils.createUpdateCollectionsLog;
-import static co.rsk.federate.bitcoin.BitcoinTestUtils.coinListOf;
-import static co.rsk.federate.signing.utils.TestUtils.createBlock;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.anyLong;
+import static co.rsk.federate.EventsTestUtils.*;
+import static co.rsk.federate.signing.utils.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,18 +15,12 @@ import co.rsk.federate.bitcoin.BitcoinTestUtils;
 import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.BridgeEvents;
-import co.rsk.peg.bitcoin.UtxoUtils;
 import co.rsk.peg.pegin.RejectedPeginReason;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+
+import java.util.*;
+
 import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.core.Block;
-import org.ethereum.core.CallTransaction;
-import org.ethereum.core.Transaction;
-import org.ethereum.core.TransactionReceipt;
-import org.ethereum.crypto.ECKey;
+import org.ethereum.core.*;
 import org.ethereum.db.BlockStore;
 import org.ethereum.db.ReceiptStore;
 import org.ethereum.db.TransactionInfo;
@@ -44,466 +30,220 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class ReleaseCreationInformationGetterTest {
+    private final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
+    private final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
+    private final HSMVersion latestHSMVersion = TestUtils.getLatestHsmVersion();
+
+    private final Sha256Hash releaseBtcTxHash = BitcoinTestUtils.createHash(1);
+    private final byte[] releaseBtcTxHashBytes = releaseBtcTxHash.getBytes();
+    private final byte[] serializedOutpointsValues = Hex.decode("FE80F0FA02FEC0687804FE00E1F505"); // 50_000_000 = FE80F0FA02, 75_000_000 = FEC0687804, 100_000_000 = FE00E1F505
+    private final LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(releaseBtcTxHash, serializedOutpointsValues);
+
+    private final Keccak256 pegoutCreationRskTxHash = TestUtils.createHash(2);
+    private final byte[] releaseCreationRskTxHashBytes = pegoutCreationRskTxHash.getBytes();
+    private final Coin pegoutAmount = Coin.COIN;
+
+    private final LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTxHash, releaseBtcTxHash, pegoutAmount);
+    private final byte[] releaseRequestedEventData = buildEncodedData(RELEASE_REQUESTED_EVENT, pegoutAmount.getValue());
+
+    private final RskAddress senderAddress = new RskAddress(TestUtils.getEcKeyFromSeed("senderKey").getAddress());
+    private final LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
+
+    private final Keccak256 anotherRskTxHash = TestUtils.createHash(123);
+    private final byte[] anotherRskTxHashBytes = anotherRskTxHash.getBytes();
+
+    private final byte[] wrongTopic = TestUtils.createHash(456).getBytes();
+
     private BtcTransaction pegoutBtcTx;
-    private Transaction pegoutCreationRskTx;
     private Block pegoutCreationBlock;
+
+    private Transaction pegoutCreationRskTx;
     private TransactionReceipt pegoutCreationRskTxReceipt;
     private TransactionInfo pegoutCreationRskTxInfo;
+
+    private Transaction anotherRskTx;
+    private TransactionReceipt anotherRskTxReceipt;
+    private TransactionInfo anotherRskTxInfo;
+
     private ReceiptStore receiptStore;
     private BlockStore blockStore;
-    private static final HSMVersion hsmVersion = TestUtils.getLatestHsmVersion();
 
     @BeforeEach
     void setUp() {
-        Sha256Hash pegoutBtcTxHash = BitcoinTestUtils.createHash(1);
-        pegoutBtcTx = mock(BtcTransaction.class);
-        when(pegoutBtcTx.getHash()).thenReturn(pegoutBtcTxHash);
+        receiptStore = mock(ReceiptStore.class);
+        blockStore = mock(BlockStore.class);
 
-        Keccak256 pegoutCreationRskTxHash = TestUtils.createHash(2);
+        pegoutBtcTx = mock(BtcTransaction.class);
+        when(pegoutBtcTx.getHash()).thenReturn(releaseBtcTxHash);
+
         pegoutCreationRskTx = mock(Transaction.class);
         when(pegoutCreationRskTx.getHash()).thenReturn(pegoutCreationRskTxHash);
         when(pegoutCreationRskTx.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
 
-        pegoutCreationBlock = createBlock(Collections.singletonList(pegoutCreationRskTx));
+        anotherRskTx = mock(Transaction.class);
+        when(anotherRskTx.getHash()).thenReturn(anotherRskTxHash);
 
         pegoutCreationRskTxReceipt = new TransactionReceipt();
-        pegoutCreationRskTxReceipt.setLogInfoList(Collections.emptyList());
+        addReleaseRequestedLogs();
 
-        pegoutCreationRskTxInfo = mock(TransactionInfo.class);
-        when(pegoutCreationRskTxInfo.getReceipt()).thenReturn(pegoutCreationRskTxReceipt);
-        when(pegoutCreationRskTxInfo.getBlockHash()).thenReturn(
-            pegoutCreationBlock.getHash().getBytes());
+        anotherRskTxReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
 
-        blockStore = mock(BlockStore.class);
-        when(blockStore.getBlockByHash(pegoutCreationBlock.getHash().getBytes())).thenReturn(
-            pegoutCreationBlock);
-        when(blockStore.getChainBlockByNumber(pegoutCreationBlock.getNumber())).thenReturn(
-            pegoutCreationBlock);
+        pegoutCreationBlock = createBlockWithTxs(Arrays.asList(anotherRskTx, pegoutCreationRskTx));
+        setUpBlockchain();
+    }
 
-        receiptStore = mock(ReceiptStore.class);
-        when(receiptStore.get(pegoutCreationRskTx.getHash().getBytes(),
-            pegoutCreationBlock.getHash().getBytes())).thenReturn(
-            Optional.of(pegoutCreationRskTxInfo));
+    private void addReleaseRequestedLogs() {
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, updateCollectionsLog);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, releaseRequestedLog);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
+    }
 
-        when(receiptStore.getInMainChain(pegoutCreationRskTx.getHash().getBytes(),
-            blockStore)).thenReturn(Optional.of(
-            pegoutCreationRskTxInfo));
+    private void setUpBlockchain() {
+        setUpAnotherRskTxInfo();
+        setUpPegoutCreationRskTxInfo();
+
+        byte[] pegoutCreationBlockHash = pegoutCreationBlock.getHash().getBytes();
+        when(blockStore.getBlockByHash(pegoutCreationBlockHash))
+            .thenReturn(pegoutCreationBlock);
+        when(receiptStore.get(releaseCreationRskTxHashBytes, pegoutCreationBlockHash))
+            .thenReturn(Optional.of(pegoutCreationRskTxInfo));
+
+        when(blockStore.getChainBlockByNumber(pegoutCreationBlock.getNumber()))
+            .thenReturn(pegoutCreationBlock);
+        when(receiptStore.getInMainChain(releaseCreationRskTxHashBytes, blockStore))
+            .thenReturn(Optional.of(pegoutCreationRskTxInfo));
+        when(receiptStore.getInMainChain(anotherRskTxHashBytes, blockStore))
+            .thenReturn(Optional.of(anotherRskTxInfo));
+    }
+
+    private void setUpAnotherRskTxInfo() {
+        int anotherTxIndex = 0;
+        anotherRskTxInfo = buildTxInfo(anotherRskTxReceipt, pegoutCreationBlock.getHash(), anotherTxIndex);
+    }
+
+    private void setUpPegoutCreationRskTxInfo() {
+        int pegoutCreationTxIndex = 1;
+        pegoutCreationRskTxInfo = buildTxInfo(pegoutCreationRskTxReceipt, pegoutCreationBlock.getHash(), pegoutCreationTxIndex);
     }
 
     @ParameterizedTest
     @EnumSource(HSMVersion.class)
-    void createGetTxInfoToSign_returnOK(HSMVersion hsmVersion)
-        throws HSMReleaseCreationInformationException {
-        List<LogInfo> logs = new ArrayList<>();
+    void getTxInfoToSign_differentHSMVersions_returnsCorrectTxInfo(HSMVersion hsmVersion) throws HSMReleaseCreationInformationException {
+        // act
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
-        ECKey senderKey = TestUtils.getEcKeyFromSeed("senderKey");
-        RskAddress senderAddress = new RskAddress(senderKey.getAddress());
-        LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
-        logs.add(updateCollectionsLog);
+        // assert
+        assertTxInfoToSign(releaseCreationInformationGetter, hsmVersion.getNumber());
+    }
 
-        Coin pegoutAmount = mock(Coin.class);
-        LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
-            pegoutBtcTx.getHash(), pegoutAmount);
-        logs.add(releaseRequestedLog);
+    @Test
+    void getTxInfoToSign_whenBatchPegoutHasPegoutTransactionCreatedEvent_returnsCorrectTxInfo() throws HSMReleaseCreationInformationException {
+        // Arrange
+        List<Keccak256> pegoutRequestsRskTxHashes = Collections.singletonList(TestUtils.createHash(10));
+        LogInfo batchPegoutCreatedLog = createBatchPegoutCreatedLog(releaseBtcTxHash, pegoutRequestsRskTxHashes);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, batchPegoutCreatedLog);
 
-        pegoutCreationRskTxReceipt.setLogInfoList(logs);
-
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
+        // act
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
             receiptStore,
             blockStore
         );
 
-        createGetTxInfoToSign_returnOK(pegoutCreationInformation, pegoutCreationRskTx.getHash(),
-            pegoutBtcTx, pegoutCreationBlock, pegoutCreationRskTxReceipt, hsmVersion.getNumber());
+        // assert
+        assertTxInfoToSign(releaseCreationInformationGetter, latestHSMVersion.getNumber());
     }
 
-    private void createGetTxInfoToSign_returnOK(
-        ReleaseCreationInformationGetter pegoutCreationInformationGetter,
-        Keccak256 rskTxHash,
-        BtcTransaction pegoutBtcTransaction,
-        Block block,
-        TransactionReceipt transactionReceipt,
-        int hsmVersion) throws HSMReleaseCreationInformationException {
-        ReleaseCreationInformation pegoutCreationInfo = pegoutCreationInformationGetter.getTxInfoToSign(
+    @Test
+    void getTxInfoToSign_whenRejectedPeginHasPegoutCreatedEvent_returnsCorrectTxInfo() throws HSMReleaseCreationInformationException {
+        // Arrange
+        LogInfo rejectedPeginLog = createRejectedPeginLog(releaseBtcTxHash, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, rejectedPeginLog);
+
+        // act
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
+            receiptStore,
+            blockStore
+        );
+
+        // assert
+        assertTxInfoToSign(releaseCreationInformationGetter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_wrongHSMVersion_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
+            receiptStore,
+            blockStore
+        );
+        int wrongHSMVersion = 2;
+
+        // act & assert
+        assertThrows(HSMReleaseCreationInformationException.class,
+            () -> pegoutCreationInformation.getTxInfoToSign(
+                wrongHSMVersion,
+                pegoutCreationRskTxHash,
+                pegoutBtcTx
+            ));
+    }
+
+    @Test
+    void getTxInfoToSign_whenTxHasEmptyReceipt_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // rsk tx receipt does not have release requested logs
+        pegoutCreationRskTxReceipt = new TransactionReceipt();
+        pegoutCreationRskTxReceipt.setLogInfoList(Collections.emptyList());
+        setUpBlockchain();
+
+        // act
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
+    }
+
+    @Test
+    void getTxInfoToSign_whenBlockDoesNotContainPegoutCreationRskTx_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // simulate pegout creation block does not have pegoutCreationRskTx
+        pegoutCreationBlock = createBlockWithTxs(Collections.singletonList(anotherRskTx));
+        setUpBlockchain();
+
+        // act
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
+            receiptStore,
+            blockStore
+        );
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
+    }
+
+    private void assertTxInfoToSign(
+        ReleaseCreationInformationGetter releaseCreationInformationGetter,
+        int hsmVersion
+    ) throws HSMReleaseCreationInformationException {
+        ReleaseCreationInformation pegoutCreationInfo = releaseCreationInformationGetter.getTxInfoToSign(
             hsmVersion,
-            rskTxHash,
-            pegoutBtcTransaction
+            pegoutCreationRskTxHash,
+            pegoutBtcTx
         );
 
-        assertEquals(block, pegoutCreationInfo.getPegoutCreationBlock());
-        assertEquals(transactionReceipt, pegoutCreationInfo.getTransactionReceipt());
-        assertEquals(rskTxHash, pegoutCreationInfo.getPegoutCreationRskTxHash());
-        assertEquals(pegoutBtcTransaction, pegoutCreationInfo.getPegoutBtcTx());
+        assertEquals(pegoutCreationBlock.getHash(), pegoutCreationInfo.getPegoutCreationBlock().getHash());
+        assertEquals(pegoutCreationRskTxReceipt, pegoutCreationInfo.getTransactionReceipt());
+        assertEquals(pegoutCreationRskTxHash, pegoutCreationInfo.getPegoutCreationRskTxHash());
+        assertEquals(pegoutBtcTx, pegoutCreationInfo.getPegoutBtcTx());
     }
 
-    @Test
-    void createGetTxInfoToSign_whenEventIsNotFoundInThePegoutCreationBlock_throwsAnException() {
-        Keccak256 blockHash = TestUtils.createHash(3);
-        Keccak256 rskTxHash = TestUtils.createHash(1);
-
-        Transaction transaction = mock(Transaction.class);
-        when(transaction.getHash()).thenReturn(rskTxHash);
-        when(transaction.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
-
-        TransactionReceipt transactionReceipt = mock(TransactionReceipt.class);
-        when(transactionReceipt.getTransaction()).thenReturn(transaction);
-        when(transactionReceipt.getLogInfoList()).thenReturn(new ArrayList<>());
-
-        TransactionInfo transactionInfo = mock(TransactionInfo.class);
-        when(transactionInfo.getReceipt()).thenReturn(transactionReceipt);
-        when(transactionInfo.getBlockHash()).thenReturn(blockHash.getBytes());
-
-        Block block = mock(Block.class);
-        when(block.getHash()).thenReturn(blockHash);
-        when(block.getTransactionsList()).thenReturn(Collections.singletonList(transaction));
-
-        // 2nd block
-        Keccak256 secondBlockHash = TestUtils.createHash(5);
-        Keccak256 rskTxHashInSecondBlock = TestUtils.createHash(4);
-        byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
-        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
-
-        CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
-        byte[] releaseRequestedSignatureTopic = releaseRequestedEvent.encodeSignatureLong();
-        List<DataWord> topics = new ArrayList<>();
-        topics.add(DataWord.valueOf(releaseRequestedSignatureTopic));
-        topics.add(DataWord.valueOf(rskTxHashInSecondBlock.getBytes()));
-        topics.add(DataWord.valueOf(btcTxHash));
-
-        List<LogInfo> logs = new ArrayList<>();
-        logs.add(new LogInfo(PrecompiledContracts.BRIDGE_ADDR.getBytes(), topics, null));
-
-        Transaction transactionInSecondBlock = mock(Transaction.class);
-        when(transactionInSecondBlock.getHash()).thenReturn(rskTxHashInSecondBlock);
-        when(transactionInSecondBlock.getReceiveAddress()).thenReturn(
-            PrecompiledContracts.BRIDGE_ADDR);
-
-        TransactionReceipt transactionReceiptInSecondBlock = mock(TransactionReceipt.class);
-        when(transactionReceiptInSecondBlock.getTransaction()).thenReturn(transactionInSecondBlock);
-        when(transactionReceiptInSecondBlock.getLogInfoList()).thenReturn(logs);
-
-        TransactionInfo transactionInfoInSecondBlock = mock(TransactionInfo.class);
-        when(transactionInfoInSecondBlock.getReceipt()).thenReturn(transactionReceiptInSecondBlock);
-        when(transactionInfoInSecondBlock.getBlockHash()).thenReturn(secondBlockHash.getBytes());
-
-        Block secondBlock = mock(Block.class);
-        when(secondBlock.getHash()).thenReturn(secondBlockHash);
-        when(secondBlock.getTransactionsList()).thenReturn(
-            Collections.singletonList(transactionInSecondBlock));
-
-        blockStore = mock(BlockStore.class);
-        when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
-        when(blockStore.getChainBlockByNumber(anyLong())).thenReturn(secondBlock);
-
-        receiptStore = mock(ReceiptStore.class);
-        when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(
-            Optional.of(transactionInfo));
-        when(receiptStore.getInMainChain(rskTxHashInSecondBlock.getBytes(), blockStore)).thenReturn(
-            Optional.of(transactionInfoInSecondBlock));
-
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        assertThrows(
-            HSMReleaseCreationInformationException.class,
-            () -> pegoutCreationInformation.getTxInfoToSign(hsmVersion.getNumber(), rskTxHash, pegoutBtcTransaction)
-        );
-    }
-
-    @Test
-    void createGetTxInfoToSign_transactionHashNotFoundInBlock() {
-        Keccak256 blockHash = TestUtils.createHash(3);
-        Block block = mock(Block.class);
-        when(block.getHash()).thenReturn(blockHash);
-        when(block.getTransactionsList()).thenReturn(new ArrayList<>());
-
-        blockStore = mock(BlockStore.class);
-        when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
-
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
+    private void assertThrowsHSMReleaseCreationInformationException(ReleaseCreationInformationGetter releaseCreationInformationGetter) {
         assertThrows(HSMReleaseCreationInformationException.class,
-            () -> pegoutCreationInformation.getTxInfoToSign(
-                hsmVersion.getNumber(),
+            () -> releaseCreationInformationGetter.getTxInfoToSign(
+                latestHSMVersion.getNumber(),
                 pegoutCreationRskTx.getHash(),
                 pegoutBtcTx
             ));
-    }
-
-    @Test
-    void createGetTxInfoToSignV2_noEventFound_noBlockFound() {
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        assertThrows(HSMReleaseCreationInformationException.class,
-            () -> pegoutCreationInformation.getTxInfoToSign(
-                2,
-                pegoutCreationRskTx.getHash(),
-                pegoutBtcTx
-            ));
-    }
-
-    @Test
-    void createGetTxInfoToSignV2_noEventFound_BestBlockFound() {
-        Keccak256 blockHash = TestUtils.createHash(3);
-        long blockNumber = 4L;
-        Block block = mock(Block.class);
-        when(block.getHash()).thenReturn(blockHash);
-        when(block.getNumber()).thenReturn(blockNumber);
-
-        blockStore = mock(BlockStore.class);
-        when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
-        when(blockStore.getChainBlockByNumber(blockNumber)).thenReturn(block);
-        when(blockStore.getBestBlock()).thenReturn(block);
-
-        Keccak256 rskTxHash = pegoutCreationRskTx.getHash();
-
-        receiptStore = mock(ReceiptStore.class);
-        when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(
-            Optional.of(pegoutCreationRskTxInfo));
-
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        assertThrows(HSMReleaseCreationInformationException.class,
-            () -> pegoutCreationInformation.getTxInfoToSign(
-                2,
-                rskTxHash,
-                pegoutBtcTx
-            ));
-    }
-
-    @Test
-    void getTxInfoToSign_whenTransactionReceiptNotFoundInSubsequentBlock_shouldThrowHSMReleaseCreationInformationException() {
-        // The event that is searched is not found in the first block
-        Keccak256 blockHash = TestUtils.createHash(3);
-
-        Block block = mock(Block.class);
-        when(block.getHash()).thenReturn(blockHash);
-        when(block.getTransactionsList()).thenReturn(Collections.singletonList(pegoutCreationRskTx));
-
-        // The event is now searched in the following block
-        Keccak256 secondBlockHash = TestUtils.createHash(5);
-        Keccak256 rskTxHashInSecondBlock = TestUtils.createHash(4);
-
-        Transaction transactionInSecondBlock = mock(Transaction.class);
-        when(transactionInSecondBlock.getHash()).thenReturn(rskTxHashInSecondBlock);
-
-        Block secondBlock = mock(Block.class);
-        when(secondBlock.getHash()).thenReturn(secondBlockHash);
-        when(secondBlock.getTransactionsList()).thenReturn(
-            Collections.singletonList(transactionInSecondBlock));
-
-        blockStore = mock(BlockStore.class);
-        when(blockStore.getBlockByHash(blockHash.getBytes())).thenReturn(block);
-        when(blockStore.getChainBlockByNumber(anyLong())).thenReturn(secondBlock);
-
-        Keccak256 rskTxHash = pegoutCreationRskTx.getHash();
-
-        receiptStore = mock(ReceiptStore.class);
-        when(receiptStore.getInMainChain(rskTxHash.getBytes(), blockStore)).thenReturn(
-            Optional.of(pegoutCreationRskTxInfo));
-        when(receiptStore.getInMainChain(rskTxHashInSecondBlock.getBytes(), blockStore)).thenReturn(
-            Optional.empty());
-
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        BtcTransaction pegoutBtcTransaction = mock(BtcTransaction.class);
-        byte[] btcTxHash = TestUtils.createHash(2).getBytes();
-        when(pegoutBtcTransaction.getHash()).thenReturn(Sha256Hash.wrap(btcTxHash));
-
-        assertThrows(HSMReleaseCreationInformationException.class,
-            () -> pegoutCreationInformation.getTxInfoToSign(
-                2,
-                rskTxHash,
-                pegoutBtcTransaction
-            ));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTxInfoToSignArgProvider")
-    void getTxInfoToSign_whenBatchPegoutHasPegoutTransactionCreatedEvent_returnsOk(
-        int version,
-        byte[] serializedOutpointValues,
-        List<Coin> expectedOutpointValues
-    ) throws HSMReleaseCreationInformationException {
-        // Arrange
-        List<LogInfo> logs = new ArrayList<>();
-
-        addCommonPegoutLogs(logs, pegoutBtcTx, serializedOutpointValues);
-
-        List<Keccak256> pegoutRequestRskTxHashes = Collections.singletonList(
-            TestUtils.createHash(10));
-        LogInfo batchPegoutCreatedLog = createBatchPegoutCreatedLog(pegoutBtcTx.getHash(),
-            pegoutRequestRskTxHashes);
-        logs.add(batchPegoutCreatedLog);
-
-        ECKey senderKey = TestUtils.getEcKeyFromSeed("senderKey");
-        RskAddress senderAddress = new RskAddress(senderKey.getAddress());
-        LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
-        logs.add(updateCollectionsLog);
-
-        pegoutCreationRskTxReceipt.setLogInfoList(logs);
-
-        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        // act
-        ReleaseCreationInformation pegoutCreationInfo = releaseCreationInformationGetter.getTxInfoToSign(
-            version,
-            pegoutCreationRskTx.getHash(),
-            pegoutBtcTx
-        );
-
-        // assert
-        assertEquals(pegoutCreationBlock, pegoutCreationInfo.getPegoutCreationBlock());
-        assertEquals(pegoutCreationRskTxReceipt, pegoutCreationInfo.getTransactionReceipt());
-        assertEquals(pegoutCreationRskTx.getHash(),
-            pegoutCreationInfo.getPegoutCreationRskTxHash());
-        assertEquals(pegoutBtcTx, pegoutCreationInfo.getPegoutBtcTx());
-        assertArrayEquals(expectedOutpointValues.toArray(),
-            pegoutCreationInfo.getUtxoOutpointValues().toArray());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTxInfoToSignArgProvider")
-    void getTxInfoToSign_whenMigrationHasPegoutCreatedEvent_returnsOk(
-        int version,
-        byte[] serializedOutpointValues,
-        List<Coin> expectedOutpointValues
-    ) throws HSMReleaseCreationInformationException {
-        // Arrange
-        List<Coin> outpointValues = UtxoUtils.decodeOutpointValues(serializedOutpointValues);
-        when(pegoutBtcTx.getInputSum()).thenReturn(
-            outpointValues.stream().reduce(Coin.ZERO, Coin::add));
-
-        List<LogInfo> logs = new ArrayList<>();
-
-        ECKey senderKey = TestUtils.getEcKeyFromSeed("senderKey");
-        RskAddress senderAddress = new RskAddress(senderKey.getAddress());
-        LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
-        logs.add(updateCollectionsLog);
-
-        addCommonPegoutLogs(logs, pegoutBtcTx, serializedOutpointValues);
-
-        pegoutCreationRskTxReceipt.setLogInfoList(logs);
-
-        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        // act
-        ReleaseCreationInformation pegoutCreationInfo = releaseCreationInformationGetter.getTxInfoToSign(
-            version,
-            pegoutCreationRskTx.getHash(),
-            pegoutBtcTx
-        );
-
-        // assert
-        assertEquals(pegoutCreationBlock, pegoutCreationInfo.getPegoutCreationBlock());
-        assertEquals(pegoutCreationRskTxReceipt, pegoutCreationInfo.getTransactionReceipt());
-        assertEquals(pegoutCreationRskTx.getHash(),
-            pegoutCreationInfo.getPegoutCreationRskTxHash());
-        assertEquals(pegoutBtcTx, pegoutCreationInfo.getPegoutBtcTx());
-        assertArrayEquals(expectedOutpointValues.toArray(),
-            pegoutCreationInfo.getUtxoOutpointValues().toArray());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getTxInfoToSignArgProvider")
-    void getTxInfoToSign_whenRejectedPeginHasPegoutCreatedEvent_returnsOk(
-        int version,
-        byte[] serializedOutpointValues,
-        List<Coin> expectedOutpointValues
-    ) throws HSMReleaseCreationInformationException {
-        // Arrange
-        List<Coin> outpointValues = UtxoUtils.decodeOutpointValues(serializedOutpointValues);
-        when(pegoutBtcTx.getInputSum()).thenReturn(
-            outpointValues.stream().reduce(Coin.ZERO, Coin::add));
-
-        List<LogInfo> logs = new ArrayList<>();
-
-        addCommonPegoutLogs(logs, pegoutBtcTx, serializedOutpointValues);
-
-        LogInfo rejectedPeginLog = createRejectedPeginLog(pegoutBtcTx.getHash(),
-            RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
-        logs.add(rejectedPeginLog);
-
-        pegoutCreationRskTxReceipt.setLogInfoList(logs);
-
-        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-
-        // act
-        ReleaseCreationInformation pegoutCreationInfo = releaseCreationInformationGetter.getTxInfoToSign(
-            version,
-            pegoutCreationRskTx.getHash(),
-            pegoutBtcTx
-        );
-
-        // assert
-        assertEquals(pegoutCreationBlock, pegoutCreationInfo.getPegoutCreationBlock());
-        assertEquals(pegoutCreationRskTxReceipt, pegoutCreationInfo.getTransactionReceipt());
-        assertEquals(pegoutCreationRskTx.getHash(),
-            pegoutCreationInfo.getPegoutCreationRskTxHash());
-        assertEquals(pegoutBtcTx, pegoutCreationInfo.getPegoutBtcTx());
-        assertArrayEquals(expectedOutpointValues.toArray(),
-            pegoutCreationInfo.getUtxoOutpointValues().toArray());
-    }
-
-    private static List<Arguments> getTxInfoToSignArgProvider() {
-        List<Arguments> arguments = new ArrayList<>();
-
-        for (HSMVersion hsmVersion : HSMVersion.values()) {
-            arguments.add(
-                Arguments.of(hsmVersion.getNumber(), Hex.decode("00"),
-                    Collections.singletonList(Coin.ZERO)));
-            arguments.add(
-                Arguments.of(hsmVersion.getNumber(), Hex.decode("01"),
-                    Collections.singletonList(Coin.SATOSHI)));
-            // 50_000_000 = FE80F0FA02, 75_000_000 = FEC0687804, 100_000_000 = FE00E1F505
-            arguments.add(
-                Arguments.of(hsmVersion.getNumber(), Hex.decode("FE80F0FA02FEC0687804FE00E1F505"),
-                    coinListOf(50_000_000, 75_000_000, 100_000_000)));
-            arguments.add(Arguments.of(hsmVersion.getNumber(), Hex.decode("FFFFFFFFFFFFFFFF7F"),
-                coinListOf(Long.MAX_VALUE)));
-        }
-
-        return arguments;
-    }
-
-    private void addCommonPegoutLogs(List<LogInfo> logs, BtcTransaction pegoutBtcTx,
-        byte[] serializedOutpointValues) {
-        Coin pegoutAmount = mock(Coin.class);
-        LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTx.getHash(),
-            pegoutBtcTx.getHash(), pegoutAmount);
-        logs.add(releaseRequestedLog);
-
-        LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(
-            pegoutBtcTx.getHash(), serializedOutpointValues);
-        logs.add(pegoutTransactionCreatedLog);
     }
 }

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -33,9 +33,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 class ReleaseCreationInformationGetterTest {
-    private final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
-    private final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
-    private final HSMVersion latestHSMVersion = TestUtils.getLatestHsmVersion();
+    private static final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
+    private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
+    private static final HSMVersion LATEST_HSM_VERSION = TestUtils.getLatestHsmVersion();
 
     private final Sha256Hash releaseBtcTxHash = BitcoinTestUtils.createHash(1);
     private final byte[] releaseBtcTxHashBytes = releaseBtcTxHash.getBytes();
@@ -153,7 +153,7 @@ class ReleaseCreationInformationGetterTest {
         );
 
         // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -169,7 +169,7 @@ class ReleaseCreationInformationGetterTest {
         );
 
         // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -236,7 +236,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -257,7 +257,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -276,7 +276,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -295,7 +295,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -311,7 +311,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -327,7 +327,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
     }
 
     @Test
@@ -346,7 +346,7 @@ class ReleaseCreationInformationGetterTest {
         ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
     }
 
     private void assertTxInfoToSign(
@@ -368,7 +368,7 @@ class ReleaseCreationInformationGetterTest {
     private void assertThrowsHSMReleaseCreationInformationException(ReleaseCreationInformationGetter releaseCreationInformationGetter) {
         assertThrows(HSMReleaseCreationInformationException.class,
             () -> releaseCreationInformationGetter.getTxInfoToSign(
-                latestHSMVersion.getNumber(),
+                LATEST_HSM_VERSION.getNumber(),
                 pegoutCreationRskTx.getHash(),
                 pegoutBtcTx
             ));

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -12,7 +12,6 @@ import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.federate.bitcoin.BitcoinTestUtils;
-import co.rsk.federate.signing.hsm.HSMVersion;
 import co.rsk.federate.signing.utils.TestUtils;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.pegin.RejectedPeginReason;
@@ -29,14 +28,11 @@ import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 class ReleaseCreationInformationGetterTest {
     private static final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
     private static final CallTransaction.Function PEGOUT_TRANSACTION_CREATED_EVENT = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
     private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
-    private static final HSMVersion LATEST_HSM_VERSION = TestUtils.getLatestHsmVersion();
 
     private final Sha256Hash pegoutBtcTxHash = BitcoinTestUtils.createHash(1);
     private final byte[] pegoutBtcTxHashBytes = pegoutBtcTxHash.getBytes();
@@ -105,19 +101,6 @@ class ReleaseCreationInformationGetterTest {
             .thenReturn(Optional.of(pegoutCreationRskTxInfo));
     }
 
-    @ParameterizedTest
-    @EnumSource(HSMVersion.class)
-    void getTxInfoToSign_differentHSMVersions_returnsCorrectTxInfo(HSMVersion hsmVersion) throws HSMReleaseCreationInformationException {
-        // arrange
-        addNeededLogsForSigning();
-
-        // act
-        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
-
-        // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, hsmVersion.getNumber());
-    }
-
     @Test
     void getTxInfoToSign_whenBatchPegoutHasPegoutTransactionCreatedEvent_returnsCorrectTxInfo() throws HSMReleaseCreationInformationException {
         // Arrange
@@ -133,7 +116,7 @@ class ReleaseCreationInformationGetterTest {
         );
 
         // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
+        assertTxInfoToSign(releaseCreationInformationGetter);
     }
 
     @Test
@@ -150,7 +133,7 @@ class ReleaseCreationInformationGetterTest {
         );
 
         // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
+        assertTxInfoToSign(releaseCreationInformationGetter);
     }
 
     private void addNeededLogsForSigning() {
@@ -164,24 +147,6 @@ class ReleaseCreationInformationGetterTest {
 
     private void addValidPegoutTransactionCreatedLogs() {
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
-    }
-
-    @Test
-    void getTxInfoToSign_wrongHSMVersion_throwsHSMReleaseCreationInformationException() {
-        // arrange
-        ReleaseCreationInformationGetter pegoutCreationInformation = new ReleaseCreationInformationGetter(
-            receiptStore,
-            blockStore
-        );
-        int wrongHSMVersion = 2;
-
-        // act & assert
-        assertThrows(HSMReleaseCreationInformationException.class,
-            () -> pegoutCreationInformation.getTxInfoToSign(
-                wrongHSMVersion,
-                pegoutCreationRskTxHash,
-                pegoutBtcTx
-            ));
     }
 
     @Test
@@ -427,11 +392,9 @@ class ReleaseCreationInformationGetterTest {
     }
 
     private void assertTxInfoToSign(
-        ReleaseCreationInformationGetter releaseCreationInformationGetter,
-        int hsmVersion
+        ReleaseCreationInformationGetter releaseCreationInformationGetter
     ) throws HSMReleaseCreationInformationException {
         ReleaseCreationInformation pegoutCreationInfo = releaseCreationInformationGetter.getTxInfoToSign(
-            hsmVersion,
             pegoutCreationRskTxHash,
             pegoutBtcTx
         );
@@ -445,7 +408,6 @@ class ReleaseCreationInformationGetterTest {
     private void assertThrowsHSMReleaseCreationInformationException(ReleaseCreationInformationGetter releaseCreationInformationGetter) {
         assertThrows(HSMReleaseCreationInformationException.class,
             () -> releaseCreationInformationGetter.getTxInfoToSign(
-                LATEST_HSM_VERSION.getNumber(),
                 pegoutCreationRskTx.getHash(),
                 pegoutBtcTx
             ));

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -37,23 +37,20 @@ class ReleaseCreationInformationGetterTest {
     private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
     private static final HSMVersion LATEST_HSM_VERSION = TestUtils.getLatestHsmVersion();
 
-    private final Sha256Hash releaseBtcTxHash = BitcoinTestUtils.createHash(1);
-    private final byte[] releaseBtcTxHashBytes = releaseBtcTxHash.getBytes();
+    private final Sha256Hash pegoutBtcTxHash = BitcoinTestUtils.createHash(1);
+    private final byte[] pegoutBtcTxHashBytes = pegoutBtcTxHash.getBytes();
     private final byte[] serializedOutpointsValues = Hex.decode("FE80F0FA02FEC0687804FE00E1F505"); // 50_000_000 = FE80F0FA02, 75_000_000 = FEC0687804, 100_000_000 = FE00E1F505
-    private final LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(releaseBtcTxHash, serializedOutpointsValues);
+    private final LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(pegoutBtcTxHash, serializedOutpointsValues);
 
-    private final Keccak256 pegoutCreationRskTxHash = TestUtils.createHash(2);
-    private final byte[] releaseCreationRskTxHashBytes = pegoutCreationRskTxHash.getBytes();
+    private final Keccak256 pegoutCreationRskTxHash = TestUtils.createHash(123);
+    private final byte[] pegoutCreationRskTxHashBytes = pegoutCreationRskTxHash.getBytes();
+
     private final Coin pegoutAmount = Coin.COIN;
-
-    private final LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTxHash, releaseBtcTxHash, pegoutAmount);
+    private final LogInfo releaseRequestedLog = createReleaseRequestedLog(pegoutCreationRskTxHash, pegoutBtcTxHash, pegoutAmount);
     private final byte[] releaseRequestedEventData = buildEncodedData(RELEASE_REQUESTED_EVENT, pegoutAmount.getValue());
 
-    private final RskAddress senderAddress = new RskAddress(TestUtils.getEcKeyFromSeed("senderKey").getAddress());
-    private final LogInfo updateCollectionsLog = createUpdateCollectionsLog(senderAddress);
-
-    private final Keccak256 anotherRskTxHash = TestUtils.createHash(123);
-    private final byte[] anotherRskTxHashBytes = anotherRskTxHash.getBytes();
+    private final RskAddress pegnatoryAddress = new RskAddress(TestUtils.getEcKeyFromSeed("pegnatory").getAddress());
+    private final LogInfo updateCollectionsLog = createUpdateCollectionsLog(pegnatoryAddress);
 
     private final byte[] wrongTopic = TestUtils.createHash(456).getBytes();
 
@@ -62,11 +59,8 @@ class ReleaseCreationInformationGetterTest {
 
     private Transaction pegoutCreationRskTx;
     private TransactionReceipt pegoutCreationRskTxReceipt;
-    private TransactionInfo pegoutCreationRskTxInfo;
 
     private Transaction anotherRskTx;
-    private TransactionReceipt anotherRskTxReceipt;
-    private TransactionInfo anotherRskTxInfo;
 
     private ReceiptStore receiptStore;
     private BlockStore blockStore;
@@ -77,61 +71,43 @@ class ReleaseCreationInformationGetterTest {
         blockStore = mock(BlockStore.class);
 
         pegoutBtcTx = mock(BtcTransaction.class);
-        when(pegoutBtcTx.getHash()).thenReturn(releaseBtcTxHash);
+        when(pegoutBtcTx.getHash()).thenReturn(pegoutBtcTxHash);
 
         pegoutCreationRskTx = mock(Transaction.class);
         when(pegoutCreationRskTx.getHash()).thenReturn(pegoutCreationRskTxHash);
         when(pegoutCreationRskTx.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
 
-        anotherRskTx = mock(Transaction.class);
-        when(anotherRskTx.getHash()).thenReturn(anotherRskTxHash);
+        pegoutCreationRskTxReceipt = buildTxReceiptForRskTx(pegoutCreationRskTxHash);
 
-        pegoutCreationRskTxReceipt = new TransactionReceipt();
-        addReleaseRequestedLogs();
-
-        anotherRskTxReceipt = buildTxReceiptForRskTx(anotherRskTxHash);
-
-        pegoutCreationBlock = createBlockWithTxs(Arrays.asList(anotherRskTx, pegoutCreationRskTx));
         setUpBlockchain();
     }
 
-    private void addReleaseRequestedLogs() {
-        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, updateCollectionsLog);
-        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, releaseRequestedLog);
-        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
-    }
-
     private void setUpBlockchain() {
-        setUpAnotherRskTxInfo();
-        setUpPegoutCreationRskTxInfo();
+        // create block with another rsk tx to be more realistic
+        anotherRskTx = mock(Transaction.class);
+        Keccak256 anotherRskTxHash = TestUtils.createHash(456);
+        when(anotherRskTx.getHash()).thenReturn(anotherRskTxHash);
+        pegoutCreationBlock = createBlockWithTxs(Arrays.asList(anotherRskTx, pegoutCreationRskTx));
+        int pegoutCreationTxIndex = 1;
+        TransactionInfo pegoutCreationRskTxInfo = buildTxInfo(pegoutCreationRskTxReceipt, pegoutCreationBlock.getHash(), pegoutCreationTxIndex);
 
         byte[] pegoutCreationBlockHash = pegoutCreationBlock.getHash().getBytes();
         when(blockStore.getBlockByHash(pegoutCreationBlockHash))
             .thenReturn(pegoutCreationBlock);
-        when(receiptStore.get(releaseCreationRskTxHashBytes, pegoutCreationBlockHash))
-            .thenReturn(Optional.of(pegoutCreationRskTxInfo));
-
         when(blockStore.getChainBlockByNumber(pegoutCreationBlock.getNumber()))
             .thenReturn(pegoutCreationBlock);
-        when(receiptStore.getInMainChain(releaseCreationRskTxHashBytes, blockStore))
+        when(receiptStore.getInMainChain(pegoutCreationRskTxHashBytes, blockStore))
             .thenReturn(Optional.of(pegoutCreationRskTxInfo));
-        when(receiptStore.getInMainChain(anotherRskTxHashBytes, blockStore))
-            .thenReturn(Optional.of(anotherRskTxInfo));
-    }
-
-    private void setUpAnotherRskTxInfo() {
-        int anotherTxIndex = 0;
-        anotherRskTxInfo = buildTxInfo(anotherRskTxReceipt, pegoutCreationBlock.getHash(), anotherTxIndex);
-    }
-
-    private void setUpPegoutCreationRskTxInfo() {
-        int pegoutCreationTxIndex = 1;
-        pegoutCreationRskTxInfo = buildTxInfo(pegoutCreationRskTxReceipt, pegoutCreationBlock.getHash(), pegoutCreationTxIndex);
+        when(receiptStore.get(pegoutCreationRskTxHashBytes, pegoutCreationBlockHash))
+            .thenReturn(Optional.of(pegoutCreationRskTxInfo));
     }
 
     @ParameterizedTest
     @EnumSource(HSMVersion.class)
     void getTxInfoToSign_differentHSMVersions_returnsCorrectTxInfo(HSMVersion hsmVersion) throws HSMReleaseCreationInformationException {
+        // arrange
+        addLogsForReleaseRequestedEvent();
+
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
@@ -143,8 +119,9 @@ class ReleaseCreationInformationGetterTest {
     void getTxInfoToSign_whenBatchPegoutHasPegoutTransactionCreatedEvent_returnsCorrectTxInfo() throws HSMReleaseCreationInformationException {
         // Arrange
         List<Keccak256> pegoutRequestsRskTxHashes = Collections.singletonList(TestUtils.createHash(10));
-        LogInfo batchPegoutCreatedLog = createBatchPegoutCreatedLog(releaseBtcTxHash, pegoutRequestsRskTxHashes);
+        LogInfo batchPegoutCreatedLog = createBatchPegoutCreatedLog(pegoutBtcTxHash, pegoutRequestsRskTxHashes);
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, batchPegoutCreatedLog);
+        addLogsForReleaseRequestedEvent();
 
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
@@ -159,8 +136,9 @@ class ReleaseCreationInformationGetterTest {
     @Test
     void getTxInfoToSign_whenRejectedPeginHasPegoutCreatedEvent_returnsCorrectTxInfo() throws HSMReleaseCreationInformationException {
         // Arrange
-        LogInfo rejectedPeginLog = createRejectedPeginLog(releaseBtcTxHash, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
+        LogInfo rejectedPeginLog = createRejectedPeginLog(pegoutBtcTxHash, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, rejectedPeginLog);
+        addLogsForReleaseRequestedEvent();
 
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
@@ -170,6 +148,12 @@ class ReleaseCreationInformationGetterTest {
 
         // assert
         assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
+    }
+
+    private void addLogsForReleaseRequestedEvent() {
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, updateCollectionsLog);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, releaseRequestedLog);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
     }
 
     @Test
@@ -209,7 +193,8 @@ class ReleaseCreationInformationGetterTest {
     void getTxInfoToSign_whenBlockDoesNotContainPegoutCreationRskTx_throwsHSMReleaseCreationInformationException() {
         // arrange
         // simulate pegout creation block does not have pegoutCreationRskTx
-        pegoutCreationBlock = createBlockWithTxs(Collections.singletonList(anotherRskTx));
+        Transaction anotherRskTx2 = mock(Transaction.class);
+        pegoutCreationBlock = createBlockWithTxs(Arrays.asList(anotherRskTx, anotherRskTx2));
         setUpBlockchain();
 
         // act
@@ -223,130 +208,122 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchIsFromWrongSender_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogsAreFromWrongSender_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - correct topics but from another sender (not the bridge)
-        List<DataWord> topics = buildEncodedTopics(RELEASE_REQUESTED_EVENT, releaseCreationRskTxHashBytes, releaseBtcTxHashBytes);
-
+        // build wrong log - correct topics but from another sender (not the bridge)
+        List<DataWord> topics = buildEncodedTopics(RELEASE_REQUESTED_EVENT, pegoutCreationRskTxHashBytes, pegoutBtcTxHashBytes);
         byte[] sender = Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
-        LogInfo wrongReleaseRequestedLogInfo = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, wrongReleaseRequestedLogInfo);
+        LogInfo wrongLog = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchHasWrongReleaseRequestedTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogHasWrongReleaseRequestedTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - wrong event topic
+        // build wrong log - wrong event topic
         CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
         List<DataWord> topics = buildCustomTopics(
             wrongEvent,
-            List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes)
+            List.of(pegoutCreationRskTxHashBytes, pegoutBtcTxHashBytes)
         );
-
-
-        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+        LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
-        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchHasWrongPegoutCreationRskTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogHasWrongPegoutCreationRskTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - wrong pegoutCreationRskTxHash topic
+        // build wrong log - wrong pegoutCreationRskTxHash topic
         List<DataWord> topics = buildCustomTopics(
             RELEASE_REQUESTED_EVENT,
-            List.of(wrongTopic, releaseBtcTxHashBytes)
+            List.of(wrongTopic, pegoutBtcTxHashBytes)
         );
-
-        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+        LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
-        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchHasWrongPegoutBtcTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogHasWrongPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - wrong pegoutBtcTxHash topic
+        // build wrong log - wrong pegoutBtcTxHash topic
         List<DataWord> topics = buildCustomTopics(
             RELEASE_REQUESTED_EVENT,
-            List.of(releaseCreationRskTxHashBytes, wrongTopic)
+            List.of(pegoutCreationRskTxHashBytes, wrongTopic)
         );
-
-        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+        LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
-        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchMissesPegoutCreationRskTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogMissesPegoutCreationRskTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - missing pegoutCreationRskTxHash topic
-        List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseBtcTxHashBytes));
-
-        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+        // build wrong log - missing pegoutCreationRskTxHash topic
+        List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(pegoutBtcTxHashBytes));
+        LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
-        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchMissesPegoutBtcTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogMissesPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - missing pegoutBtcTxHash topic
-        List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseCreationRskTxHashBytes));
-
-        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+        // build wrong log - missing pegoutBtcTxHash topic
+        List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(pegoutCreationRskTxHashBytes));
+        LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
-        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     @Test
-    void getTxInfoToSign_whenFirstMatchHasExtraTopics_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+    void getTxInfoToSign_whenLogHasExtraTopics_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // build tx with wrong log - one extra topic
+        // build wrong log - one extra topic
         List<DataWord> topics = buildCustomTopics(
             RELEASE_REQUESTED_EVENT,
-            List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, wrongTopic)
+            List.of(pegoutCreationRskTxHashBytes, pegoutBtcTxHashBytes, wrongTopic)
         );
-
-        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
-        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+        LogInfo wrongLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongLog);
 
         // act
-        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
 
         // assert
-        assertTxInfoToSign(getter, LATEST_HSM_VERSION.getNumber());
+        assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
     private void assertTxInfoToSign(

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 class ReleaseCreationInformationGetterTest {
     private static final CallTransaction.Function RELEASE_REQUESTED_EVENT = BridgeEvents.RELEASE_REQUESTED.getEvent();
+    private static final CallTransaction.Function PEGOUT_TRANSACTION_CREATED_EVENT = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
     private static final byte[] BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR.getBytes();
     private static final HSMVersion LATEST_HSM_VERSION = TestUtils.getLatestHsmVersion();
 
@@ -41,6 +42,7 @@ class ReleaseCreationInformationGetterTest {
     private final byte[] pegoutBtcTxHashBytes = pegoutBtcTxHash.getBytes();
     private final byte[] serializedOutpointsValues = Hex.decode("FE80F0FA02FEC0687804FE00E1F505"); // 50_000_000 = FE80F0FA02, 75_000_000 = FEC0687804, 100_000_000 = FE00E1F505
     private final LogInfo pegoutTransactionCreatedLog = createPegoutTransactionCreatedLog(pegoutBtcTxHash, serializedOutpointsValues);
+    private final byte[] pegoutTransactionCreatedEventData = buildEncodedData(PEGOUT_TRANSACTION_CREATED_EVENT, serializedOutpointsValues);
 
     private final Keccak256 pegoutCreationRskTxHash = TestUtils.createHash(123);
     private final byte[] pegoutCreationRskTxHashBytes = pegoutCreationRskTxHash.getBytes();
@@ -78,6 +80,7 @@ class ReleaseCreationInformationGetterTest {
         when(pegoutCreationRskTx.getReceiveAddress()).thenReturn(PrecompiledContracts.BRIDGE_ADDR);
 
         pegoutCreationRskTxReceipt = buildTxReceiptForRskTx(pegoutCreationRskTxHash);
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, updateCollectionsLog);
 
         setUpBlockchain();
     }
@@ -106,7 +109,7 @@ class ReleaseCreationInformationGetterTest {
     @EnumSource(HSMVersion.class)
     void getTxInfoToSign_differentHSMVersions_returnsCorrectTxInfo(HSMVersion hsmVersion) throws HSMReleaseCreationInformationException {
         // arrange
-        addLogsForReleaseRequestedEvent();
+        addNeededLogsForSigning();
 
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
@@ -121,7 +124,7 @@ class ReleaseCreationInformationGetterTest {
         List<Keccak256> pegoutRequestsRskTxHashes = Collections.singletonList(TestUtils.createHash(10));
         LogInfo batchPegoutCreatedLog = createBatchPegoutCreatedLog(pegoutBtcTxHash, pegoutRequestsRskTxHashes);
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, batchPegoutCreatedLog);
-        addLogsForReleaseRequestedEvent();
+        addNeededLogsForSigning();
 
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
@@ -138,7 +141,7 @@ class ReleaseCreationInformationGetterTest {
         // Arrange
         LogInfo rejectedPeginLog = createRejectedPeginLog(pegoutBtcTxHash, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER);
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, rejectedPeginLog);
-        addLogsForReleaseRequestedEvent();
+        addNeededLogsForSigning();
 
         // act
         ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(
@@ -150,9 +153,16 @@ class ReleaseCreationInformationGetterTest {
         assertTxInfoToSign(releaseCreationInformationGetter, LATEST_HSM_VERSION.getNumber());
     }
 
-    private void addLogsForReleaseRequestedEvent() {
-        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, updateCollectionsLog);
+    private void addNeededLogsForSigning() {
+        addValidReleaseRequestedLogs();
+        addValidPegoutTransactionCreatedLogs();
+    }
+
+    private void addValidReleaseRequestedLogs() {
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, releaseRequestedLog);
+    }
+
+    private void addValidPegoutTransactionCreatedLogs() {
         addLogToRskTxReceipt(pegoutCreationRskTxReceipt, pegoutTransactionCreatedLog);
     }
 
@@ -175,9 +185,9 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenTxHasEmptyReceipt_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenPegoutCreationRskTxHasEmptyReceipt_throwsHSMReleaseCreationInformationException() {
         // arrange
-        // rsk tx receipt does not have release requested logs
+        // rsk tx receipt does not have any logs
         pegoutCreationRskTxReceipt = new TransactionReceipt();
         pegoutCreationRskTxReceipt.setLogInfoList(Collections.emptyList());
         setUpBlockchain();
@@ -208,7 +218,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogsAreFromWrongSender_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogIsFromWrongSender_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - correct topics but from another sender (not the bridge)
         List<DataWord> topics = buildEncodedTopics(RELEASE_REQUESTED_EVENT, pegoutCreationRskTxHashBytes, pegoutBtcTxHashBytes);
@@ -224,7 +234,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogHasWrongReleaseRequestedTopic_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogHasWrongReleaseRequestedTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - wrong event topic
         CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
@@ -243,7 +253,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogHasWrongPegoutCreationRskTxHashTopic_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogHasWrongPegoutCreationRskTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - wrong pegoutCreationRskTxHash topic
         List<DataWord> topics = buildCustomTopics(
@@ -261,7 +271,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogHasWrongPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogHasWrongPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - wrong pegoutBtcTxHash topic
         List<DataWord> topics = buildCustomTopics(
@@ -279,7 +289,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogMissesPegoutCreationRskTxHashTopic_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogMissesPegoutCreationRskTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - missing pegoutCreationRskTxHash topic
         List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(pegoutBtcTxHashBytes));
@@ -294,7 +304,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogMissesPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogMissesPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - missing pegoutBtcTxHash topic
         List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(pegoutCreationRskTxHashBytes));
@@ -309,7 +319,7 @@ class ReleaseCreationInformationGetterTest {
     }
 
     @Test
-    void getTxInfoToSign_whenLogHasExtraTopics_throwsHSMReleaseCreationInformationException() {
+    void getTxInfoToSign_whenReleaseRequestedLogHasExtraTopics_throwsHSMReleaseCreationInformationException() {
         // arrange
         // build wrong log - one extra topic
         List<DataWord> topics = buildCustomTopics(
@@ -324,6 +334,96 @@ class ReleaseCreationInformationGetterTest {
 
         // assert
         assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
+    }
+    @Test
+    void getTxInfoToSign_whenPegoutTransactionCreatedLogFromWrongSender_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // build wrong log - correct topics but from another sender (not the bridge)
+        List<DataWord> topics = buildCustomTopics(
+            PEGOUT_TRANSACTION_CREATED_EVENT,
+            List.of(pegoutBtcTxHashBytes)
+        );
+        byte[] sender = Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+        LogInfo wrongPegoutLog = buildLogInfoFrom(sender, topics, pegoutTransactionCreatedEventData);
+        addValidReleaseRequestedLogs();
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongPegoutLog);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(getter);
+    }
+
+    @Test
+    void getTxInfoToSign_whenPegoutTransactionCreatedLogHasWrongEventTopic_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // build wrong log - wrong event topic
+        CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
+        List<DataWord> topics = buildCustomTopics(wrongEvent, List.of(pegoutBtcTxHashBytes));
+        LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+        addValidReleaseRequestedLogs();
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongPegoutLog);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(getter);
+    }
+
+    @Test
+    void getTxInfoToSign_whenPegoutTransactionCreatedLogHasWrongPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // build wrong log - wrong pegoutBtcTxHash topic
+        List<DataWord> topics = buildCustomTopics(
+            PEGOUT_TRANSACTION_CREATED_EVENT,
+            List.of(wrongTopic)
+        );
+        LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+        addValidReleaseRequestedLogs();
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongPegoutLog);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(getter);
+    }
+
+    @Test
+    void getTxInfoToSign_whenPegoutTransactionCreatedLogMissesPegoutBtcTxHashTopic_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // build wrong log - missing pegoutBtcTxHash topic
+        List<DataWord> topics = buildCustomTopics(PEGOUT_TRANSACTION_CREATED_EVENT, List.of());
+        LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+        addValidReleaseRequestedLogs();
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongPegoutLog);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(getter);
+    }
+
+    @Test
+    void getTxInfoToSign_whenPegoutTransactionCreatedLogHasExtraTopics_throwsHSMReleaseCreationInformationException() {
+        // arrange
+        // build wrong log - one extra topic
+        List<DataWord> topics = buildCustomTopics(
+            PEGOUT_TRANSACTION_CREATED_EVENT,
+            List.of(pegoutBtcTxHashBytes, wrongTopic)
+        );
+        LogInfo wrongPegoutLog = buildLogInfoFrom(BRIDGE_ADDRESS, topics, pegoutTransactionCreatedEventData);
+        addValidReleaseRequestedLogs();
+        addLogToRskTxReceipt(pegoutCreationRskTxReceipt, wrongPegoutLog);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertThrowsHSMReleaseCreationInformationException(getter);
     }
 
     private void assertTxInfoToSign(

--- a/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/ReleaseCreationInformationGetterTest.java
@@ -222,6 +222,133 @@ class ReleaseCreationInformationGetterTest {
         assertThrowsHSMReleaseCreationInformationException(releaseCreationInformationGetter);
     }
 
+    @Test
+    void getTxInfoToSign_whenFirstMatchIsFromWrongSender_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - correct topics but from another sender (not the bridge)
+        List<DataWord> topics = buildEncodedTopics(RELEASE_REQUESTED_EVENT, releaseCreationRskTxHashBytes, releaseBtcTxHashBytes);
+
+        byte[] sender = Hex.decode("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+        LogInfo wrongReleaseRequestedLogInfo = buildLogInfoFrom(sender, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, wrongReleaseRequestedLogInfo);
+
+        // act
+        ReleaseCreationInformationGetter releaseCreationInformationGetter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(releaseCreationInformationGetter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_whenFirstMatchHasWrongReleaseRequestedTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - wrong event topic
+        CallTransaction.Function wrongEvent = BridgeEvents.LOCK_BTC.getEvent();
+        List<DataWord> topics = buildCustomTopics(
+            wrongEvent,
+            List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes)
+        );
+
+
+        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_whenFirstMatchHasWrongPegoutCreationRskTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - wrong pegoutCreationRskTxHash topic
+        List<DataWord> topics = buildCustomTopics(
+            RELEASE_REQUESTED_EVENT,
+            List.of(wrongTopic, releaseBtcTxHashBytes)
+        );
+
+        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_whenFirstMatchHasWrongPegoutBtcTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - wrong pegoutBtcTxHash topic
+        List<DataWord> topics = buildCustomTopics(
+            RELEASE_REQUESTED_EVENT,
+            List.of(releaseCreationRskTxHashBytes, wrongTopic)
+        );
+
+        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_whenFirstMatchMissesPegoutCreationRskTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - missing pegoutCreationRskTxHash topic
+        List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseBtcTxHashBytes));
+
+        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_whenFirstMatchMissesPegoutBtcTxHashTopic_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - missing pegoutBtcTxHash topic
+        List<DataWord> topics = buildCustomTopics(RELEASE_REQUESTED_EVENT, List.of(releaseCreationRskTxHashBytes));
+
+        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+    }
+
+    @Test
+    void getTxInfoToSign_whenFirstMatchHasExtraTopics_returnsInfoFromCorrectTx() throws HSMReleaseCreationInformationException {
+        // arrange
+        // build tx with wrong log - one extra topic
+        List<DataWord> topics = buildCustomTopics(
+            RELEASE_REQUESTED_EVENT,
+            List.of(releaseCreationRskTxHashBytes, releaseBtcTxHashBytes, wrongTopic)
+        );
+
+        LogInfo log = buildLogInfoFrom(BRIDGE_ADDRESS, topics, releaseRequestedEventData);
+        addLogToRskTxReceipt(anotherRskTxReceipt, log);
+
+        // act
+        ReleaseCreationInformationGetter getter = new ReleaseCreationInformationGetter(receiptStore, blockStore);
+
+        // assert
+        assertTxInfoToSign(getter, latestHSMVersion.getNumber());
+    }
+
     private void assertTxInfoToSign(
         ReleaseCreationInformationGetter releaseCreationInformationGetter,
         int hsmVersion

--- a/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
+++ b/src/test/java/co/rsk/federate/signing/hsm/message/SignerMessageBuilderFactoryTest.java
@@ -83,7 +83,8 @@ class SignerMessageBuilderFactoryTest {
                 block,
                 mock(TransactionReceipt.class),
                 Keccak256.ZERO_HASH,
-                tx
+                tx,
+                Collections.emptyList()
             ),
             0
         );

--- a/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
+++ b/src/test/java/co/rsk/federate/signing/utils/TestUtils.java
@@ -1,6 +1,8 @@
 package co.rsk.federate.signing.utils;
 
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,9 +31,12 @@ import co.rsk.peg.federation.constants.FederationConstants;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.db.TransactionInfo;
+import org.ethereum.vm.LogInfo;
 
 public final class TestUtils {
     private static final long CREATION_BLOCK_NUMBER = 0;
@@ -47,14 +52,54 @@ public final class TestUtils {
     private TestUtils() {
     }
 
-    public static Block createBlock(List<Transaction> rskTxs) {
-        int blockNumber = 1;
+    public static TransactionReceipt buildTxReceiptForRskTx(Keccak256 rskTxHash) {
+        List<LogInfo> logInfoList = new ArrayList<>();
+        byte[] notNullBytes = new byte[]{0x01};
+        Bloom bloom = mock(Bloom.class);
+
+        return new TransactionReceipt(
+            rskTxHash.getBytes(),
+            notNullBytes,
+            notNullBytes,
+            bloom,
+            logInfoList,
+            notNullBytes
+        );
+    }
+
+    public static void addLogToRskTxReceipt(TransactionReceipt txReceipt, LogInfo logToAdd) {
+        List<LogInfo> logs = txReceipt.getLogInfoList();
+        logs.add(logToAdd);
+
+        txReceipt.setLogInfoList(logs);
+    }
+
+    public static TransactionInfo buildTxInfo(TransactionReceipt txReceipt, Keccak256 pegoutCreationRskBlockHash, int index) {
+        return new TransactionInfo(
+            txReceipt,
+            pegoutCreationRskBlockHash.getBytes(),
+            index
+        );
+    }
+
+    public static Block createBlockWithTxs(List<Transaction> rskTxs) {
         int parentBlockNumber = 0;
-        BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
+        Keccak256 parentBlockHash = TestUtils.createHash(parentBlockNumber);
+        int blockNumber = 1;
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(any(ConsensusRule.class))).thenReturn(true);
+        ActivationConfig activationConfig = mock(ActivationConfig.class);
+        when(activationConfig.forBlock(anyLong())).thenReturn(activations);
+        when(activationConfig.isActive(any(ConsensusRule.class), anyLong())).thenReturn(true);
+
+        List<BlockHeader> uncles = Collections.emptyList();
+
+        BlockHeader blockHeader = new BlockHeaderBuilder(activationConfig)
             .setNumber(blockNumber)
-            .setParentHashFromKeccak256(TestUtils.createHash(parentBlockNumber))
+            .setParentHashFromKeccak256(parentBlockHash)
             .build();
-        return new Block(blockHeader, rskTxs, Collections.emptyList(), true, true);
+        return new Block(blockHeader, rskTxs, uncles, true, true);
     }
 
     public static Keccak256 createHash(int nHash) {


### PR DESCRIPTION
This pull request refactors how pegout UTXO outpoint values are handled and improves logging and exception handling in the pegout signing process. The most significant changes are the removal of redundant decoding logic from `ReleaseCreationInformation`, passing UTXO outpoint values explicitly, and enhanced traceability through additional logging.

### Refactoring UTXO Outpoint Values Handling

* The `ReleaseCreationInformation` class no longer decodes UTXO outpoint values from transaction logs internally; instead, these values are now passed directly to its constructor, simplifying the class and improving clarity. [[1]](diffhunk://#diff-629845584d2ebb3e983db3667c68cf488c953b4e87c92b326f16517b0a76ec7cL34-R36) [[2]](diffhunk://#diff-629845584d2ebb3e983db3667c68cf488c953b4e87c92b326f16517b0a76ec7cL92-R61)
* Related changes in `PowHSMSignerMessageBuilder` now use the new `utxoOutpointValues` field from `ReleaseCreationInformation` instead of maintaining their own copy. [[1]](diffhunk://#diff-fb468c7d28f1b4e79c4c48b2e4aaaaf8e6962dfe921cc0726193e9dc0f60299fL4-R16) [[2]](diffhunk://#diff-fb468c7d28f1b4e79c4c48b2e4aaaaf8e6962dfe921cc0726193e9dc0f60299fL32-L37) [[3]](diffhunk://#diff-fb468c7d28f1b4e79c4c48b2e4aaaaf8e6962dfe921cc0726193e9dc0f60299fL66-R61)

### Improved Logging and Traceability

* Added detailed trace logs to key validation and processing steps in `BtcReleaseClient`, making it easier to follow pegout signing logic and diagnose issues. [[1]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fL318-R364) [[2]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fR374-R377) [[3]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fR409-R412)

### Exception Handling and Method Signature Updates

* The `tryGetReleaseInformation` method in `BtcReleaseClient` now catches additional exceptions and logs errors more consistently, improving robustness.
* Method signatures in `BtcReleaseClient` were updated to remove unnecessary parameters, reflecting the updated flow of information. [[1]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fL246-R247) [[2]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fL289-R288) [[3]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fL318-R364)

These changes collectively improve the maintainability, traceability, and reliability of the pegout signing process.

`rit:VETIVER-9.0.3-rc`