### PR TITLE
Defer segwit transaction registration until the coinbase has been informed

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -622,6 +622,21 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
                         continue;
                     }
 
+                    // A segwit tx is registered with a wtxid-based pmt, which the Bridge can only
+                    // validate against the witness commitment in the block's registered coinbase.
+                    // Until the coinbase is registered, the Bridge would reject the registration,
+                    // so keep the tx in the list and retry on a future updateBridge run.
+                    Sha256Hash txBlockHash = txStoredBlock.getHeader().getHash();
+                    if (tx.hasWitnesses() && !federatorSupport.hasBlockCoinbaseInformed(txBlockHash)) {
+                        logger.debug(
+                            "[updateBridgeBtcTransactions] Coinbase of block {} not yet informed to the Bridge. Postponing registration of segwit tx {} (wtxid: {})",
+                            txBlockHash,
+                            txId,
+                            wTxId
+                        );
+                        continue;
+                    }
+
                     sendTx(tx, txStoredBlock, pmt.get());
                     numberOfTxsSent++;
                     // Sent a maximum of 40 registerBtcTransaction txs per federator

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -1697,6 +1697,9 @@ class BtcToRskClientTest {
                 Sha256Hash blockHash = blocks[i].getHeader().getHash();
                 when(federatorSupport.getBtcBlockchainBlockHashAtDepth(i)).thenReturn(blockHash);
                 when(federatorSupport.isBlockHashInformedToBridge(blockHash)).thenReturn(true);
+                // Segwit txs are only registered once their block's coinbase is informed, so default to
+                // informed; tests exercising the coinbase informing flow re-stub this to false.
+                when(federatorSupport.hasBlockCoinbaseInformed(blockHash)).thenReturn(true);
             }
         }
 
@@ -1913,6 +1916,61 @@ class BtcToRskClientTest {
             addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
 
             setUpTx(activeFedClient, peginBtcTx, DEFAULT_BLOCK_WITH_TX_INDEX);
+
+            // act
+            activeFedClient.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxSentToBridgeByActiveFedClient(peginBtcTx);
+        }
+
+        @Test
+        void updateBridgeBtcTransactions_segwitPegin_coinbaseNotInformed_shouldPostponeRegistration() throws Exception {
+            // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
+            setUpActiveFedClient(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(activeFedClient, peginBtcTx, DEFAULT_BLOCK_WITH_TX_INDEX);
+
+            // the Bridge cannot validate a segwit tx registration until the coinbase of its block,
+            // holding the witness commitment, is registered
+            Sha256Hash blockWithTxHash = blocks[DEFAULT_BLOCK_WITH_TX_INDEX].getHeader().getHash();
+            when(federatorSupport.hasBlockCoinbaseInformed(blockWithTxHash)).thenReturn(false);
+
+            // act
+            activeFedClient.updateBridgeBtcTransactions();
+
+            // assert
+            assertTxNotSentToBridge(peginBtcTx);
+            // the tx should stay pending so it is retried once the coinbase is registered
+            assertWTxIdIsInActiveFedClientTxsToBeSentMap(peginBtcTx);
+        }
+
+        @Test
+        void updateBridgeBtcTransactions_segwitPegin_coinbaseInformedAfterPostponing_shouldBeInformed() throws Exception {
+            // arrange
+            Federation federation = TestUtils.createP2shP2wshErpFederation(
+                MAINNET_BTC_PARAMS,
+                20
+            );
+            setUpActiveFedClient(federation);
+            var peginBtcTx = createTxFromP2shP2wpkh(MAINNET_BTC_PARAMS);
+            addOutputToFedWithMinimumPeginValue(peginBtcTx, federation.getAddress());
+
+            setUpTx(activeFedClient, peginBtcTx, DEFAULT_BLOCK_WITH_TX_INDEX);
+
+            Sha256Hash blockWithTxHash = blocks[DEFAULT_BLOCK_WITH_TX_INDEX].getHeader().getHash();
+            when(federatorSupport.hasBlockCoinbaseInformed(blockWithTxHash)).thenReturn(false);
+            // registration is postponed while the coinbase is not informed
+            activeFedClient.updateBridgeBtcTransactions();
+            assertTxNotSentToBridge(peginBtcTx);
+
+            when(federatorSupport.hasBlockCoinbaseInformed(blockWithTxHash)).thenReturn(true);
 
             // act
             activeFedClient.updateBridgeBtcTransactions();
@@ -3749,6 +3807,7 @@ class BtcToRskClientTest {
             setUpTx(activeFedClient, segwitPeginBtcTx, DEFAULT_BLOCK_WITH_TX_INDEX);
             Block blockWithPegin = blocks[DEFAULT_BLOCK_WITH_TX_INDEX].getHeader();
             assertBlockWithTxHashIsInCoinbaseInformationMap(MAINNET_PARAMS, btcToRskActiveFedClientFileStorage, blockWithPegin);
+            when(federatorSupport.hasBlockCoinbaseInformed(blockWithPegin.getHash())).thenReturn(false);
 
             activeFedClient.updateBridgeBtcBlockchain();
             updateBridgeBestChainHeight();
@@ -3880,6 +3939,7 @@ class BtcToRskClientTest {
             Block blockWithPeginBeforeReorg = blocks[blockWithSegwitPeginIndex].getHeader();
             Sha256Hash blockWithPeginBeforeReorgHash = blockWithPeginBeforeReorg.getHash();
             CoinbaseInformation coinbaseInformationBeforeReorg = getCoinbaseInformation(blockWithPeginBeforeReorgHash);
+            when(federatorSupport.hasBlockCoinbaseInformed(blockWithPeginBeforeReorgHash)).thenReturn(false);
 
             activeFedClient.updateBridgeBtcBlockchain();
             updateBridgeBestChainHeight();
@@ -3904,6 +3964,7 @@ class BtcToRskClientTest {
             setUpTx(activeFedClient, segwitPeginBtcTx, blockWithSegwitPeginIndexInNewChain);
             Block blockWithPeginInNewChain = blocks[blockWithSegwitPeginIndexInNewChain].getHeader();
             Sha256Hash blockWithPeginInNewChainHash = blockWithPeginInNewChain.getHash();
+            when(federatorSupport.hasBlockCoinbaseInformed(blockWithPeginInNewChainHash)).thenReturn(false);
             activeFedClient.updateBridgeBtcBlockchain();
             updateBridgeBestChainHeight();
 


### PR DESCRIPTION
This pull request improves the handling of SegWit peg-in transactions in the Bridge integration logic, ensuring that SegWit transactions are only registered after the coinbase transaction of their containing block has been informed to the Bridge. This prevents premature registration attempts that would be rejected by the Bridge, and adds comprehensive tests to verify this behavior.

## Description
**SegWit Peg-in Registration Handling:**

* Updated `updateBridgeBtcTransactions` in `BtcToRskClient.java` to postpone registration of SegWit transactions until the coinbase of their block is informed to the Bridge, preventing failed registration attempts and ensuring retry once the coinbase is available.

**Test Enhancements:**

* Modified test setup in `BtcToRskClientTest.java` to default `hasBlockCoinbaseInformed` to `true` for all blocks, allowing specific tests to override this as needed for SegWit scenarios.
* Added tests to verify that SegWit peg-in transactions are not sent to the Bridge if the coinbase is not informed, and are correctly sent once the coinbase is informed.
* Updated additional test cases to explicitly set `hasBlockCoinbaseInformed` to `false` where necessary for accurate simulation of coinbase informing flows. [[1]](diffhunk://#diff-34cbd6d3438cd131c3ba5a6f9be3b37210a380e87dfb039fd9d0ac459c0413d9R3810) [[2]](diffhunk://#diff-34cbd6d3438cd131c3ba5a6f9be3b37210a380e87dfb039fd9d0ac459c0413d9R3942) [[3]](diffhunk://#diff-34cbd6d3438cd131c3ba5a6f9be3b37210a380e87dfb039fd9d0ac459c0413d9R3967)

## Motivation and Context
Avoid unnecessary calls to registerBtcTransaction

## How Has This Been Tested?
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
`rit:fix-svp-spend-tx-registration-race`