### PR TITLE
Refactor federation checks in BtcToRskClient and BtcReleaseClient

### DIFF
--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -118,20 +118,19 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
 
     public void start(Federation federation) {
         logger.info("[start] Starting for federation {}", federation.getAddress());
-        this.federationToListen = federation;
 
         FederationMember federator = federatorSupport.getFederationMember();
         BtcECKey federatorBtcKey = federator.getBtcPublicKey();
-        boolean isMember = federation.isMember(federator);
-        if (!isMember) {
-            String message = String.format(
-                "Member %s is not part of the federation %s",
+        if (!federation.isMember(federator)) {
+            logger.warn(
+                "[start] Member {} is not part of the federation {}, skipping. This node will not watch this federation nor update the bridge for it",
                 federatorBtcKey,
                 federation.getAddress()
             );
-            logger.error("[start] {}", message);
-            throw new IllegalStateException(message);
+            return;
         }
+
+        this.federationToListen = federation;
 
         logger.info(
             "[start] Pegnatory {} watching federation {} since I belong to it",

--- a/src/main/java/co/rsk/federate/BtcToRskClient.java
+++ b/src/main/java/co/rsk/federate/BtcToRskClient.java
@@ -395,7 +395,7 @@ public class BtcToRskClient implements BlockListener, TransactionListener {
         }
     }
 
-    protected int updateBridgeBtcBlockchain() throws BlockStoreException, IOException {
+    protected int updateBridgeBtcBlockchain() throws BlockStoreException {
         int bridgeBtcBlockchainBestChainHeight = federatorSupport.getBtcBlockchainBestChainHeight();
         int federatorBtcBlockchainBestChainHeight = bitcoinWrapper.getBestChainHeight();
         if (federatorBtcBlockchainBestChainHeight > bridgeBtcBlockchainBestChainHeight) {

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.annotation.PreDestroy;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
@@ -74,7 +75,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Responsible for managing the signing and broadcasting of pegout transactions
  * to the Bitcoin network in a federated bridge environment. The BtcReleaseClient
- * coordinates the execution of pegout operations, ensuring transactions are 
+ * coordinates the execution of pegout operations, ensuring transactions are
  * correctly signed and propagated.
  *
  * <p>Key responsibilities include:</p>
@@ -205,7 +206,7 @@ public class BtcReleaseClient {
                 logger.warn("[onBestBlock] Node is not ready to process pegouts");
                 return;
             }
-          
+
             // Sign svp spend tx waiting for signatures, if it exists,
             // before attempting to sign any pegouts.
             federatorSupport.getStateForProposedFederator()
@@ -230,14 +231,19 @@ public class BtcReleaseClient {
             /* Pegout events must be processed on an every-single-block basis,
              since otherwise we could be missing pegouts potentially mined
              on what originally were side-chains and then turned into best-chains.*/
+            Stream<BtcTransaction> pegoutTxs = getPegoutTxs(receipts);
+
+            pegoutTxs.forEach(BtcReleaseClient.this::onBtcRelease);
+        }
+
+        @Nonnull
+        private Stream<BtcTransaction> getPegoutTxs(List<TransactionReceipt> receipts) {
             Stream<LogInfo> transactionLogs = receipts.stream().map(TransactionReceipt::getLogInfoList).flatMap(Collection::stream);
             Stream<LogInfo> bridgeLogs = transactionLogs.filter(info -> Arrays.equals(info.getAddress(), PrecompiledContracts.BRIDGE_ADDR.getBytes()));
 
             Stream<LogInfo> pegoutLogs = bridgeLogs.filter(info -> RELEASE_BTC_TOPIC.equals(info.getTopics().get(0)));
 
-            Stream<BtcTransaction> pegoutTxs = pegoutLogs.map(info -> convertToBtcTxFromSolidityData(info.getData()));
-
-            pegoutTxs.forEach(BtcReleaseClient.this::onBtcRelease);
+            return pegoutLogs.map(info -> convertToBtcTxFromSolidityData(info.getData()));
         }
 
         private boolean shouldProcessPegouts() {

--- a/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
+++ b/src/main/java/co/rsk/federate/btcreleaseclient/BtcReleaseClient.java
@@ -154,14 +154,14 @@ public class BtcReleaseClient {
     }
 
     public void start(Federation federation) {
-       FederationMember federationMember = federatorSupport.getFederationMember();
-       if (!federation.isMember(federationMember)) {
-            String message = String.format(
-                "Member %s is no part of the federation %s",
+        FederationMember federationMember = federatorSupport.getFederationMember();
+        if (!federation.isMember(federationMember)) {
+            logger.warn(
+                "[start] Member {} is not part of the federation {}, skipping. This node will not sign pegouts for it",
                 federationMember.getBtcPublicKey(),
-                federation.getAddress());
-            logger.error("[start] {}", message);
-            throw new IllegalStateException(message);
+                federation.getAddress()
+            );
+            return;
         }
 
         if (!observedFederations.contains(federation)) {

--- a/src/main/java/co/rsk/federate/watcher/FederationWatcherListenerImpl.java
+++ b/src/main/java/co/rsk/federate/watcher/FederationWatcherListenerImpl.java
@@ -47,47 +47,41 @@ public class FederationWatcherListenerImpl implements FederationWatcherListener 
             return;
         }
 
-        try {
-            // start {@code BtcReleaseClient} with proposed federation,
-            // so it can sign svp spend tx
-            btcReleaseClient.start(newProposedFederation);
+        // start {@code BtcReleaseClient} with proposed federation,
+        // so it can sign svp spend tx
+        //
+        // Failures are propagated on purpose, so that FederationWatcher does not record this
+        // federation as notified and retries on the next best block. See triggerClientChange
+        btcReleaseClient.start(newProposedFederation);
 
-            logger.info(
-                "[onProposedFederationChange] BtcReleaseClient for proposed federation [{}] started with success",
-                newProposedFederation.getAddress()
-            );
-        } catch (Exception e) {
-            logger.error(
-                "[onProposedFederationChange] BtcReleaseClient for proposed federation [{}] failed to start",
-                newProposedFederation.getAddress(),
-                e
-            );
-        }
+        logger.info(
+            "[onProposedFederationChange] BtcReleaseClient for proposed federation [{}] started with success",
+            newProposedFederation.getAddress()
+        );
     }
 
     private void triggerClientChange(BtcToRskClient btcToRskClient, Federation newFederation) {
         // This method assumes that the new federation cannot be null
         Objects.requireNonNull(newFederation);
-      
-        try {
-            // Stop the current clients
-            btcToRskClient.stop();
-            btcReleaseClient.stop(newFederation);
 
-            // Start the current clients
-            btcToRskClient.start(newFederation);
-            btcReleaseClient.start(newFederation);
+        // Failures are propagated on purpose. FederationWatcher records the federation it notified
+        // about only after this method returns normally, so throwing keeps its state stale and the
+        // change is retried on the next best block; stop and start are idempotent, so retrying is
+        // safe. Swallowing here would instead leave this node neither watching pegins nor signing
+        // pegouts for the federation, with no further attempt. Escaping exceptions cannot disrupt
+        // block processing, since rskj isolates every listener callback.
 
-            logger.info(
-                "[triggerClientChange] Clients for federation [{}] changed with success",
-                newFederation.getAddress());
-        } catch (Exception e) {
-            logger.error(
-                "[triggerClientChange] Clients for federation [{}] cannot be changed",
-                newFederation.getAddress(),
-                e
-            );
-        }
+        // Stop the current clients
+        btcToRskClient.stop();
+        btcReleaseClient.stop(newFederation);
+
+        // Start the current clients
+        btcToRskClient.start(newFederation);
+        btcReleaseClient.start(newFederation);
+
+        logger.info(
+            "[triggerClientChange] Clients for federation [{}] changed with success",
+            newFederation.getAddress());
     }
     
     private void clearRetiringFederationClient() {

--- a/src/test/java/co/rsk/federate/BtcToRskClientTest.java
+++ b/src/test/java/co/rsk/federate/BtcToRskClientTest.java
@@ -99,13 +99,17 @@ class BtcToRskClientTest {
     }
 
     @Test
-    void start_withNoFederationMember_doesntThrowError() throws Exception {
-        BitcoinWrapper bw = new SimpleBitcoinWrapper();
+    void start_withNoFederationMember_doesntThrowError_andDoesntWatchFederation() throws Exception {
+        BitcoinWrapper bw = mock(BitcoinWrapper.class);
         SimpleFederatorSupport fh = new SimpleFederatorSupport();
 
-        fh.setMember(activeFederationMember);
+        BtcECKey nonMemberKey = TestUtils.getBtcEcKeyFromSeed("nonFederationMember");
+        fh.setMember(FederationMember.getFederationMemberFromKey(nonMemberKey));
+
         BtcToRskClient client = createClientWithMocks(bw, fh);
+
         assertDoesNotThrow(() -> client.start(activeFederation));
+        verify(bw, never()).addFederationListener(any(), any());
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
+++ b/src/test/java/co/rsk/federate/btcreleaseclient/BtcReleaseClientTest.java
@@ -95,7 +95,7 @@ class BtcReleaseClientTest {
     }
 
     @Test
-    void start_whenFederationMemberNotPartOfDesiredFederation_shouldThrowException() {
+    void start_whenFederationMemberNotPartOfDesiredFederation_shouldNotObserveFederation() {
         // Arrange
         powpegNodeSystemProperties = getPowpegNodeSystemProperties(true);
         Federation federation = TestUtils.createP2shP2wshErpFederation(params, 10);
@@ -109,15 +109,17 @@ class BtcReleaseClientTest {
 
         doReturn(federationMember).when(federatorSupport).getFederationMember();
 
+        Ethereum ethereum = mock(Ethereum.class);
         BtcReleaseClient btcReleaseClient = new BtcReleaseClient(
-            mock(Ethereum.class),
+            ethereum,
             federatorSupport,
             powpegNodeSystemProperties,
             mock(NodeBlockProcessor.class)
         );
 
         // Act & Assert
-        assertThrows(IllegalStateException.class, () -> btcReleaseClient.start(federation));
+        assertDoesNotThrow(() -> btcReleaseClient.start(federation));
+        verify(ethereum, never()).addListener(any());
     }
 
     @Test

--- a/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
+++ b/src/test/java/co/rsk/federate/watcher/FederationWatcherListenerImplTest.java
@@ -1,6 +1,7 @@
 package co.rsk.federate.watcher;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -82,13 +83,22 @@ class FederationWatcherListenerImplTest {
     }
 
     @Test
-    void triggerClientChange_whenExceptionOccurs_shouldHandleException() {
+    void triggerClientChange_whenExceptionOccurs_shouldPropagateException() {
         // Arrange
         // Simulate an exception in one of the called methods
-        doThrow(new RuntimeException("Simulated exception")).when(btcToRskClientActive).stop();
+        RuntimeException exception = new RuntimeException("Simulated exception");
+        doThrow(exception).when(btcToRskClientActive).stop();
 
         // Act & Assert
-        assertDoesNotThrow(() -> federationWatcherListener.onActiveFederationChange(FEDERATION));
+        // The exception must reach the FederationWatcher, so it does not record this federation as
+        // already notified and retries the change on the next best block
+        RuntimeException thrownException = assertThrows(
+            RuntimeException.class,
+            () -> federationWatcherListener.onActiveFederationChange(FEDERATION));
+
+        assertSame(exception, thrownException);
+        verify(btcToRskClientActive, never()).start(FEDERATION);
+        verify(btcReleaseClient, never()).start(FEDERATION);
     }
 
     @Test
@@ -114,12 +124,17 @@ class FederationWatcherListenerImplTest {
     }
 
     @Test
-    void onProposedFederationChange_whenClientStartThrowsException_shouldHandleException() {
+    void onProposedFederationChange_whenClientStartThrowsException_shouldPropagateException() {
         // Arrange
-        doThrow(new RuntimeException("Start failed")).when(btcReleaseClient).start(FEDERATION);
+        RuntimeException exception = new RuntimeException("Start failed");
+        doThrow(exception).when(btcReleaseClient).start(FEDERATION);
 
         // Act & Assert
-        assertDoesNotThrow(() -> federationWatcherListener.onProposedFederationChange(FEDERATION));
+        RuntimeException thrownException = assertThrows(
+            RuntimeException.class,
+            () -> federationWatcherListener.onProposedFederationChange(FEDERATION));
+
+        assertSame(exception, thrownException);
     }
 
     private static List<FederationMember> getFederationMembersFromPksForBtc(Integer... pks) {

--- a/src/test/java/co/rsk/federate/watcher/FederationWatcherTest.java
+++ b/src/test/java/co/rsk/federate/watcher/FederationWatcherTest.java
@@ -2,10 +2,13 @@ package co.rsk.federate.watcher;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -383,6 +386,32 @@ class FederationWatcherTest {
         verify(federationProvider).getRetiringFederationAddress();
         verify(federationProvider).getRetiringFederation();
         verify(federationWatcherListener).onRetiringFederationChange(SECOND_FEDERATION);
+    }
+
+    @Test
+    void onBestBlock_whenListenerFails_shouldRetryFederationChangeOnNextBestBlock() throws Exception {
+        // Arrange
+        var rskListener = setupAndGetRskListener(null, FIRST_FEDERATION, null);
+        when(federationProvider.getProposedFederationAddress()).thenReturn(Optional.empty());
+        when(federationProvider.getActiveFederationAddress()).thenReturn(SECOND_FEDERATION.getAddress());
+        when(federationProvider.getActiveFederation()).thenReturn(SECOND_FEDERATION);
+        when(federationProvider.getRetiringFederationAddress()).thenReturn(Optional.empty());
+
+        // The first notification fails, the second one succeeds
+        RuntimeException exception = new RuntimeException("Clients cannot be changed");
+        doThrow(exception).doNothing()
+            .when(federationWatcherListener).onActiveFederationChange(SECOND_FEDERATION);
+
+        federationWatcher.start(federationProvider, federationWatcherListener);
+
+        // Act
+        // Since the notification failed, the new active federation must not be recorded as notified
+        assertThrows(RuntimeException.class, () -> rskListener.onBestBlock(null, null));
+        // So the very same change is detected again on the next best block, and retried
+        rskListener.onBestBlock(null, null);
+
+        // Assert
+        verify(federationWatcherListener, times(2)).onActiveFederationChange(SECOND_FEDERATION);
     }
 
     private EthereumListenerAdapter setupAndGetRskListener(


### PR DESCRIPTION
This pull request focuses on improving the robustness and safety of federation membership handling in the bridge clients, as well as ensuring correct error propagation and retry logic in the federation watcher. The main changes prevent nodes that are not part of a federation from attempting to watch or sign for it, and ensure that failures in starting or switching federation clients are properly propagated, allowing for safe retries. The associated tests have been updated to reflect the new behavior.

**Federation membership checks and client startup:**

* Updated `BtcToRskClient` and `BtcReleaseClient` so that if the local node is not a member of a given federation, the client logs a warning and skips starting, instead of throwing an exception. This prevents nodes from attempting to participate in federations they don't belong to. [[1]](diffhunk://#diff-66d9da7d6fb52a1b0467b1e5f6ea16676b5932449ddb9888a103905cac4fd661L121-R134) [[2]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fL159-R165)
* Changed related tests to verify that clients do not observe federations or add listeners when not a member, and that no exceptions are thrown in these scenarios. [[1]](diffhunk://#diff-34cbd6d3438cd131c3ba5a6f9be3b37210a380e87dfb039fd9d0ac459c0413d9L102-R112) [[2]](diffhunk://#diff-b949f3b5dbf6f3f1df7bbd54970226ba91570deadbfff56beb932d7517042deeL98-R98) [[3]](diffhunk://#diff-b949f3b5dbf6f3f1df7bbd54970226ba91570deadbfff56beb932d7517042deeR112-R122)

**Error propagation and retry logic in federation watcher:**

* Modified `FederationWatcherListenerImpl` so that exceptions during federation client changes are now propagated instead of being swallowed. This ensures that the federation watcher does not record a failed change as successful, and will retry the operation on the next block. [[1]](diffhunk://#diff-658210afc49fb5cc7c10e1d16657f0af013a1f797b193fc61e1174ea2a5b3188L50-R73) [[2]](diffhunk://#diff-658210afc49fb5cc7c10e1d16657f0af013a1f797b193fc61e1174ea2a5b3188L84-L90)
* Updated tests to assert that exceptions are propagated and retried as intended, improving reliability in handling federation changes. [[1]](diffhunk://#diff-6fa46cc16cb7590f46d38e1bf6ea659e84be1eb4a67511404b55e6a49ab0617fL85-R101) [[2]](diffhunk://#diff-6fa46cc16cb7590f46d38e1bf6ea659e84be1eb4a67511404b55e6a49ab0617fL117-R137) [[3]](diffhunk://#diff-128b0a546016cc246e8f4bc689f9f45457bd83515d3058a045b3905f03ba5293R391-R416)

**Minor refactoring and improvements:**

* Refactored code for clarity, such as extracting methods and improving stream processing in `BtcReleaseClient`.
* Removed unnecessary exception types from method signatures where no longer needed.
* Minor imports and annotation improvements for code clarity and null-safety. [[1]](diffhunk://#diff-6ff1f34ebaa5559c6471a8989429cf9d0450c6dd70b51bd02da4f20d4c7e453fR56) [[2]](diffhunk://#diff-6fa46cc16cb7590f46d38e1bf6ea659e84be1eb4a67511404b55e6a49ab0617fL3-R4) [[3]](diffhunk://#diff-128b0a546016cc246e8f4bc689f9f45457bd83515d3058a045b3905f03ba5293R5-R11)