### PR TITLE
Minor fixes to RIT workflow

### DIFF
--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -162,20 +162,30 @@ jobs:
           GITHUB_EVENT_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           GITHUB_EVENT_HEAD_COMMIT_URL: ${{ github.event.head_commit.url || '' }}
           GITHUB_REF_NAME: ${{ github.ref_name || '' }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
-          # Delete non-alphanumeric characters and limit to 75 chars, which is the branch title limit in GitHub
+          # Replace (not delete) non-alphanumeric characters so stripped punctuation never welds
+          # two words together (e.g. "rsksmart/rit-update" must not become "rsksmartrit-update"),
+          # then squeeze runs of spaces and trim, and cap length to keep the Slack message concise.
           sanitize() {
-            printf '%s' "$1" | tr -cd '[:alnum:]_ -' | cut -c1-75
+            printf '%s' "$1" | tr -c '[:alnum:]_ -' ' ' | tr -s ' ' | sed 's/^ *//;s/ *$//' | cut -c1-75
           }
 
           if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
             NOTIFICATION_TITLE="PR #${GITHUB_EVENT_PULL_REQUEST_NUMBER}"
             NOTIFICATION_SUBTITLE=$(sanitize "$GITHUB_EVENT_PULL_REQUEST_TITLE")
+            # A PR title made up entirely of characters sanitize() strips (e.g. only emoji)
+            # would otherwise produce an empty string, which Slack's Block Kit rejects (text
+            # objects require a minimum length of 1), failing this step and misreporting a
+            # successful run as failed.
+            : "${NOTIFICATION_SUBTITLE:=PR #${GITHUB_EVENT_PULL_REQUEST_NUMBER}}"
             NOTIFICATION_URL="$GITHUB_EVENT_PULL_REQUEST_HTML_URL"
             NOTIFICATION_ACTION_LABEL="Open PR"
           else
             NOTIFICATION_TITLE="Push to ${GITHUB_REF_NAME}"
             NOTIFICATION_SUBTITLE=$(sanitize "$(printf '%s' "$GITHUB_EVENT_HEAD_COMMIT_MESSAGE" | head -n1)")
+            # Same empty-string risk as above, for commit messages.
+            : "${NOTIFICATION_SUBTITLE:=Commit ${GITHUB_SHA:0:7}}"
             NOTIFICATION_URL="$GITHUB_EVENT_HEAD_COMMIT_URL"
             NOTIFICATION_ACTION_LABEL="View Commit"
           fi

--- a/.github/workflows/rit.yml
+++ b/.github/workflows/rit.yml
@@ -174,7 +174,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
             NOTIFICATION_TITLE="PR #${GITHUB_EVENT_PULL_REQUEST_NUMBER}"
             NOTIFICATION_SUBTITLE=$(sanitize "$GITHUB_EVENT_PULL_REQUEST_TITLE")
-            # A PR title made up entirely of characters sanitize() strips (e.g. only emoji)
+            # A PR title made up entirely of characters sanitize() replaces with spaces (e.g. only emoji)
             # would otherwise produce an empty string, which Slack's Block Kit rejects (text
             # objects require a minimum length of 1), failing this step and misreporting a
             # successful run as failed.


### PR DESCRIPTION
This pull request updates the workflow notification logic in `.github/workflows/rit.yml` to improve the handling of branch and message titles sent to Slack. The main focus is on better sanitization of notification subtitles and ensuring that Slack messages are never empty, which could cause workflow failures.

**Notification subtitle sanitization and safety:**

* The `sanitize()` function now replaces non-alphanumeric characters with spaces (instead of deleting them), squeezes consecutive spaces, trims leading/trailing spaces, and limits the result to 75 characters. This prevents words from being unintentionally joined and keeps messages readable.
* For both pull request titles and commit messages, if the sanitized subtitle ends up empty (e.g., the original string was only emoji or punctuation), a fallback value is provided (`PR #<number>` for PRs, `Commit <sha>` for pushes). This ensures the Slack notification always contains valid text and avoids workflow failures.

**Environment variables:**

* The `GITHUB_SHA` environment variable is now explicitly set for use in the notification logic.