### PR TITLE
Log FederatorAlreadySignedException as info, not error

### DIFF
--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -378,13 +378,16 @@ public class BtcReleaseClient {
                 pegoutBtcTxHash
             );
             return Optional.of(releaseToSignCreationInformation);
-        } catch (FederatorAlreadySignedException | FederationCantSignException | HSMReleaseCreationInformationException e) {
+        } catch (FederatorAlreadySignedException e) {
+            logger.info("[tryGetReleaseInformation] {}", e.getMessage());
+        } catch (FederationCantSignException | HSMReleaseCreationInformationException e) {
             String message = String.format(
                 "[tryGetReleaseInformation] There was an error trying to process pegout with btcTxHash %s",
                 pegoutBtcTxHash
             );
             logger.error(message, e);
         }
+
         return Optional.empty();
     }
 


### PR DESCRIPTION
This pull request updates the exception handling logic in the `tryGetReleaseInformation` method in `BtcReleaseClient.java` to provide more specific logging for different exception types. The main change is splitting the catch block to handle `FederatorAlreadySignedException` separately with an info log, while other exceptions are still logged as errors.

Exception handling improvements:

* [`src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java`](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fL381-R390): Now catches `FederatorAlreadySignedException` separately and logs it as an info message, while `FederationCantSignException` and `HSMReleaseCreationInformationException` are logged as errors with additional context.