### PR TITLE
Update RIT workflow to run short test suite for PRs

### DIFF
--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
     branches: [ "master", "*-rc" ]
+  push:
+    branches: [ "master", "*-rc" ]
   workflow_dispatch:
     inputs:
       rit-branch:
@@ -14,9 +16,24 @@ on:
         description: 'Branch for RSKJ repo'
         required: false
         default: 'master'
+      test-suite:
+        description: 'Test suite to run: short (fast PR subset) or full (short + extra tests)'
+        required: false
+        default: 'full'
+        type: choice
+        options:
+          - short
+          - full
 
 # Declare default permissions as read only.
 permissions: read-all
+
+# Cancel a still-running PR run when a new commit lands on the same PR, so a superseded commit
+# doesn't keep occupying a runner. Push/workflow_dispatch runs are only serialized (queued), not
+# cancelled, since those represent completed states worth validating to completion.
+concurrency:
+  group: rit-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   rootstock-integration-tests:
@@ -34,6 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           github_event_inputs_rskj_branch: ${{ github.event.inputs.rskj-branch }}
           github_event_inputs_rit_branch: ${{ github.event.inputs.rit-branch }}
+          github_event_inputs_test_suite: ${{ github.event.inputs.test-suite }}
           github_event_name: ${{ github.event_name }}
           github_event_pull_request_number: ${{ github.event.pull_request.number }}
           github_head_ref: ${{ github.head_ref }}
@@ -48,6 +66,7 @@ jobs:
           default_rskj_branch=master
           default_powpeg_branch=master
           default_rit_branch=main
+          default_test_suite=full
 
           get_branch_from_description()
           {
@@ -70,6 +89,7 @@ jobs:
             POWPEG_BRANCH=$github_ref_name
             RSKJ_BRANCH=${github_event_inputs_rskj_branch:-$default_rskj_branch}
             RIT_BRANCH=${github_event_inputs_rit_branch:-$default_rit_branch}
+            TEST_SUITE=${github_event_inputs_test_suite:-$default_test_suite}
           elif [ "$github_event_name" = pull_request ]; then
             gh pr view "$github_event_pull_request_number" --json body -q .body >"$PR_DESCRIPTION"
 
@@ -81,10 +101,23 @@ jobs:
 
             RIT_BRANCH=$(get_branch_from_description rit)
             : ${RIT_BRANCH:=$default_rit_branch}
+
+            # PRs default to the short suite for fast feedback, but can opt into the full suite
+            # via a `test-suite:full` tag in the PR description (e.g. before merging into master).
+            TEST_SUITE=$(get_branch_from_description test-suite)
+            : ${TEST_SUITE:=short}
+          elif [ "$github_event_name" = push ]; then
+            # A push targets a specific branch (master or a *-rc release branch), so test
+            # against that branch rather than defaulting to master.
+            POWPEG_BRANCH=$github_ref_name
+            RSKJ_BRANCH=$default_rskj_branch
+            RIT_BRANCH=$default_rit_branch
+            TEST_SUITE=$default_test_suite
           else
             RSKJ_BRANCH=$default_rskj_branch
             POWPEG_BRANCH=$default_powpeg_branch
             RIT_BRANCH=$default_rit_branch
+            TEST_SUITE=$default_test_suite
           fi
 
           if ! is_valid_branch_name "$RSKJ_BRANCH"; then
@@ -99,6 +132,10 @@ jobs:
             echo "rit: invalid branch name: $RIT_BRANCH" >&2
             exit 1
           fi
+          if [ "$TEST_SUITE" != "short" ] && [ "$TEST_SUITE" != "full" ]; then
+            echo "test-suite: invalid value: $TEST_SUITE, must be 'short' or 'full'" >&2
+            exit 1
+          fi
 
           # Set the Repo Owner
           REPO_OWNER="${github_event_pull_request_head_repo_owner_login:-$github_repository_owner}"
@@ -107,6 +144,7 @@ jobs:
           echo "RSKJ_BRANCH=$RSKJ_BRANCH" >> $GITHUB_ENV
           echo "RIT_BRANCH=$RIT_BRANCH" >> $GITHUB_ENV
           echo "POWPEG_BRANCH=$POWPEG_BRANCH" >> $GITHUB_ENV
+          echo "TEST_SUITE=$TEST_SUITE" >> $GITHUB_ENV
 
       - name: Set Build URL
         id: set-build-url
@@ -114,14 +152,38 @@ jobs:
           BUILD_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "BUILD_URL=$BUILD_URL" >> $GITHUB_ENV
 
-      - name: Sanitize Github Variables
-        id: sanitize-github-variables
+      - name: Set Notification Context
+        id: set-notification-context
         env:
-          GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+          GITHUB_EVENT_PULL_REQUEST_TITLE: ${{ github.event.pull_request.title || '' }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url || '' }}
+          GITHUB_EVENT_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
+          GITHUB_EVENT_HEAD_COMMIT_URL: ${{ github.event.head_commit.url || '' }}
+          GITHUB_REF_NAME: ${{ github.ref_name || '' }}
         run: |
-          # Delete non-alphanumeric characters and limit to 75 chars which is the branch title limit in GitHub
-          SAFE_PULL_REQUEST_TITLE=$(echo "${GITHUB_EVENT_PULL_REQUEST_TITLE}" | tr -cd '[:alnum:]_ -' | cut -c1-75)
-          echo "SAFE_PULL_REQUEST_TITLE=$SAFE_PULL_REQUEST_TITLE" >> $GITHUB_ENV
+          # Delete non-alphanumeric characters and limit to 75 chars, which is the branch title limit in GitHub
+          sanitize() {
+            echo "$1" | tr -cd '[:alnum:]_ -' | cut -c1-75
+          }
+
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            NOTIFICATION_TITLE="PR #${GITHUB_EVENT_PULL_REQUEST_NUMBER}"
+            NOTIFICATION_SUBTITLE=$(sanitize "$GITHUB_EVENT_PULL_REQUEST_TITLE")
+            NOTIFICATION_URL="$GITHUB_EVENT_PULL_REQUEST_HTML_URL"
+            NOTIFICATION_ACTION_LABEL="Open PR"
+          else
+            NOTIFICATION_TITLE="Push to ${GITHUB_REF_NAME}"
+            NOTIFICATION_SUBTITLE=$(sanitize "$(echo "$GITHUB_EVENT_HEAD_COMMIT_MESSAGE" | head -n1)")
+            NOTIFICATION_URL="$GITHUB_EVENT_HEAD_COMMIT_URL"
+            NOTIFICATION_ACTION_LABEL="View Commit"
+          fi
+
+          echo "NOTIFICATION_TITLE=$NOTIFICATION_TITLE" >> $GITHUB_ENV
+          echo "NOTIFICATION_SUBTITLE=$NOTIFICATION_SUBTITLE" >> $GITHUB_ENV
+          echo "NOTIFICATION_URL=$NOTIFICATION_URL" >> $GITHUB_ENV
+          echo "NOTIFICATION_ACTION_LABEL=$NOTIFICATION_ACTION_LABEL" >> $GITHUB_ENV
 
       - name: Run Rootstock Integration Tests
         uses: rsksmart/rootstock-integration-tests@main
@@ -130,9 +192,10 @@ jobs:
           powpeg-node-branch: ${{ env.POWPEG_BRANCH }}
           rit-branch: ${{ env.RIT_BRANCH }}
           repo-owner: ${{ env.REPO_OWNER }}
+          test-suite: ${{ env.TEST_SUITE }}
 
       - name: Send Slack Notification on Success
-        if: success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart'
+        if: success() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart'))
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           token: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
@@ -143,12 +206,12 @@ jobs:
             - type: header
               text:
                 type: plain_text
-                text: "✅ PASSED — ${{ github.repository }} – PR #${{ github.event.pull_request.number }}"
+                text: "✅ PASSED — ${{ github.repository }} – ${{ env.NOTIFICATION_TITLE }}"
                 emoji: true
             - type: section
               text:
                 type: mrkdwn
-                text: "*${{ env.SAFE_PULL_REQUEST_TITLE }}*"
+                text: "*${{ env.NOTIFICATION_SUBTITLE }}*"
               fields:
                 - type: mrkdwn
                   text: "• rskj: `${{ env.RSKJ_BRANCH }}`\n• fed: `${{ env.POWPEG_BRANCH }}`\n• rit: `${{ env.RIT_BRANCH }}`"
@@ -157,8 +220,8 @@ jobs:
                 - type: button
                   text:
                     type: plain_text
-                    text: Open PR
-                  url: "${{ github.event.pull_request.html_url }}"
+                    text: "${{ env.NOTIFICATION_ACTION_LABEL }}"
+                  url: "${{ env.NOTIFICATION_URL }}"
                 - type: button
                   text:
                     type: plain_text
@@ -166,7 +229,7 @@ jobs:
                   url: "${{ env.BUILD_URL }}"
 
       - name: Send Slack Notification on Failure
-        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart'
+        if: failure() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'rsksmart'))
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           token: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
@@ -177,12 +240,12 @@ jobs:
               - type: header
                 text:
                   type: plain_text
-                  text: "❌ FAILED — ${{ github.repository }} – PR #${{ github.event.pull_request.number }}"
+                  text: "❌ FAILED — ${{ github.repository }} – ${{ env.NOTIFICATION_TITLE }}"
                   emoji: true
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*${{ env.SAFE_PULL_REQUEST_TITLE }}*"
+                  text: "*${{ env.NOTIFICATION_SUBTITLE }}*"
                 fields:
                   - type: mrkdwn
                     text: "• rskj: `${{ env.RSKJ_BRANCH }}`\n• fed: `${{ env.POWPEG_BRANCH }}`\n• rit: `${{ env.RIT_BRANCH }}`"
@@ -192,8 +255,8 @@ jobs:
                     style: danger
                     text:
                       type: plain_text
-                      text: Open PR
-                    url: "${{ github.event.pull_request.html_url }}"
+                      text: "${{ env.NOTIFICATION_ACTION_LABEL }}"
+                    url: "${{ env.NOTIFICATION_URL }}"
                   - type: button
                     style: danger
                     text:


### PR DESCRIPTION
## Description
PRs against master or *-rc branches run short RIT test suite by default
After merge, on push full suite is executed and result reported in slack
Short or full test suites can be manually executed from Actions tab in github
Suite to run can also be determined in the PR description. "test-suite:short" or "test-suite:full"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
